### PR TITLE
Pedir confirmación de datos por cursada y pre-llenar el form de registro

### DIFF
--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,24 +22,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int",
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
+          "unique": true,
+          "length": 255,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "integer"
+          "mappedType": "string"
         },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -54,29 +54,61 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "boolean",
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": null,
+          "length": 255,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "boolean"
+          "mappedType": "string"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -84,26 +116,90 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
-      "name": "comision",
+      "name": "alumno",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "comision_pkey",
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_github_username_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_legajo_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "alumno_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
+          "constraintName": "alumno_comision_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -244,7 +340,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -276,15 +372,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -296,209 +392,43 @@
       "indexes": [
         {
           "columnNames": [
-            "tipo"
-          ],
-          "composite": false,
-          "keyName": "assignment_tipo_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "assignment_pkey",
-          "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "tipo"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "assignment_tipo_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
           "constraintName": "assignment_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
           "localTableName": "public.assignment",
+          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        }
-      },
-      "name": "alumno",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "keyName": "alumno_legajo_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "keyName": "alumno_github_username_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "alumno_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "constraintName": "alumno_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -539,47 +469,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_assignment_id_foreign": {
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.assignment_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "assignment_alumnos_alumno_id_foreign": {
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "assignment_alumnos_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
+          "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -599,60 +530,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
+        "anio": {
+          "name": "anio",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "integer"
         },
-        "creado_por": {
-          "name": "creado_por",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -667,9 +562,25 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
+        "activa": {
+          "name": "activa",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -681,40 +592,27 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "json"
         }
       },
-      "name": "grupo",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "comision_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "constraintName": "grupo_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -741,22 +639,6 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -830,25 +712,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "repo_deleted": {
-          "name": "repo_deleted",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "false",
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
-        },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -861,65 +727,234 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "repo_deleted": {
+          "name": "repo_deleted",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "entrega_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "entrega_assignment_id_foreign": {
-          "constraintName": "entrega_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.entrega",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "entrega_alumno_id_foreign": {
-          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "entrega_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "entrega_assignment_id_foreign",
+          "localTableName": "public.entrega",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
-          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
+          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
+        },
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        }
+      },
+      "name": "grupo",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "grupo_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "grupo_assignment_id_foreign",
+          "localTableName": "public.grupo",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -960,47 +995,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "grupo_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_grupo_id_foreign": {
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
-          "columnNames": [
-            "grupo_id"
-          ],
-          "localTableName": "public.grupo_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "grupo_alumnos_alumno_id_foreign": {
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "grupo_alumnos_grupo_id_foreign": {
+          "columnNames": [
+            "grupo_id"
+          ],
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
+          "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260417230133_add_registro_confirmado_en_to_alumno.ts
+++ b/migrations/Migration20260417230133_add_registro_confirmado_en_to_alumno.ts
@@ -1,0 +1,16 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260417230133_add_registro_confirmado_en_to_alumno extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "alumno" add column "registro_confirmado_en_id" uuid null;`);
+    this.addSql(`alter table "alumno" add constraint "alumno_registro_confirmado_en_id_foreign" foreign key ("registro_confirmado_en_id") references "comision" ("id") on update cascade on delete set null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" drop constraint "alumno_registro_confirmado_en_id_foreign";`);
+
+    this.addSql(`alter table "alumno" drop column "registro_confirmado_en_id";`);
+  }
+
+}

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -87,12 +87,12 @@ describe("PATCH /api/perfil", () => {
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
-  it("maneja ausencia de comisión activa pasando undefined", async () => {
+  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    await PATCH(makeRequest(validBody));
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
-    );
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(409);
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockGetComisionActiva = vi.fn();
+const mockUpsertAlumno = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/sheets", () => ({
+  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+}));
+
+import { PATCH } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/perfil", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  legajo: "12345",
+  apellido: "García",
+  nombre: "Juan",
+  email: "juan@gmail.com",
+};
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/perfil", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      name: "Juan",
+      image: "",
+      isAdmin: false,
+    });
+    mockGetComisionActiva.mockResolvedValue({
+      id: "c1",
+      spreadsheetId: "sheet-xyz",
+      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    });
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockUpsertAlumno.mockResolvedValue(undefined);
+  });
+
+  it("actualiza Sheets y DB en un mismo request", async () => {
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledTimes(1);
+    expect(mockUpsertAlumno).toHaveBeenCalledTimes(1);
+  });
+
+  it("usa el githubUsername del usuario autenticado (no del body)", async () => {
+    await PATCH(makeRequest({ ...validBody, githubUsername: "attacker" }));
+    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    expect(inputPasado.githubUsername).toBe("juangarcia");
+  });
+
+  it("vuelve a setear registroConfirmadoEn a la comisión activa (mantiene consistencia)", async () => {
+    const comision = await mockGetComisionActiva();
+    await PATCH(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ registroConfirmadoEn: comision })
+    );
+  });
+
+  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "email inválido" });
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(400);
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("maneja ausencia de comisión activa pasando undefined", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    await PATCH(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
+    );
+  });
+
+  it("devuelve 500 si algo tira un error inesperado", async () => {
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -16,10 +16,17 @@ export async function PATCH(req: Request) {
     };
 
     const comisionActiva = await getComisionActiva();
+    if (!comisionActiva) {
+      return NextResponse.json(
+        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
+        { status: 409 }
+      );
+    }
+
     const result = await upsertarAlumnoEnSheets(
       input,
-      comisionActiva?.spreadsheetId,
-      comisionActiva?.columnConfig
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
     );
 
     if (!result.ok) {
@@ -32,8 +39,8 @@ export async function PATCH(req: Request) {
       apellido: input.apellido,
       githubUsername: input.githubUsername,
       email: input.email,
-      comision: comisionActiva ?? undefined,
-      registroConfirmadoEn: comisionActiva ?? undefined,
+      comision: comisionActiva,
+      registroConfirmadoEn: comisionActiva,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,17 +1,23 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { actualizarAlumno, type ActualizarInput } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
+import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
+
+type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
 export async function PATCH(req: Request) {
   try {
     const user = await requireUser();
-    const body = (await req.json()) as ActualizarInput;
+    const body = (await req.json()) as PerfilInput;
+
+    const input: RegistroInput = {
+      ...body,
+      githubUsername: user.githubUsername,
+    };
 
     const comisionActiva = await getComisionActiva();
-    const result = await actualizarAlumno(
-      user.githubUsername,
-      body,
+    const result = await upsertarAlumnoEnSheets(
+      input,
       comisionActiva?.spreadsheetId,
       comisionActiva?.columnConfig
     );
@@ -19,6 +25,16 @@ export async function PATCH(req: Request) {
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
+
+    await upsertAlumno({
+      legajo: input.legajo,
+      nombre: input.nombre,
+      apellido: input.apellido,
+      githubUsername: input.githubUsername,
+      email: input.email,
+      comision: comisionActiva ?? undefined,
+      registroConfirmadoEn: comisionActiva ?? undefined,
+    });
 
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -100,17 +100,12 @@ describe("POST /api/registro", () => {
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
-  it("maneja ausencia de comisión activa pasando undefined a los helpers", async () => {
+  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    await POST(makeRequest(validBody));
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
-      expect.any(Object),
-      undefined,
-      undefined
-    );
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
-    );
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(409);
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockGetComisionActiva = vi.fn();
+const mockUpsertAlumno = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/sheets", () => ({
+  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+}));
+
+import { POST } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/registro", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  legajo: "12345",
+  apellido: "García",
+  nombre: "Juan",
+  email: "juan@gmail.com",
+  githubUsername: "attacker", // se ignora — se reemplaza por el del user autenticado
+};
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("POST /api/registro", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      name: "Juan",
+      image: "",
+      isAdmin: false,
+    });
+    mockGetComisionActiva.mockResolvedValue({
+      id: "c1",
+      spreadsheetId: "sheet-xyz",
+      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    });
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockUpsertAlumno.mockResolvedValue(undefined);
+  });
+
+  it("fuerza el githubUsername del usuario autenticado (ignora el del body)", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    expect(inputPasado.githubUsername).toBe("juangarcia");
+  });
+
+  it("llama a upsertarAlumnoEnSheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
+    const comision = await mockGetComisionActiva();
+    await POST(makeRequest(validBody));
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      expect.any(Object),
+      "sheet-xyz",
+      comision.columnConfig
+    );
+  });
+
+  it("llama a upsertAlumno con comision y registroConfirmadoEn = comisión activa", async () => {
+    const comision = await mockGetComisionActiva();
+    await POST(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({
+        legajo: "12345",
+        githubUsername: "juangarcia",
+        email: "juan@gmail.com",
+        comision,
+        registroConfirmadoEn: comision,
+      })
+    );
+  });
+
+  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Legajo duplicado");
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("maneja ausencia de comisión activa pasando undefined a los helpers", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    await POST(makeRequest(validBody));
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      expect.any(Object),
+      undefined,
+      undefined
+    );
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
+    );
+  });
+
+  it("devuelve 500 si algo tira un error inesperado", async () => {
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("boom");
+  });
+});

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { registrarAlumno, type RegistroInput } from "@/lib/sheets";
+import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
 
 export async function POST(req: Request) {
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
     body.githubUsername = user.githubUsername;
 
     const comisionActiva = await getComisionActiva();
-    const result = await registrarAlumno(
+    const result = await upsertarAlumnoEnSheets(
       body,
       comisionActiva?.spreadsheetId,
       comisionActiva?.columnConfig
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
       githubUsername: body.githubUsername,
       email: body.email,
       comision: comisionActiva ?? undefined,
+      registroConfirmadoEn: comisionActiva ?? undefined,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -12,10 +12,17 @@ export async function POST(req: Request) {
     body.githubUsername = user.githubUsername;
 
     const comisionActiva = await getComisionActiva();
+    if (!comisionActiva) {
+      return NextResponse.json(
+        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
+        { status: 409 }
+      );
+    }
+
     const result = await upsertarAlumnoEnSheets(
       body,
-      comisionActiva?.spreadsheetId,
-      comisionActiva?.columnConfig
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
     );
 
     if (!result.ok) {
@@ -28,8 +35,8 @@ export async function POST(req: Request) {
       apellido: body.apellido,
       githubUsername: body.githubUsername,
       email: body.email,
-      comision: comisionActiva ?? undefined,
-      registroConfirmadoEn: comisionActiva ?? undefined,
+      comision: comisionActiva,
+      registroConfirmadoEn: comisionActiva,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/components/AlumnoForm.test.tsx
+++ b/src/app/components/AlumnoForm.test.tsx
@@ -61,6 +61,21 @@ describe("AlumnoForm", () => {
       renderForm({ submitLabel: "Registrarme" });
       expect(screen.getByRole("button", { name: "Registrarme" })).toBeInTheDocument();
     });
+
+    it("muestra la explicación sobre el email leído asiduamente", () => {
+      renderForm();
+      expect(
+        screen.getByText(/email que leas asiduamente/i)
+      ).toBeInTheDocument();
+    });
+
+    it("el input de email tiene pattern RFC-lite para validar en el cliente", () => {
+      renderForm();
+      const emailInput = screen.getByDisplayValue("juan@example.com");
+      expect(emailInput).toHaveAttribute("pattern", "[^\\s@]+@[^\\s@]+\\.[^\\s@]+");
+      expect(emailInput).toHaveAttribute("type", "email");
+      expect(emailInput).toBeRequired();
+    });
   });
 
   describe("submit exitoso", () => {

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -128,9 +128,15 @@ export function AlumnoForm({
           name="email"
           type="email"
           required
+          pattern="[^\s@]+@[^\s@]+\.[^\s@]+"
+          title="Ingresá un email con formato válido (usuario@dominio.com)"
           defaultValue={defaultValues.email}
           className={INPUT_CLASS}
         />
+        <p className="text-xs text-gray-500 mt-1">
+          Ingresá un email que leas asiduamente — por este canal mandamos
+          avisos importantes del curso.
+        </p>
       </div>
 
       {error && (

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -7,6 +7,7 @@ import { IndividualAssignment, Entrega } from "@/domain/entities";
 
 const mockRequireUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
+const mockGetComisionActiva = vi.fn();
 const mockGetAssignments = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
@@ -17,17 +18,11 @@ vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("next/cache", () => ({
-  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
-}));
-
-vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
-}));
-
 vi.mock("@/lib/repositories", () => ({
   getAssignments: () => mockGetAssignments(),
   getEntregasDeUsuario: (username: string) => mockGetEntregaDeUsuario(username),
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  getComisionActiva: () => mockGetComisionActiva(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -89,10 +84,12 @@ describe("Dashboard page", () => {
     });
     mockGetAssignments.mockResolvedValue([]);
     mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+    mockGetComisionActiva.mockResolvedValue({ id: "c1" });
+    mockGetAlumnoByGithub.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
-    it("redirige a /registro si el alumno no está registrado y no es admin", async () => {
+    it("redirige a /registro si el alumno no existe en la DB y no es admin", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetAlumnoByGithub.mockResolvedValue(null);
 
@@ -100,7 +97,22 @@ describe("Dashboard page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/registro");
     });
 
-    it("no redirige a /registro si el alumno está registrado", async () => {
+    it("redirige a /registro si el alumno confirmó en otra comisión (recursante)", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetComisionActiva.mockResolvedValue({ id: "c2" });
+      mockGetAlumnoByGithub.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Test",
+        apellido: "User",
+        githubUsername: "testuser",
+        email: "test@example.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+
+      await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
+    });
+
+    it("redirige a /registro si el alumno nunca confirmó (registroConfirmadoEn null)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetAlumnoByGithub.mockResolvedValue({
         legajo: "12345",
@@ -108,8 +120,32 @@ describe("Dashboard page", () => {
         apellido: "User",
         githubUsername: "testuser",
         email: "test@example.com",
-        comision: "miércoles noche",
+        registroConfirmadoEn: null,
       });
+
+      await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
+    });
+
+    it("no redirige si el alumno confirmó para la comisión activa", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Test",
+        apellido: "User",
+        githubUsername: "testuser",
+        email: "test@example.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+
+      const element = await DashboardPage();
+      expect(element).toBeDefined();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("no redirige si no hay comisión activa (deja pasar aunque no haya confirmado)", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetComisionActiva.mockResolvedValue(null);
+      mockGetAlumnoByGithub.mockResolvedValue(null);
 
       const element = await DashboardPage();
       expect(element).toBeDefined();
@@ -262,7 +298,7 @@ describe("Dashboard page", () => {
 
     it("consulta las entregas usando el username del usuario actual", async () => {
       mockRequireUser.mockResolvedValue(
-        makeUser({ githubUsername: "miusuario" })
+        makeUser({ githubUsername: "miusuario", isAdmin: true })
       );
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "tp-1" })]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,24 +1,30 @@
 import { requireUser } from "@/lib/session";
-import { getAssignments, getEntregasDeUsuario } from "@/lib/repositories";
-import { getAlumnoByGithub } from "@/lib/sheets";
+import {
+  getAssignments,
+  getEntregasDeUsuario,
+  getAlumnoByGithub,
+  getComisionActiva,
+} from "@/lib/repositories";
 import { AcceptButton } from "./accept-button";
 import { redirect } from "next/navigation";
-import { unstable_cache } from "next/cache";
-
-// Cachea la verificación de alumno por 5 minutos — evita un round-trip a Sheets en cada render
-const getAlumnoCached = unstable_cache(
-  async (username: string) => getAlumnoByGithub(username),
-  ["alumno-by-github"],
-  { revalidate: 300 }
-);
 
 export default async function DashboardPage() {
   const user = await requireUser();
 
-  // Si no es admin y no está registrado, mandar a registro
+  // Los admins no pasan por el gate de registro; pueden entrar sin estar como alumnos.
   if (!user.isAdmin) {
-    const alumno = await getAlumnoCached(user.githubUsername);
-    if (!alumno) redirect("/registro");
+    const [alumno, comisionActiva] = await Promise.all([
+      getAlumnoByGithub(user.githubUsername),
+      getComisionActiva(),
+    ]);
+    // Sin comisión activa no podemos pedirle nada — se deja pasar.
+    // Con comisión activa, bloquear hasta que el alumno la haya confirmado.
+    if (
+      comisionActiva &&
+      alumno?.registroConfirmadoEn?.id !== comisionActiva.id
+    ) {
+      redirect("/registro");
+    }
   }
 
   // Dos queries paralelas: assignments + todas las entregas del usuario

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -7,7 +7,6 @@ import type { Alumno } from "@/domain/entities";
 
 const mockAuth = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
-const mockGetComisionActiva = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -16,12 +15,8 @@ vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
 
-vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
-}));
-
 vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,11 +24,12 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/app/components/AlumnoForm", () => ({
-  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; legajo: string } }) => (
+  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; legajo?: string; email?: string } }) => (
     <div
       data-testid="alumno-form"
       data-github={defaultValues.githubUsername}
-      data-legajo={defaultValues.legajo}
+      data-legajo={defaultValues.legajo ?? ""}
+      data-email={defaultValues.email ?? ""}
     />
   ),
 }));
@@ -76,7 +72,6 @@ describe("Perfil page", () => {
     mockRedirect.mockImplementation((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     });
-    mockGetComisionActiva.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
@@ -87,7 +82,7 @@ describe("Perfil page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login");
     });
 
-    it("redirige a /registro si el alumno no está en la planilla", async () => {
+    it("redirige a /registro si el alumno no está en la DB", async () => {
       mockAuth.mockResolvedValue(makeSession("nuevo"));
       mockGetAlumnoByGithub.mockResolvedValue(null);
 
@@ -119,31 +114,12 @@ describe("Perfil page", () => {
       const html = renderToStaticMarkup(element);
       expect(html).toContain('data-github="juangarcia"');
       expect(html).toContain('data-legajo="12345"');
+      expect(html).toContain('data-email="juan@example.com"');
     });
 
-    it("consulta getAlumnoByGithub con el username de la sesión", async () => {
+    it("consulta getAlumnoByGithub de la DB con el username de la sesión", async () => {
       await PerfilPage();
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
-        "juangarcia",
-        undefined,
-        undefined
-      );
-    });
-
-    it("usa el spreadsheetId y columnConfig de la comisión activa", async () => {
-      const comision = {
-        spreadsheetId: "sheet-abc",
-        columnConfig: { sheetName: "Listado", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4, comision: 5 },
-      };
-      mockGetComisionActiva.mockResolvedValue(comision);
-
-      await PerfilPage();
-
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
-        "juangarcia",
-        "sheet-abc",
-        comision.columnConfig
-      );
+      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("juangarcia");
     });
   });
 });

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/lib/auth";
-import { getAlumnoByGithub } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { getAlumnoByGithub } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
 import type { PdepUser } from "@/types";
@@ -12,13 +11,7 @@ export default async function PerfilPage() {
   const pdepUser = (session as unknown as { pdepUser: PdepUser }).pdepUser;
   const githubUsername = pdepUser.githubUsername;
 
-  const comisionActiva = await getComisionActiva();
-  const alumno = await getAlumnoByGithub(
-    githubUsername,
-    comisionActiva?.spreadsheetId,
-    comisionActiva?.columnConfig
-  );
-
+  const alumno = await getAlumnoByGithub(githubUsername);
   if (!alumno) redirect("/registro");
 
   return (

--- a/src/app/registro/page.test.tsx
+++ b/src/app/registro/page.test.tsx
@@ -5,9 +5,9 @@ import type { PdepUser } from "@/types";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockAuth = vi.fn();
-const mockGetAlumnoByGithub = vi.fn();
+const mockGetAlumnoDeSheets = vi.fn();
+const mockGetAlumnoDeDB = vi.fn();
 const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -17,12 +17,12 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoDeSheets(...args),
 }));
 
 vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoDeDB(...args),
   getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (...args: unknown[]) => mockUpsertAlumno(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -30,12 +30,21 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/app/components/AlumnoForm", () => ({
-  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; email: string; nombre: string; apellido: string } }) => (
+  AlumnoForm: ({
+    defaultValues,
+    submitLabel,
+  }: {
+    defaultValues: { githubUsername: string; email: string; nombre: string; apellido: string; legajo?: string };
+    submitLabel: string;
+  }) => (
     <div
       data-testid="alumno-form"
       data-github={defaultValues.githubUsername}
       data-email={defaultValues.email}
       data-nombre={defaultValues.nombre}
+      data-apellido={defaultValues.apellido}
+      data-legajo={defaultValues.legajo ?? ""}
+      data-submit-label={submitLabel}
     />
   ),
 }));
@@ -67,7 +76,8 @@ describe("Registro page", () => {
       throw new Error(`REDIRECT:${url}`);
     });
     mockGetComisionActiva.mockResolvedValue(null);
-    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockGetAlumnoDeDB.mockResolvedValue(null);
+    mockGetAlumnoDeSheets.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
@@ -78,132 +88,208 @@ describe("Registro page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login");
     });
 
-    it("redirige a /dashboard si el alumno ya está registrado", async () => {
-      mockAuth.mockResolvedValue(makeSession("juangarcia"));
-      mockGetAlumnoByGithub.mockResolvedValue({
+    it("redirige a /dashboard si el alumno ya confirmó sus datos para la comisión activa", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
         legajo: "12345",
         nombre: "Juan",
-        apellido: "Garcia",
-        githubUsername: "juangarcia",
-        email: "juan@example.com",
-        comision: "miércoles noche",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
       });
 
       await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
     });
 
-    it("hace upsert en la DB cuando el alumno es reconocido desde la planilla", async () => {
-      const alumno = {
+    it("NO redirige a /dashboard si el alumno confirmó en una comisión distinta (recursante)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
         legajo: "12345",
         nombre: "Juan",
-        apellido: "Garcia",
-        githubUsername: "juangarcia",
-        email: "juan@example.com",
-      };
-      mockAuth.mockResolvedValue(makeSession("juangarcia"));
-      mockGetAlumnoByGithub.mockResolvedValue(alumno);
-
-      await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      // comisionActiva es null en el mock → comision: undefined en el upsert
-      expect(mockUpsertAlumno).toHaveBeenCalledWith({ ...alumno, comision: undefined });
-    });
-
-    it("hace upsert con la comisión activa cuando existe", async () => {
-      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
-      mockGetComisionActiva.mockResolvedValue(comision);
-      const alumno = { legajo: "12345", nombre: "Juan", apellido: "G", githubUsername: "j", email: "j@j.com" };
-      mockAuth.mockResolvedValue(makeSession("j"));
-      mockGetAlumnoByGithub.mockResolvedValue(alumno);
-
-      await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      expect(mockUpsertAlumno).toHaveBeenCalledWith({ ...alumno, comision });
-    });
-
-    it("no hace upsert si el alumno no está en la planilla", async () => {
-      mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
 
       await RegistroPage();
-      expect(mockUpsertAlumno).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("NO redirige a /dashboard si el alumno nunca confirmó (registroConfirmadoEn null)", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: null,
+      });
+
+      await RegistroPage();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("NO redirige si no hay comisión activa aunque el alumno exista en DB", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: null,
+      });
+
+      await RegistroPage();
+      expect(mockRedirect).not.toHaveBeenCalled();
     });
   });
 
-  describe("render cuando el alumno no está registrado", () => {
-    beforeEach(() => {
+  describe("prefill del formulario", () => {
+    it("usa los datos de DB cuando el alumno existe (recursante — gana DB)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "99999",
+        nombre: "Juan Carlos",
+        apellido: "García",
+        githubUsername: "juan",
+        email: "personal@gmail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+      // Sheets tiene otro email y otro legajo (el admin rearmó la planilla) — debe ganar DB
+      mockGetAlumnoDeSheets.mockResolvedValue({
+        legajo: "11111",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "institucional@utn.edu.ar",
+      });
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-legajo="99999"');
+      expect(html).toContain('data-email="personal@gmail.com"');
+      expect(html).toContain('data-nombre="Juan Carlos"');
+      expect(html).toContain('data-apellido="García"');
+    });
+
+    it("usa los datos de Sheets cuando no hay DB (nuevo alumno pre-cargado por admin)", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("nuevo"));
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue({
+        legajo: "54321",
+        nombre: "María",
+        apellido: "Pérez",
+        githubUsername: "nuevo",
+        email: "maria@utn.edu.ar",
+      });
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-legajo="54321"');
+      expect(html).toContain('data-email="maria@utn.edu.ar"');
+      expect(html).toContain('data-nombre="María"');
+      expect(html).toContain('data-apellido="Pérez"');
+    });
+
+    it("cae a la sesión cuando no hay DB ni Sheets (nuevo sin pre-carga)", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
       mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
-    });
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue(null);
 
-    it("muestra el título de registro", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain("Registro");
-    });
-
-    it("muestra el nombre de usuario de GitHub vinculado", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain("nuevouser");
-    });
-
-    it("renderiza el AlumnoForm", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain('data-testid="alumno-form"');
-    });
-
-    it("pasa el githubUsername correcto al AlumnoForm", async () => {
       const element = await RegistroPage();
       const html = renderToStaticMarkup(element);
       expect(html).toContain('data-github="nuevouser"');
-    });
-
-    it("pasa el email de la sesión al AlumnoForm", async () => {
-      const session = makeSession("nuevouser");
-      mockAuth.mockResolvedValue(session);
-
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
       expect(html).toContain('data-email="test@example.com"');
+      expect(html).toContain('data-nombre="Test"');
+      expect(html).toContain('data-apellido="User"');
+      expect(html).toContain('data-legajo=""');
     });
 
-    it("pasa el nombre spliteado de la sesión al AlumnoForm", async () => {
+    it("no crashea si el nombre de sesión está vacío", async () => {
       const session = makeSession("nuevouser");
+      session.user.name = "";
       mockAuth.mockResolvedValue(session);
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue(null);
 
       const element = await RegistroPage();
       const html = renderToStaticMarkup(element);
-      // "Test User" → nombre: "Test", apellido: "User"
-      expect(html).toContain('data-nombre="Test"');
+      expect(html).toContain('data-nombre=""');
+      expect(html).toContain('data-apellido=""');
+    });
+  });
+
+  describe("copy y submit label", () => {
+    it("muestra 'Registrarme' para alumno nuevo", async () => {
+      mockAuth.mockResolvedValue(makeSession("nuevo"));
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-submit-label="Registrarme"');
+      expect(html).toContain("Completá tus datos");
     });
 
-    it("consulta por el username correcto en sheets", async () => {
-      await RegistroPage();
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("nuevouser", undefined, undefined);
-    });
+    it("muestra 'Confirmar datos' para recursante (ya está en DB pero no confirmó esta comisión)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
 
-    it("usa el spreadsheetId y columnConfig de la comisión activa", async () => {
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-submit-label="Confirmar datos"');
+      expect(html).toContain("Confirmá tus datos");
+    });
+  });
+
+  describe("consulta a Sheets", () => {
+    it("consulta Sheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
       const comision = {
+        id: "c1",
         spreadsheetId: "sheet-xyz",
-        columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4, comision: 5 },
+        columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
       };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
 
       await RegistroPage();
 
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
+      expect(mockGetAlumnoDeSheets).toHaveBeenCalledWith(
         "nuevouser",
         "sheet-xyz",
         comision.columnConfig
       );
     });
 
-    it("no redirige a /login ni /dashboard", async () => {
+    it("consulta la DB con el username de la sesión", async () => {
+      mockAuth.mockResolvedValue(makeSession("miuser"));
+
       await RegistroPage();
-      expect(mockRedirect).not.toHaveBeenCalled();
+      expect(mockGetAlumnoDeDB).toHaveBeenCalledWith("miuser");
     });
   });
 });

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -30,11 +30,14 @@ export default async function RegistroPage() {
   // Prefill: gana lo que el alumno confirmó alguna vez (DB); si no, lo que
   // pre-cargó el admin en la planilla (Sheets); y como último recurso, lo que
   // viene del perfil de GitHub de la sesión.
-  const alumnoSheets = await getAlumnoDeSheets(
-    githubUsername,
-    comisionActiva?.spreadsheetId,
-    comisionActiva?.columnConfig
-  );
+  // Sin comisión activa no hay planilla que leer; caemos al prefill de DB/sesión.
+  const alumnoSheets = comisionActiva
+    ? await getAlumnoDeSheets(
+        githubUsername,
+        comisionActiva.spreadsheetId,
+        comisionActiva.columnConfig
+      )
+    : undefined;
 
   const nameParts = (session.user?.name ?? "").split(" ").filter(Boolean);
   const defaultNombre = nameParts.slice(0, -1).join(" ") || nameParts[0] || "";

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from "@/lib/auth";
-import { getAlumnoByGithub } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { getAlumnoByGithub as getAlumnoDeSheets } from "@/lib/sheets";
+import {
+  getAlumnoByGithub as getAlumnoDeDB,
+  getComisionActiva,
+} from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
-import { upsertAlumno } from "@/lib/repositories";
 import type { PdepUser } from "@/types";
 
 export default async function RegistroPage() {
@@ -14,46 +16,61 @@ export default async function RegistroPage() {
   const githubUsername = pdepUser.githubUsername;
 
   const comisionActiva = await getComisionActiva();
+  const alumnoDB = await getAlumnoDeDB(githubUsername);
 
-  const existente = await getAlumnoByGithub(
+  // Si ya confirmó los datos para esta comisión, no tiene nada que hacer acá.
+  if (
+    alumnoDB &&
+    comisionActiva &&
+    alumnoDB.registroConfirmadoEn?.id === comisionActiva.id
+  ) {
+    redirect("/dashboard");
+  }
+
+  // Prefill: gana lo que el alumno confirmó alguna vez (DB); si no, lo que
+  // pre-cargó el admin en la planilla (Sheets); y como último recurso, lo que
+  // viene del perfil de GitHub de la sesión.
+  const alumnoSheets = await getAlumnoDeSheets(
     githubUsername,
     comisionActiva?.spreadsheetId,
     comisionActiva?.columnConfig
   );
-  if (existente) {
-    await upsertAlumno({ ...existente, comision: comisionActiva ?? undefined });
-    redirect("/dashboard");
-  }
 
-  // Split del nombre de GitHub en nombre/apellido como sugerencia
-  const parts = (session.user?.name ?? "").split(" ");
-  const defaultNombre = parts.slice(0, -1).join(" ") || parts[0] || "";
-  const defaultApellido = parts.length > 1 ? parts[parts.length - 1] : "";
+  const nameParts = (session.user?.name ?? "").split(" ").filter(Boolean);
+  const defaultNombre = nameParts.slice(0, -1).join(" ") || nameParts[0] || "";
+  const defaultApellido = nameParts.length > 1 ? nameParts[nameParts.length - 1] : "";
+
+  const defaultValues = {
+    githubUsername,
+    legajo: alumnoDB?.legajo ?? alumnoSheets?.legajo ?? "",
+    apellido: alumnoDB?.apellido ?? alumnoSheets?.apellido ?? defaultApellido,
+    nombre: alumnoDB?.nombre ?? alumnoSheets?.nombre ?? defaultNombre,
+    email: alumnoDB?.email ?? alumnoSheets?.email ?? session.user?.email ?? "",
+  };
+
+  const esRecursante = Boolean(alumnoDB);
 
   return (
     <div className="max-w-md mx-auto">
       <h1 className="text-2xl font-bold mb-2">Registro</h1>
       <p className="text-gray-500 text-sm mb-6">
-        Completá tus datos para registrarte en el curso. Tu usuario de GitHub
-        ya está vinculado:{" "}
+        {esRecursante
+          ? "Confirmá tus datos para esta cursada. "
+          : "Completá tus datos para registrarte en el curso. "}
+        Tu usuario de GitHub ya está vinculado:{" "}
         <span className="font-mono font-medium text-gray-700">
           {githubUsername}
         </span>
       </p>
 
       <AlumnoForm
-        defaultValues={{
-          githubUsername,
-          email: session.user?.email ?? "",
-          nombre: defaultNombre,
-          apellido: defaultApellido,
-        }}
+        defaultValues={defaultValues}
         apiEndpoint="/api/registro"
         method="POST"
         extraBody={{ githubUsername }}
         onSuccessRedirect="/dashboard"
-        submitLabel="Registrarme"
-        successMessage="¡Registro exitoso! Redirigiendo al dashboard…"
+        submitLabel={esRecursante ? "Confirmar datos" : "Registrarme"}
+        successMessage="¡Listo! Redirigiendo al dashboard…"
       />
     </div>
   );

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -25,6 +25,11 @@ export class Alumno {
   @ManyToOne(() => Comision, { nullable: true })
   comision?: Comision;
 
+  // Marca la comisión en la que el alumno confirmó sus datos por última vez.
+  // Si no coincide con la comisión activa, se le pide re-confirmar en /registro.
+  @ManyToOne(() => Comision, { nullable: true })
+  registroConfirmadoEn?: Comision;
+
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;
   }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -30,6 +30,7 @@ export interface AlumnoData {
   githubUsername: string;
   email: string;
   comision?: Comision;
+  registroConfirmadoEn?: Comision;
 }
 
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
@@ -41,6 +42,7 @@ export async function createAlumno(data: AlumnoData): Promise<Alumno> {
   alumno.githubUsername = data.githubUsername.toLowerCase().trim();
   alumno.email = data.email.toLowerCase().trim();
   alumno.comision = data.comision;
+  alumno.registroConfirmadoEn = data.registroConfirmadoEn;
   em.persist(alumno);
   await em.flush();
   return alumno;
@@ -59,6 +61,9 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
     existing.apellido = data.apellido.trim();
     existing.email = data.email.toLowerCase().trim();
     existing.comision = data.comision;
+    if (data.registroConfirmadoEn !== undefined) {
+      existing.registroConfirmadoEn = data.registroConfirmadoEn;
+    }
     await em.flush();
     return existing;
   }

--- a/src/lib/sheets.test.ts
+++ b/src/lib/sheets.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseAlumnosRows, validateRegistro, colLetter, actualizarAlumno } from "./sheets";
+import {
+  parseAlumnosRows,
+  validateRegistro,
+  colLetter,
+  isValidEmail,
+  upsertarAlumnoEnSheets,
+} from "./sheets";
 
 // ── parseAlumnosRows ────────────────────────────────────────
 
@@ -144,6 +150,54 @@ describe("validateRegistro", () => {
     expect(validateRegistro({ ...valid, email: "" })).toContain("email");
   });
 
+  it("rechaza email sin dominio con punto", () => {
+    expect(validateRegistro({ ...valid, email: "juan@gmail" })).toContain("email");
+  });
+
+  it("rechaza email con espacios", () => {
+    expect(validateRegistro({ ...valid, email: "juan @gmail.com" })).toContain("email");
+  });
+
+  it("acepta emails con subdominios", () => {
+    expect(validateRegistro({ ...valid, email: "juan@mail.frba.utn.edu.ar" })).toBeNull();
+  });
+
+  it("acepta emails con + en la parte local", () => {
+    expect(validateRegistro({ ...valid, email: "juan+curso@gmail.com" })).toBeNull();
+  });
+
+});
+
+// ── isValidEmail (helper) ────────────────────────────────────
+
+describe("isValidEmail", () => {
+  it("acepta email estándar", () => {
+    expect(isValidEmail("juan@gmail.com")).toBe(true);
+  });
+
+  it("acepta email con subdominios", () => {
+    expect(isValidEmail("juan@mail.utn.edu.ar")).toBe(true);
+  });
+
+  it("rechaza email sin arroba", () => {
+    expect(isValidEmail("juangmail.com")).toBe(false);
+  });
+
+  it("rechaza email sin dominio con punto", () => {
+    expect(isValidEmail("juan@gmail")).toBe(false);
+  });
+
+  it("rechaza string vacío", () => {
+    expect(isValidEmail("")).toBe(false);
+  });
+
+  it("rechaza email con espacios", () => {
+    expect(isValidEmail("juan @gmail.com")).toBe(false);
+  });
+
+  it("ignora whitespace al borde (trim)", () => {
+    expect(isValidEmail("  juan@gmail.com  ")).toBe(true);
+  });
 });
 
 // ── colLetter ────────────────────────────────────────────────
@@ -158,69 +212,65 @@ describe("colLetter", () => {
   it("52 → BA", () => expect(colLetter(52)).toBe("BA"));
 });
 
-// ── actualizarAlumno – validaciones síncronas ────────────────
+// ── upsertarAlumnoEnSheets – validaciones síncronas ──────────
 
-describe("actualizarAlumno – validaciones", () => {
+describe("upsertarAlumnoEnSheets – validaciones", () => {
   const valid = {
     legajo: "12345",
     apellido: "García",
     nombre: "Juan",
+    githubUsername: "juangarcia",
     email: "juan@gmail.com",
   };
 
   it("rechaza apellido vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, apellido: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "" });
     expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza apellido con solo espacios", async () => {
-    const r = await actualizarAlumno("user", { ...valid, apellido: "   " });
+    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "   " });
     expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza nombre vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, nombre: "" });
-    expect(r).toEqual({ ok: false, error: "El nombre es obligatorio" });
-  });
-
-  it("rechaza nombre con solo espacios", async () => {
-    const r = await actualizarAlumno("user", { ...valid, nombre: "   " });
+    const r = await upsertarAlumnoEnSheets({ ...valid, nombre: "" });
     expect(r).toEqual({ ok: false, error: "El nombre es obligatorio" });
   });
 
   it("rechaza legajo vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "" });
     expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza legajo con letras", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "abc12" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
-  });
-
-  it("rechaza legajo demasiado corto", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "12" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
-  });
-
-  it("rechaza legajo demasiado largo", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "123456789" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "abc12" });
     expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza email sin @", async () => {
-    const r = await actualizarAlumno("user", { ...valid, email: "juangmail.com" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juangmail.com" });
+    expect(r).toEqual({ ok: false, error: "El email no es válido" });
+  });
+
+  it("rechaza email sin punto en el dominio", async () => {
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juan@gmail" });
     expect(r).toEqual({ ok: false, error: "El email no es válido" });
   });
 
   it("rechaza email vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, email: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "" });
     expect(r).toEqual({ ok: false, error: "El email no es válido" });
   });
 
+  it("rechaza github vacío", async () => {
+    const r = await upsertarAlumnoEnSheets({ ...valid, githubUsername: "" });
+    expect(r).toEqual({ ok: false, error: "El usuario de GitHub es obligatorio" });
+  });
+
   it("lanza error si no hay spreadsheetId configurado (input válido)", async () => {
-    await expect(
-      actualizarAlumno("user", valid, undefined)
-    ).rejects.toThrow("No hay una comisión activa");
+    await expect(upsertarAlumnoEnSheets(valid, undefined)).rejects.toThrow(
+      "No hay una comisión activa"
+    );
   });
 });

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -148,6 +148,14 @@ export interface RegistroInput {
   email: string;
 }
 
+// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
+// Suficiente para detectar typos comunes sin sobre-complicar.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
 export function validateRegistro(input: RegistroInput): string | null {
   const { legajo, apellido, nombre, githubUsername, email } = input;
 
@@ -158,11 +166,16 @@ export function validateRegistro(input: RegistroInput): string | null {
   if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
   if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
     return "El usuario de GitHub no tiene un formato válido";
-  if (!email.trim() || !email.includes("@")) return "El email no es válido";
+  if (!isValidEmail(email)) return "El email no es válido";
   return null;
 }
 
-export async function registrarAlumno(
+// ── Upsert de alumno en la planilla ─────────────────────────
+// Unifica registro (insert) y actualización (update): busca la fila por
+// githubUsername; si existe, la actualiza respetando columnas desconocidas,
+// y si no, la agrega al final.
+
+export async function upsertarAlumnoEnSheets(
   input: RegistroInput,
   spreadsheetId?: string,
   config?: Partial<ColumnConfig>
@@ -172,102 +185,56 @@ export async function registrarAlumno(
 
   const id = resolveSpreadsheetId(spreadsheetId);
   const cfg = resolveConfig(config);
+  const githubNormalizado = input.githubUsername.trim().toLowerCase();
 
-  // Verificar duplicados
+  // El legajo puede pertenecer al mismo alumno (al actualizar) o a otro (colisión).
   const porLegajo = await getAlumnoByLegajo(input.legajo, id, cfg);
-  if (porLegajo) {
+  if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubNormalizado) {
     return {
       ok: false,
       error: `El legajo ${input.legajo} ya está registrado (${porLegajo.githubUsername})`,
     };
   }
 
-  const porGithub = await getAlumnoByGithub(input.githubUsername, id, cfg);
-  if (porGithub) {
-    return {
-      ok: false,
-      error: `El usuario ${input.githubUsername} ya está registrado (legajo ${porGithub.legajo})`,
-    };
-  }
-
-  // Construir la fila según la config de columnas
+  const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, cfg);
+  const sheets = getSheetsClient(false);
   const maxCol = Math.max(
     cfg.legajo, cfg.apellido, cfg.nombre,
     cfg.githubUsername, cfg.email
   );
-  const row = new Array(maxCol + 1).fill("");
-  row[cfg.legajo] = input.legajo.trim();
-  row[cfg.apellido] = input.apellido.trim();
-  row[cfg.nombre] = input.nombre.trim();
-  row[cfg.githubUsername] = input.githubUsername.trim().toLowerCase();
-  row[cfg.email] = input.email.trim().toLowerCase();
 
-  const sheets = getSheetsClient(false);
-  await sheets.spreadsheets.values.append({
-    spreadsheetId: id,
-    range: `${cfg.sheetName}!A:${colLetter(maxCol)}`,
-    valueInputOption: "USER_ENTERED",
-    requestBody: { values: [row] },
-  });
-
-  return { ok: true };
-}
-
-// ── Actualizar datos de un alumno ya registrado ─────────────
-
-export type ActualizarInput = Omit<RegistroInput, "githubUsername">;
-
-export async function actualizarAlumno(
-  githubUsername: string,
-  updates: ActualizarInput,
-  spreadsheetId?: string,
-  config?: Partial<ColumnConfig>
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  if (!updates.apellido.trim()) return { ok: false, error: "El apellido es obligatorio" };
-  if (!updates.nombre.trim()) return { ok: false, error: "El nombre es obligatorio" };
-  if (!updates.legajo || !/^\d{4,8}$/.test(updates.legajo.trim()))
-    return { ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" };
-  if (!updates.email.trim() || !updates.email.includes("@"))
-    return { ok: false, error: "El email no es válido" };
-
-  const id = resolveSpreadsheetId(spreadsheetId);
-  const cfg = resolveConfig(config);
-
-  const rowNumber = await findAlumnoRowIndex(githubUsername, id, cfg);
   if (rowNumber === null) {
-    return { ok: false, error: "No se encontró al alumno en la planilla" };
+    const row = new Array(maxCol + 1).fill("");
+    row[cfg.legajo] = input.legajo.trim();
+    row[cfg.apellido] = input.apellido.trim();
+    row[cfg.nombre] = input.nombre.trim();
+    row[cfg.githubUsername] = githubNormalizado;
+    row[cfg.email] = input.email.trim().toLowerCase();
+
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: id,
+      range: `${cfg.sheetName}!A:${colLetter(maxCol)}`,
+      valueInputOption: "USER_ENTERED",
+      requestBody: { values: [row] },
+    });
+    return { ok: true };
   }
 
-  // Verificar que el legajo no esté tomado por otro alumno
-  const porLegajo = await getAlumnoByLegajo(updates.legajo, id, cfg);
-  if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubUsername.toLowerCase()) {
-    return {
-      ok: false,
-      error: `El legajo ${updates.legajo} ya está registrado (${porLegajo.githubUsername})`,
-    };
-  }
-
-  // Leer la fila completa primero para no pisar columnas desconocidas
-  const sheets = getSheetsClient(false);
-  const maxCol = Math.max(
-    cfg.legajo, cfg.apellido, cfg.nombre,
-    cfg.githubUsername, cfg.email
-  );
+  // Leemos la fila completa para no pisar columnas desconocidas que el admin
+  // pueda tener (notas, observaciones, etc).
   const range = `${cfg.sheetName}!A${rowNumber}:${colLetter(maxCol)}${rowNumber}`;
-
   const { data: existing } = await sheets.spreadsheets.values.get({
     spreadsheetId: id,
     range,
   });
   const existingRow: unknown[] = existing.values?.[0] ?? [];
-  // Expandir si hace falta
   while (existingRow.length <= maxCol) existingRow.push("");
 
-  existingRow[cfg.legajo] = updates.legajo.trim();
-  existingRow[cfg.apellido] = updates.apellido.trim();
-  existingRow[cfg.nombre] = updates.nombre.trim();
-  existingRow[cfg.email] = updates.email.trim().toLowerCase();
-  // githubUsername y comision no se tocan
+  existingRow[cfg.legajo] = input.legajo.trim();
+  existingRow[cfg.apellido] = input.apellido.trim();
+  existingRow[cfg.nombre] = input.nombre.trim();
+  existingRow[cfg.email] = input.email.trim().toLowerCase();
+  // githubUsername NO se sobrescribe: la fila se identifica por él.
 
   await sheets.spreadsheets.values.update({
     spreadsheetId: id,
@@ -275,7 +242,6 @@ export async function actualizarAlumno(
     valueInputOption: "USER_ENTERED",
     requestBody: { values: [existingRow] },
   });
-
   return { ok: true };
 }
 


### PR DESCRIPTION
## Summary

- Nuevo campo `Alumno.registroConfirmadoEn` + gate en `/dashboard`: si no coincide con la comisión activa, se pide re-confirmar (cubre alumno nuevo y recursante con una sola condición).
- `/registro` ya no hace upsert silencioso: siempre muestra el form, pre-llenado con `DB > Sheets > sesión` (gana lo que el alumno confirmó antes). Copy y label cambian para recursante.
- `upsertarAlumnoEnSheets` unifica registro y actualización — evita que el admin pre-cargado produzca una fila duplicada cuando el alumno confirma, y /perfil ahora escribe en Sheets **y** DB.
- Validación de email endurecida (RFC-lite) en cliente (`pattern` + helper) y servidor (`isValidEmail` / `validateRegistro`).

## Motivación

El flujo anterior reconocía al alumno pre-cargado en Sheets y lo mandaba directo al dashboard sin preguntarle nada. Eso nos hacía perder la chance de capturar un email que leyera asiduamente (el admin suele cargar el institucional, que nadie mira), y al recursar pisaba silenciosamente el email personal que el alumno había dado en la cursada anterior con lo que venía en la planilla nueva.

## Migración

Nuevo campo nullable `registro_confirmado_en_id` con FK a `comision`. Sin data productiva, no hace falta backfill: los registros de prueba existentes verán el form una vez y se re-confirman naturalmente.

## Test plan

- [x] `pnpm test:run` — 467 tests passing (42 archivos)
- [x] Loguearse como alumno nuevo sin pre-carga → aparece form vacío con email de la sesión
- [x] Loguearse como alumno pre-cargado en Sheets → aparece form con legajo/nombre/email institucional pre-llenados; al submit, confirma y redirige al dashboard
- [x] Loguearse como alumno ya confirmado para la comisión activa → va directo al dashboard
- [x] Loguearse como alumno que confirmó en otra comisión (recursante) → aparece form con sus datos de DB, copy "Confirmá tus datos" y botón "Confirmar datos"
- [x] Editar perfil → los cambios se reflejan en Sheets y en DB
- [x] Email sin `@` o sin `.` en el dominio → rechazado en cliente y servidor

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Características**
  * Validación RFC-lite de correo y texto guía en el formulario.
  * Registro que guarda en qué comisión se confirmó el alumno (nuevo campo de confirmación).

* **Comportamiento**
  * Flujos de registro y perfil ahora priorizan datos de la base y condicionan redirecciones según confirmación en comisión.
  * Escritura/actualización en planilla revisada para evitar sobrescribir usuario de GitHub.

* **Tests**
  * Amplia cobertura nueva y actualizada para rutas, páginas, componentes y utilidades.

* **Chores**
  * Migración de esquema para soportar los cambios de datos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->