### PR TITLE
Hacer la app usable en mobile (header + tablas + forms)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "es"
 
 reviews:
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: true
   poem: false
   review_status: true
@@ -18,6 +18,17 @@ reviews:
     base_branches:
       - "master"
       - "Development"
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  auto_apply_labels: false
+  auto_assign_reviewers: false
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
     drafts: false
     base_branches:
       - "master"
-      - "Development"
+      - "development"
 
   finishing_touches:
     docstrings:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "vercel-build": "npm run db:migration:up && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",

--- a/src/app/admin/alumnos/page.test.tsx
+++ b/src/app/admin/alumnos/page.test.tsx
@@ -69,12 +69,12 @@ describe("Admin Alumnos page", () => {
   });
 
   describe("con alumnos", () => {
-    it("muestra la tabla cuando hay alumnos", async () => {
+    it("no muestra el estado vacío cuando hay alumnos", async () => {
       mockGetAlumnos.mockResolvedValue([makeAlumno()]);
 
       const element = await AdminAlumnosPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay alumnos ingresados");
     });
 
     it("muestra la cantidad de alumnos en el subtítulo", async () => {

--- a/src/app/admin/alumnos/page.tsx
+++ b/src/app/admin/alumnos/page.tsx
@@ -2,6 +2,15 @@ import { requireAdmin } from "@/lib/session";
 import { getAlumnos } from "@/lib/sheets";
 import { getComisionActiva } from "@/lib/repositories";
 import Link from "next/link";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminAlumnosPage() {
   await requireAdmin();
@@ -33,55 +42,43 @@ export default async function AdminAlumnosPage() {
       </p>
 
       {alumnos.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay alumnos ingresados.
-        </div>
+        <DataEmpty>No hay alumnos ingresados.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Legajo
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Nombre
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  GitHub
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Email
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {alumnos.map((a) => (
-                <tr key={a.legajo} className="hover:bg-gray-50">
-                  <td className="px-4 py-2.5 font-mono text-xs">
-                    {a.legajo}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    {a.apellido}, {a.nombre}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <a
-                      href={`https://github.com/${a.githubUsername}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-mono text-xs text-pdep-600 hover:underline"
-                    >
-                      {a.githubUsername}
-                    </a>
-                  </td>
-                  <td className="px-4 py-2.5 text-gray-500 text-xs">
+        <DataTable columns="1.5fr 100px 1.2fr 2fr">
+          <DataHeader>
+            <DataHeaderCell>Nombre</DataHeaderCell>
+            <DataHeaderCell>Legajo</DataHeaderCell>
+            <DataHeaderCell>GitHub</DataHeaderCell>
+            <DataHeaderCell>Email</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {alumnos.map((a) => (
+              <DataRow key={a.legajo}>
+                <DataCell label="Nombre" heading>
+                  {a.apellido}, {a.nombre}
+                </DataCell>
+                <DataCell label="Legajo">
+                  <span className="font-mono text-xs">{a.legajo}</span>
+                </DataCell>
+                <DataCell label="GitHub">
+                  <a
+                    href={`https://github.com/${a.githubUsername}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-xs text-pdep-600 hover:underline break-all"
+                  >
+                    {a.githubUsername}
+                  </a>
+                </DataCell>
+                <DataCell label="Email">
+                  <span className="text-gray-500 text-xs break-all">
                     {a.email}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  </span>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/assignments/[id]/entregas-table.test.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.test.tsx
@@ -80,14 +80,14 @@ describe("EntregasTable", () => {
     expect(html).toContain("No hay entregas todavía");
   });
 
-  it("no muestra la tabla cuando no hay entregas", () => {
+  it("no muestra filas cuando no hay entregas", () => {
     const html = renderToStaticMarkup(<EntregasTable entregas={[]} />);
-    expect(html).not.toContain("<table");
+    expect(html).not.toContain("data-cols");
   });
 
-  it("muestra la tabla cuando hay entregas", () => {
+  it("muestra filas cuando hay entregas", () => {
     const html = renderToStaticMarkup(<EntregasTable entregas={[makeRow()]} />);
-    expect(html).toContain("<table");
+    expect(html).toContain("García, Juan");
   });
 
   it("muestra las cabeceras de la tabla", () => {

--- a/src/app/admin/assignments/[id]/entregas-table.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+} from "@/app/components/DataTable";
 
 export type EntregaRow = {
   id: string;
@@ -28,7 +36,7 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
 
   return (
     <div>
-      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between gap-4">
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <h2 className="font-medium text-gray-700 shrink-0">
           Entregas aceptadas
         </h2>
@@ -38,7 +46,7 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Buscar por usuario o repo..."
-          className="border border-gray-300 rounded-md px-3 py-1 text-sm w-64 focus:outline-none focus:ring-2 focus:ring-pdep-400"
+          className="border border-gray-300 rounded-md px-3 py-1 text-sm w-full sm:w-64 focus:outline-none focus:ring-2 focus:ring-pdep-400"
         />
       </div>
 
@@ -49,35 +57,29 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
             : "No hay entregas todavía."}
         </div>
       ) : (
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50 border-b border-gray-200">
-            <tr>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Usuario(s)
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Nombre completo
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Repositorio
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Fecha
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
+        <DataTable columns="1.5fr 1.2fr 1.5fr 120px" bare>
+          <DataHeader>
+            <DataHeaderCell>Nombre completo</DataHeaderCell>
+            <DataHeaderCell>Usuario(s)</DataHeaderCell>
+            <DataHeaderCell>Repositorio</DataHeaderCell>
+            <DataHeaderCell>Fecha</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
             {filtradas.map((e) => (
-              <tr key={e.id} className="hover:bg-gray-50">
-                <td className="px-4 py-3 font-mono text-xs">
-                  {e.githubUsernames.join(", ")}
-                </td>
-                <td className="px-4 py-3 text-xs text-gray-700">
+              <DataRow key={e.id}>
+                <DataCell label="Nombre completo" heading>
                   {e.nombreCompleto}
-                </td>
-                <td className="px-4 py-3">
+                </DataCell>
+                <DataCell label="Usuario(s)">
+                  <span className="font-mono text-xs break-all">
+                    {e.githubUsernames.join(", ")}
+                  </span>
+                </DataCell>
+                <DataCell label="Repositorio">
                   {e.repoDeleted ? (
-                    <span className="text-red-400 text-xs">Repositorio borrado</span>
+                    <span className="text-red-400 text-xs">
+                      Repositorio borrado
+                    </span>
                   ) : e.repoUrl ? (
                     <a
                       href={e.repoUrl}
@@ -103,14 +105,14 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
                   ) : (
                     <span className="text-gray-400 text-xs">Sin repo</span>
                   )}
-                </td>
-                <td className="px-4 py-3 text-gray-500 text-xs">
-                  {e.createdAt}
-                </td>
-              </tr>
+                </DataCell>
+                <DataCell label="Fecha">
+                  <span className="text-gray-500 text-xs">{e.createdAt}</span>
+                </DataCell>
+              </DataRow>
             ))}
-          </tbody>
-        </table>
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -222,7 +222,7 @@ export function AssignmentForm({
       </div>
 
       {/* Paradigma y Tipo en fila */}
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Paradigma *
@@ -304,11 +304,11 @@ export function AssignmentForm({
       </div>
 
       {/* Submit */}
-      <div className="flex gap-3 pt-2">
+      <div className="flex flex-col sm:flex-row gap-3 pt-2">
         <SubmitButton label={submitLabel} />
         <a
           href="/admin/assignments"
-          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors"
+          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors text-center"
         >
           Cancelar
         </a>

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -90,20 +90,20 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("No hay assignments todavía");
     });
 
-    it("no muestra la tabla cuando no hay assignments", async () => {
+    it("no muestra filas cuando no hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([]);
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
-      expect(html).not.toContain("<table");
+      expect(html).not.toContain("Kata Funcional");
     });
   });
 
   describe("con assignments", () => {
-    it("muestra la tabla cuando hay assignments", async () => {
+    it("no muestra el estado vacío cuando hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay assignments todavía");
     });
 
     it("muestra el título del assignment", async () => {

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -46,13 +46,13 @@ export default async function AdminAssignmentsPage() {
       {sorted.length === 0 ? (
         <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px auto">
+        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px 180px">
           <DataHeader>
             <DataHeaderCell>Título</DataHeaderCell>
             <DataHeaderCell>Paradigma</DataHeaderCell>
             <DataHeaderCell>Tipo</DataHeaderCell>
             <DataHeaderCell>Template</DataHeaderCell>
-            <DataHeaderCell align="right">Entregas</DataHeaderCell>
+            <DataHeaderCell>Entregas</DataHeaderCell>
             <DataHeaderCell>Deadline</DataHeaderCell>
             <DataHeaderCell>Acciones</DataHeaderCell>
           </DataHeader>
@@ -75,7 +75,7 @@ export default async function AdminAssignmentsPage() {
                     {a.templateRepo}
                   </span>
                 </DataCell>
-                <DataCell label="Entregas" align="right">
+                <DataCell label="Entregas">
                   <span className="font-mono">
                     {entregasCounts.get(a.id) ?? 0}
                   </span>

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -1,22 +1,39 @@
 import { requireAdmin } from "@/lib/session";
-import { getAssignments, getEntregaCountsByAssignment, getActiveRepoCountsByAssignment } from "@/lib/repositories";
+import {
+  getAssignments,
+  getEntregaCountsByAssignment,
+  getActiveRepoCountsByAssignment,
+} from "@/lib/repositories";
 import Link from "next/link";
 import { DeleteAssignmentButton } from "./delete-button";
 import { DeleteReposButton } from "./delete-repos-button";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminAssignmentsPage() {
   await requireAdmin();
 
-  // Una query para assignments, una para conteos — en paralelo
   const [assignments, entregasCounts, activeRepoCounts] = await Promise.all([
     getAssignments(),
     getEntregaCountsByAssignment(),
     getActiveRepoCountsByAssignment(),
   ]);
 
+  const sorted = [...assignments].sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <h1 className="text-2xl font-bold">Assignments</h1>
         <Link
           href="/admin/assignments/new"
@@ -26,91 +43,75 @@ export default async function AdminAssignmentsPage() {
         </Link>
       </div>
 
-      {assignments.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay assignments todavía. Creá el primero.
-        </div>
+      {sorted.length === 0 ? (
+        <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Título
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Paradigma
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Tipo
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Template
-                </th>
-                <th className="text-right px-4 py-3 font-medium text-gray-600">
-                  Entregas
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Deadline
-                </th>
-                <th className="px-4 py-3 font-medium text-gray-600">
-                  Acciones
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {assignments
-                .sort(
-                  (a, b) =>
-                    new Date(b.createdAt).getTime() -
-                    new Date(a.createdAt).getTime()
-                )
-                .map((a) => (
-                  <tr key={a.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium">{a.titulo}</td>
-                    <td className="px-4 py-3">
-                      <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">
-                        {a.paradigma}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">{a.tipo}</td>
-                    <td className="px-4 py-3 font-mono text-xs text-gray-500">
-                      {a.templateRepo}
-                    </td>
-                    <td className="px-4 py-3 text-right font-mono">
-                      {entregasCounts.get(a.id) ?? 0}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {a.deadline
-                        ? new Date(a.deadline).toLocaleDateString("es-AR")
-                        : "—"}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <Link
-                          href={`/admin/assignments/${a.id}`}
-                          className="text-gray-500 hover:text-gray-700 text-xs font-medium"
-                        >
-                          Ver
-                        </Link>
-                        <Link
-                          href={`/admin/assignments/${a.id}/edit`}
-                          className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
-                        >
-                          Editar
-                        </Link>
-                        <DeleteReposButton
-                          assignmentId={a.id}
-                          activeRepoCount={activeRepoCounts.get(a.id) ?? 0}
-                        />
-                        <DeleteAssignmentButton id={a.id} titulo={a.titulo} />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
-        </div>
+        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px auto">
+          <DataHeader>
+            <DataHeaderCell>Título</DataHeaderCell>
+            <DataHeaderCell>Paradigma</DataHeaderCell>
+            <DataHeaderCell>Tipo</DataHeaderCell>
+            <DataHeaderCell>Template</DataHeaderCell>
+            <DataHeaderCell align="right">Entregas</DataHeaderCell>
+            <DataHeaderCell>Deadline</DataHeaderCell>
+            <DataHeaderCell>Acciones</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {sorted.map((a) => (
+              <DataRow key={a.id}>
+                <DataCell label="Título" heading>
+                  {a.titulo}
+                </DataCell>
+                <DataCell label="Paradigma">
+                  <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">
+                    {a.paradigma}
+                  </span>
+                </DataCell>
+                <DataCell label="Tipo">
+                  <span className="text-gray-500">{a.tipo}</span>
+                </DataCell>
+                <DataCell label="Template">
+                  <span className="font-mono text-xs text-gray-500 break-all">
+                    {a.templateRepo}
+                  </span>
+                </DataCell>
+                <DataCell label="Entregas" align="right">
+                  <span className="font-mono">
+                    {entregasCounts.get(a.id) ?? 0}
+                  </span>
+                </DataCell>
+                <DataCell label="Deadline">
+                  <span className="text-gray-500">
+                    {a.deadline
+                      ? new Date(a.deadline).toLocaleDateString("es-AR")
+                      : "—"}
+                  </span>
+                </DataCell>
+                <DataCell label="">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <Link
+                      href={`/admin/assignments/${a.id}`}
+                      className="text-gray-500 hover:text-gray-700 text-xs font-medium"
+                    >
+                      Ver
+                    </Link>
+                    <Link
+                      href={`/admin/assignments/${a.id}/edit`}
+                      className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
+                    >
+                      Editar
+                    </Link>
+                    <DeleteReposButton
+                      assignmentId={a.id}
+                      activeRepoCount={activeRepoCounts.get(a.id) ?? 0}
+                    />
+                    <DeleteAssignmentButton id={a.id} titulo={a.titulo} />
+                  </div>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -125,7 +125,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         </p>
 
         {/* Nombre de la hoja y filas de encabezado */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">
               Nombre de la hoja
@@ -155,7 +155,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         </div>
 
         {/* Selectores de columna */}
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           <ColSelect name="col_legajo" label="Legajo" defaultValue={cfg.legajo} error={errors.col_legajo?.[0]} />
           <ColSelect name="col_apellido" label="Apellido" defaultValue={cfg.apellido} error={errors.col_apellido?.[0]} />
           <ColSelect name="col_nombre" label="Nombre" defaultValue={cfg.nombre} error={errors.col_nombre?.[0]} />
@@ -165,11 +165,11 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
       </fieldset>
 
       {/* Submit */}
-      <div className="flex gap-3 pt-2">
+      <div className="flex flex-col sm:flex-row gap-3 pt-2">
         <SubmitButton label={submitLabel} />
         <a
           href="/admin/comisiones"
-          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors"
+          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors text-center"
         >
           Cancelar
         </a>

--- a/src/app/admin/comisiones/page.test.tsx
+++ b/src/app/admin/comisiones/page.test.tsx
@@ -64,20 +64,20 @@ describe("Admin Comisiones page", () => {
       expect(html).toContain("No hay comisiones todavía");
     });
 
-    it("no muestra la tabla cuando no hay comisiones", async () => {
+    it("no muestra ninguna fila cuando no hay comisiones", async () => {
       mockGetComisiones.mockResolvedValue([]);
       const element = await AdminComisionesPage();
       const html = renderToStaticMarkup(element);
-      expect(html).not.toContain("<table");
+      expect(html).not.toContain("Editar");
     });
   });
 
   describe("con comisiones", () => {
-    it("muestra la tabla cuando hay comisiones", async () => {
+    it("no muestra el estado vacío cuando hay comisiones", async () => {
       mockGetComisiones.mockResolvedValue([makeComision()]);
       const element = await AdminComisionesPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay comisiones todavía");
     });
 
     it("muestra el año de la comisión", async () => {

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -1,6 +1,15 @@
 import { requireAdmin } from "@/lib/session";
 import { getComisiones } from "@/lib/repositories";
 import { DeleteComisionButton } from "./delete-button";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminComisionesPage() {
   await requireAdmin();
@@ -8,7 +17,7 @@ export default async function AdminComisionesPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <h1 className="text-2xl font-bold">Comisiones</h1>
         <a
           href="/admin/comisiones/new"
@@ -19,53 +28,51 @@ export default async function AdminComisionesPage() {
       </div>
 
       {comisiones.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay comisiones todavía.
-        </div>
+        <DataEmpty>No hay comisiones todavía.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Año</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Planilla</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Estado</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Acciones</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {comisiones.map((c) => (
-                <tr key={c.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-semibold">{c.anio}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-500 max-w-xs truncate">
+        <DataTable columns="100px 2fr 140px auto">
+          <DataHeader>
+            <DataHeaderCell>Año</DataHeaderCell>
+            <DataHeaderCell>Planilla</DataHeaderCell>
+            <DataHeaderCell>Estado</DataHeaderCell>
+            <DataHeaderCell>Acciones</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {comisiones.map((c) => (
+              <DataRow key={c.id}>
+                <DataCell label="Año" heading>
+                  {c.anio}
+                </DataCell>
+                <DataCell label="Planilla">
+                  <span className="font-mono text-xs text-gray-500 break-all md:truncate md:block">
                     {c.spreadsheetId}
-                  </td>
-                  <td className="px-4 py-3">
-                    {c.activa ? (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
-                        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                        Activa
-                      </span>
-                    ) : (
-                      <span className="text-xs text-gray-400">Inactiva</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <a
-                        href={`/admin/comisiones/${c.id}/edit`}
-                        className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
-                      >
-                        Editar
-                      </a>
-                      <DeleteComisionButton id={c.id} anio={c.anio} />
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  </span>
+                </DataCell>
+                <DataCell label="Estado">
+                  {c.activa ? (
+                    <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
+                      <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+                      Activa
+                    </span>
+                  ) : (
+                    <span className="text-xs text-gray-400">Inactiva</span>
+                  )}
+                </DataCell>
+                <DataCell label="">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <a
+                      href={`/admin/comisiones/${c.id}/edit`}
+                      className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
+                    >
+                      Editar
+                    </a>
+                    <DeleteComisionButton id={c.id} anio={c.anio} />
+                  </div>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminComisionesPage() {
       {comisiones.length === 0 ? (
         <DataEmpty>No hay comisiones todavía.</DataEmpty>
       ) : (
-        <DataTable columns="100px 2fr 140px auto">
+        <DataTable columns="100px 2fr 140px 160px">
           <DataHeader>
             <DataHeaderCell>Año</DataHeaderCell>
             <DataHeaderCell>Planilla</DataHeaderCell>

--- a/src/app/admin/grupos/page.tsx
+++ b/src/app/admin/grupos/page.tsx
@@ -27,7 +27,7 @@ export default async function AdminGruposPage({
       </p>
 
       {/* Filtro por paradigma */}
-      <div className="flex gap-2 mb-6">
+      <div className="flex flex-wrap gap-2 mb-6">
         <a
           href="/admin/grupos"
           className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -90,6 +90,7 @@ export function AlumnoForm({
           name="legajo"
           required
           pattern="\d{4,8}"
+          inputMode="numeric"
           placeholder="12345678"
           defaultValue={defaultValues.legajo}
           className={INPUT_CLASS}

--- a/src/app/components/DataTable.test.tsx
+++ b/src/app/components/DataTable.test.tsx
@@ -55,7 +55,7 @@ describe("DataTable", () => {
     expect(screen.getByText("Tipo")).toHaveClass("md:hidden");
   });
 
-  it("DataHeader solo se muestra en md+ (hidden md:grid)", () => {
+  it("DataHeader solo se muestra en md+", () => {
     const { container } = render(
       <DataTable columns="1fr 1fr">
         <DataHeader>
@@ -64,7 +64,7 @@ describe("DataTable", () => {
         </DataHeader>
       </DataTable>
     );
-    const header = container.querySelector(".hidden.md\\:grid");
+    const header = container.querySelector(".hidden.md\\:block");
     expect(header).toBeInTheDocument();
     expect(screen.getByText("Título")).toBeInTheDocument();
     expect(screen.getByText("Entregas")).toHaveClass("text-right");
@@ -82,6 +82,28 @@ describe("DataTable", () => {
     );
     expect(screen.queryByText("Título")).not.toBeInTheDocument();
     expect(screen.getByText("Mi TP").className).toContain("font-semibold");
+  });
+
+  it("expone roles ARIA tabulares para screen readers", () => {
+    render(
+      <DataTable columns="1fr 1fr">
+        <DataHeader>
+          <DataHeaderCell>A</DataHeaderCell>
+          <DataHeaderCell>B</DataHeaderCell>
+        </DataHeader>
+        <DataBody>
+          <DataRow>
+            <DataCell label="A">a1</DataCell>
+            <DataCell label="B">b1</DataCell>
+          </DataRow>
+        </DataBody>
+      </DataTable>
+    );
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("rowgroup")).toHaveLength(2);
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(screen.getAllByRole("columnheader")).toHaveLength(2);
+    expect(screen.getAllByRole("cell")).toHaveLength(2);
   });
 
   it("DataEmpty muestra el mensaje vacío", () => {

--- a/src/app/components/DataTable.test.tsx
+++ b/src/app/components/DataTable.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "./DataTable";
+
+describe("DataTable", () => {
+  it("propaga la definición de columnas al estilo CSS del container", () => {
+    const { container } = render(
+      <DataTable columns="2fr 1fr 100px">
+        <div>x</div>
+      </DataTable>
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.getPropertyValue("--data-cols")).toBe("2fr 1fr 100px");
+  });
+
+  it("DataCell muestra el label y el valor", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Paradigma">Funcional</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.getByText("Paradigma")).toBeInTheDocument();
+    expect(screen.getByText("Funcional")).toBeInTheDocument();
+  });
+
+  it("DataCell sin label no renderiza el prefijo", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="">Acciones</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.queryByText(/:/)).not.toBeInTheDocument();
+    expect(screen.getByText("Acciones")).toBeInTheDocument();
+  });
+
+  it("el label de DataCell se oculta en md+ (md:hidden)", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Tipo">grupal</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.getByText("Tipo")).toHaveClass("md:hidden");
+  });
+
+  it("DataHeader solo se muestra en md+ (hidden md:grid)", () => {
+    const { container } = render(
+      <DataTable columns="1fr 1fr">
+        <DataHeader>
+          <DataHeaderCell>Título</DataHeaderCell>
+          <DataHeaderCell align="right">Entregas</DataHeaderCell>
+        </DataHeader>
+      </DataTable>
+    );
+    const header = container.querySelector(".hidden.md\\:grid");
+    expect(header).toBeInTheDocument();
+    expect(screen.getByText("Título")).toBeInTheDocument();
+    expect(screen.getByText("Entregas")).toHaveClass("text-right");
+  });
+
+  it("DataCell con heading oculta el label y destaca el valor", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Título" heading>
+            Mi TP
+          </DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.queryByText("Título")).not.toBeInTheDocument();
+    expect(screen.getByText("Mi TP").className).toContain("font-semibold");
+  });
+
+  it("DataEmpty muestra el mensaje vacío", () => {
+    render(<DataEmpty>No hay nada todavía</DataEmpty>);
+    expect(screen.getByText("No hay nada todavía")).toBeInTheDocument();
+  });
+
+  it("DataBody envuelve las filas", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataBody>
+          <DataRow>
+            <DataCell label="X">a</DataCell>
+          </DataRow>
+          <DataRow>
+            <DataCell label="X">b</DataCell>
+          </DataRow>
+        </DataBody>
+      </DataTable>
+    );
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -13,15 +13,22 @@ interface DataTableProps {
   columns: string;
   children: ReactNode;
   className?: string;
+  /** Si true, no aplica el contenedor (bg/borde/rounded). Usalo cuando el padre envuelve. */
+  bare?: boolean;
 }
 
-export function DataTable({ columns, children, className = "" }: DataTableProps) {
+export function DataTable({
+  columns,
+  children,
+  className = "",
+  bare = false,
+}: DataTableProps) {
   const style = { ["--data-cols" as string]: columns } as CSSProperties;
+  const containerClass = bare
+    ? ""
+    : "bg-white border border-gray-200 rounded-lg overflow-hidden";
   return (
-    <div
-      className={`bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
-      style={style}
-    >
+    <div className={`${containerClass} ${className}`} style={style}>
       {children}
     </div>
   );

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -1,0 +1,110 @@
+import type { CSSProperties, ReactNode } from "react";
+
+type Align = "left" | "right" | "center";
+
+function alignClass(align: Align, prefix = "") {
+  if (align === "right") return `${prefix}text-right`;
+  if (align === "center") return `${prefix}text-center`;
+  return "";
+}
+
+interface DataTableProps {
+  /** grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px auto" */
+  columns: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function DataTable({ columns, children, className = "" }: DataTableProps) {
+  const style = { ["--data-cols" as string]: columns } as CSSProperties;
+  return (
+    <div
+      className={`bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+const ROW_TEMPLATE = { gridTemplateColumns: "var(--data-cols)" } as CSSProperties;
+
+export function DataHeader({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="hidden md:grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
+      style={ROW_TEMPLATE}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataHeaderCell({
+  children,
+  align = "left",
+}: {
+  children: ReactNode;
+  align?: Align;
+}) {
+  return <div className={alignClass(align)}>{children}</div>;
+}
+
+export function DataBody({ children }: { children: ReactNode }) {
+  return <div className="divide-y divide-gray-100">{children}</div>;
+}
+
+export function DataRow({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="block md:grid md:gap-3 md:items-center px-4 py-4 md:py-3 hover:bg-gray-50 space-y-3 md:space-y-0 text-sm"
+      style={ROW_TEMPLATE}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface DataCellProps {
+  /** Prefijo del valor en mobile (oculto en md+). Vacío = no se muestra. */
+  label: string;
+  children: ReactNode;
+  align?: Align;
+  className?: string;
+  /**
+   * En mobile, destaca el valor como título de la card (más grande, bold)
+   * y oculta el label. En desktop se comporta como una celda normal.
+   */
+  heading?: boolean;
+}
+
+export function DataCell({
+  label,
+  children,
+  align = "left",
+  className = "",
+  heading = false,
+}: DataCellProps) {
+  const showLabel = label && !heading;
+  const valueClass = heading
+    ? "text-base font-semibold text-gray-900 md:text-sm md:font-medium"
+    : "";
+  return (
+    <div className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
+      {showLabel && (
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-0.5 md:hidden">
+          {label}
+        </div>
+      )}
+      <div className={valueClass}>{children}</div>
+    </div>
+  );
+}
+
+export function DataEmpty({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -28,7 +28,7 @@ export function DataTable({
     ? ""
     : "bg-white border border-gray-200 rounded-lg overflow-hidden";
   return (
-    <div className={`${containerClass} ${className}`} style={style}>
+    <div role="table" className={`${containerClass} ${className}`} style={style}>
       {children}
     </div>
   );
@@ -38,11 +38,14 @@ const ROW_TEMPLATE = { gridTemplateColumns: "var(--data-cols)" } as CSSPropertie
 
 export function DataHeader({ children }: { children: ReactNode }) {
   return (
-    <div
-      className="hidden md:grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
-      style={ROW_TEMPLATE}
-    >
-      {children}
+    <div role="rowgroup" className="hidden md:block">
+      <div
+        role="row"
+        className="grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
+        style={ROW_TEMPLATE}
+      >
+        {children}
+      </div>
     </div>
   );
 }
@@ -54,16 +57,25 @@ export function DataHeaderCell({
   children: ReactNode;
   align?: Align;
 }) {
-  return <div className={alignClass(align)}>{children}</div>;
+  return (
+    <div role="columnheader" className={alignClass(align)}>
+      {children}
+    </div>
+  );
 }
 
 export function DataBody({ children }: { children: ReactNode }) {
-  return <div className="divide-y divide-gray-100">{children}</div>;
+  return (
+    <div role="rowgroup" className="divide-y divide-gray-100">
+      {children}
+    </div>
+  );
 }
 
 export function DataRow({ children }: { children: ReactNode }) {
   return (
     <div
+      role="row"
       className="block md:grid md:gap-3 md:items-center px-4 py-4 md:py-3 hover:bg-gray-50 space-y-3 md:space-y-0 text-sm"
       style={ROW_TEMPLATE}
     >
@@ -97,7 +109,7 @@ export function DataCell({
     ? "text-base font-semibold text-gray-900 md:text-sm md:font-medium"
     : "";
   return (
-    <div className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
+    <div role="cell" className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
       {showLabel && (
         <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-0.5 md:hidden">
           {label}

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -9,7 +9,11 @@ function alignClass(align: Align, prefix = "") {
 }
 
 interface DataTableProps {
-  /** grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px auto" */
+  /**
+   * grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px 180px".
+   * Evitá `auto`: el header y las filas son grids separados, y `auto` se
+   * resuelve distinto en cada uno, desalineando las columnas.
+   */
   columns: string;
   children: ReactNode;
   className?: string;
@@ -58,7 +62,7 @@ export function DataHeaderCell({
   align?: Align;
 }) {
   return (
-    <div role="columnheader" className={alignClass(align)}>
+    <div role="columnheader" className={`min-w-0 ${alignClass(align)}`}>
       {children}
     </div>
   );

--- a/src/app/dashboard/accept-button.tsx
+++ b/src/app/dashboard/accept-button.tsx
@@ -23,7 +23,7 @@ export function AcceptButton({ assignmentId }: { assignmentId: string }) {
       <button
         onClick={handleAccept}
         disabled={loading}
-        className="inline-flex items-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-1.5 rounded-lg font-medium hover:bg-pdep-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center justify-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full sm:w-auto"
       >
         {loading ? (
           <>

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -57,10 +57,10 @@ export default async function DashboardPage() {
           {assignmentsConEntrega.map(({ assignment, entrega }) => (
             <div
               key={assignment.id}
-              className="bg-white border border-gray-200 rounded-lg p-5 flex items-center justify-between"
+              className="bg-white border border-gray-200 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
             >
-              <div>
-                <div className="flex items-center gap-2 mb-1">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 mb-1">
                   <h3 className="font-semibold">{assignment.titulo}</h3>
                   <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full font-medium">
                     {assignment.paradigma}
@@ -86,13 +86,13 @@ export default async function DashboardPage() {
                 )}
               </div>
 
-              <div className="flex-shrink-0 ml-4">
+              <div className="flex-shrink-0 w-full sm:w-auto">
                 {entrega ? (
                   <a
                     href={entrega.repoUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-sm bg-green-50 text-green-700 border border-green-200 px-3 py-1.5 rounded-lg font-medium hover:bg-green-100 transition-colors"
+                    className="inline-flex items-center justify-center gap-1.5 text-sm bg-green-50 text-green-700 border border-green-200 px-3 py-2 rounded-lg font-medium hover:bg-green-100 transition-colors w-full sm:w-auto"
                   >
                     <svg
                       className="w-4 h-4"

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,15 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Nav } from "./nav";
 
 export const metadata: Metadata = {
   title: "PdeP Classroom",
   description: "Gestión de TPs - Paradigmas de Programación - UTN FRBA",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -16,7 +21,7 @@ export default function RootLayout({
     <html lang="es">
       <body className="font-sans">
         <Nav />
-        <main className="max-w-5xl mx-auto px-4 py-8">{children}</main>
+        <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8">{children}</main>
       </body>
     </html>
   );

--- a/src/app/logout-button.test.tsx
+++ b/src/app/logout-button.test.tsx
@@ -8,6 +8,12 @@ vi.mock("next-auth/react", () => ({
 
 import { UserMenu } from "./logout-button";
 
+async function openMenu(username: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: new RegExp(username) }));
+  return user;
+}
+
 describe("UserMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,28 +32,47 @@ describe("UserMenu", () => {
     expect(img).toHaveAttribute("src", "https://github.com/juangarcia.png");
   });
 
-  it("llama a signOut con callbackUrl '/' al hacer click en Salir", async () => {
-    const user = userEvent.setup();
+  it("no muestra el menú hasta hacer click en el trigger", () => {
     render(<UserMenu username="juangarcia" image="" />);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
 
-    await user.click(screen.getByRole("button", { name: "Salir" }));
+  it("abre el menú al hacer click en el trigger", async () => {
+    render(<UserMenu username="juangarcia" image="" />);
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("llama a signOut con callbackUrl '/' al hacer click en Salir", async () => {
+    render(<UserMenu username="juangarcia" image="" />);
+    const user = await openMenu("juangarcia");
+
+    await user.click(screen.getByRole("menuitem", { name: "Salir" }));
 
     expect(mockSignOut).toHaveBeenCalledOnce();
     expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
   });
 
-  it("muestra el link Editar perfil para alumnos", () => {
+  it("muestra el link Editar perfil para alumnos", async () => {
     render(<UserMenu username="juangarcia" image="" isAdmin={false} />);
-    expect(screen.getByRole("link", { name: "Editar perfil" })).toHaveAttribute("href", "/perfil");
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menuitem", { name: "Editar perfil" })).toHaveAttribute(
+      "href",
+      "/perfil"
+    );
   });
 
-  it("no muestra el link Editar perfil para admins", () => {
+  it("no muestra el link Editar perfil para admins", async () => {
     render(<UserMenu username="admin" image="" isAdmin={true} />);
-    expect(screen.queryByRole("link", { name: "Editar perfil" })).not.toBeInTheDocument();
+    await openMenu("admin");
+    expect(
+      screen.queryByRole("menuitem", { name: "Editar perfil" })
+    ).not.toBeInTheDocument();
   });
 
-  it("muestra Editar perfil por defecto (sin isAdmin)", () => {
+  it("muestra Editar perfil por defecto (sin isAdmin)", async () => {
     render(<UserMenu username="juangarcia" image="" />);
-    expect(screen.getByRole("link", { name: "Editar perfil" })).toBeInTheDocument();
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menuitem", { name: "Editar perfil" })).toBeInTheDocument();
   });
 });

--- a/src/app/logout-button.tsx
+++ b/src/app/logout-button.tsx
@@ -2,6 +2,7 @@
 
 import { signOut } from "next-auth/react";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   username: string;
@@ -10,32 +11,66 @@ interface Props {
 }
 
 export function UserMenu({ username, image, isAdmin = false }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
   return (
-    <div className="relative group">
-      <button className="flex items-center gap-2 cursor-pointer">
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        className="flex items-center gap-2 cursor-pointer"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={image} alt="" className="w-7 h-7 rounded-full" />
         <span className="font-mono text-xs text-pdep-200">{username}</span>
       </button>
 
-      <div className="absolute right-0 top-full pt-2 hidden group-hover:block">
-        <div className="bg-pdep-800 border border-pdep-700 rounded-lg shadow-lg py-1 min-w-[140px]">
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-2 bg-pdep-800 border border-pdep-700 rounded-lg shadow-lg py-1 min-w-[160px]"
+        >
           {!isAdmin && (
             <Link
               href="/perfil"
+              role="menuitem"
+              onClick={() => setOpen(false)}
               className="block px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
             >
               Editar perfil
             </Link>
           )}
           <button
+            type="button"
+            role="menuitem"
             onClick={() => signOut({ callbackUrl: "/" })}
             className="w-full text-left px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
           >
             Salir
           </button>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -78,83 +78,84 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         </svg>
       </button>
 
-      {open && (
-        <>
-          <div
-            className="md:hidden fixed inset-0 bg-black/50 z-40"
+      <div
+        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      <aside
+        id="mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menú de navegación"
+        inert={!open}
+        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+          <span className="font-bold text-white">Menú</span>
+          <button
+            type="button"
+            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+            aria-label="Cerrar menú"
             onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-
-          <aside
-            id="mobile-drawer"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Menú de navegación"
-            className="md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl"
           >
-            <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
-              <span className="font-bold text-white">Menú</span>
-              <button
-                type="button"
-                className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
-                aria-label="Cerrar menú"
-                onClick={() => setOpen(false)}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={2}
-                  stroke="currentColor"
-                  className="w-6 h-6"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M6 6l12 12M6 18L18 6"
-                  />
-                </svg>
-              </button>
-            </div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 6l12 12M6 18L18 6"
+              />
+            </svg>
+          </button>
+        </div>
 
-            <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={image} alt="" className="w-10 h-10 rounded-full" />
-              <span className="font-mono text-sm text-pdep-200 truncate">
-                {username}
-              </span>
-            </div>
+        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" className="w-10 h-10 rounded-full" />
+          <span className="font-mono text-sm text-pdep-200 truncate">
+            {username}
+          </span>
+        </div>
 
-            <nav className="flex flex-col py-2">
-              {links.map((l) => (
-                <Link
-                  key={l.href}
-                  href={l.href}
-                  className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
-                >
-                  {l.label}
-                </Link>
-              ))}
-              {!isAdmin && (
-                <Link
-                  href="/perfil"
-                  className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-                >
-                  Editar perfil
-                </Link>
-              )}
-              <button
-                type="button"
-                className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-                onClick={() => signOut({ callbackUrl: "/" })}
-              >
-                Salir
-              </button>
-            </nav>
-          </aside>
-        </>
-      )}
+        <nav className="flex flex-col py-2">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+            >
+              {l.label}
+            </Link>
+          ))}
+          {!isAdmin && (
+            <Link
+              href="/perfil"
+              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            >
+              Editar perfil
+            </Link>
+          )}
+          <button
+            type="button"
+            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            Salir
+          </button>
+        </nav>
+      </aside>
     </>
   );
 }

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -78,83 +78,83 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         </svg>
       </button>
 
-      <div
-        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
-          open ? "opacity-100" : "opacity-0 pointer-events-none"
-        }`}
-        onClick={() => setOpen(false)}
-        aria-hidden="true"
-      />
-
-      <aside
-        id="mobile-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Menú de navegación"
-        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
-          open ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
-          <span className="font-bold text-white">Menú</span>
-          <button
-            type="button"
-            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
-            aria-label="Cerrar menú"
+      {open && (
+        <>
+          <div
+            className="md:hidden fixed inset-0 bg-black/50 z-40"
             onClick={() => setOpen(false)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              className="w-6 h-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 6l12 12M6 18L18 6"
-              />
-            </svg>
-          </button>
-        </div>
+            aria-hidden="true"
+          />
 
-        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={image} alt="" className="w-10 h-10 rounded-full" />
-          <span className="font-mono text-sm text-pdep-200 truncate">
-            {username}
-          </span>
-        </div>
-
-        <nav className="flex flex-col py-2">
-          {links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
-            >
-              {l.label}
-            </Link>
-          ))}
-          {!isAdmin && (
-            <Link
-              href="/perfil"
-              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-            >
-              Editar perfil
-            </Link>
-          )}
-          <button
-            type="button"
-            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-            onClick={() => signOut({ callbackUrl: "/" })}
+          <aside
+            id="mobile-drawer"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Menú de navegación"
+            className="md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl"
           >
-            Salir
-          </button>
-        </nav>
-      </aside>
+            <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+              <span className="font-bold text-white">Menú</span>
+              <button
+                type="button"
+                className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+                aria-label="Cerrar menú"
+                onClick={() => setOpen(false)}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  className="w-6 h-6"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 6l12 12M6 18L18 6"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={image} alt="" className="w-10 h-10 rounded-full" />
+              <span className="font-mono text-sm text-pdep-200 truncate">
+                {username}
+              </span>
+            </div>
+
+            <nav className="flex flex-col py-2">
+              {links.map((l) => (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+                >
+                  {l.label}
+                </Link>
+              ))}
+              {!isAdmin && (
+                <Link
+                  href="/perfil"
+                  className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+                >
+                  Editar perfil
+                </Link>
+              )}
+              <button
+                type="button"
+                className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+                onClick={() => signOut({ callbackUrl: "/" })}
+              >
+                Salir
+              </button>
+            </nav>
+          </aside>
+        </>
+      )}
     </>
   );
 }

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
+import { UserMenu } from "./logout-button";
+
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+interface Props {
+  links: NavLink[];
+  username: string;
+  image: string;
+  isAdmin: boolean;
+}
+
+export function NavMenu({ links, username, image, isAdmin }: Props) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div className="hidden md:flex items-center gap-6 text-sm">
+        {links.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="hover:text-pdep-200 transition-colors"
+          >
+            {l.label}
+          </Link>
+        ))}
+        <UserMenu username={username} image={image} isAdmin={isAdmin} />
+      </div>
+
+      <button
+        type="button"
+        className="md:hidden p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+        aria-label="Abrir menú"
+        aria-expanded={open}
+        aria-controls="mobile-drawer"
+        onClick={() => setOpen(true)}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-6 h-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
+          />
+        </svg>
+      </button>
+
+      <div
+        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      <aside
+        id="mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menú de navegación"
+        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+          <span className="font-bold text-white">Menú</span>
+          <button
+            type="button"
+            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+            aria-label="Cerrar menú"
+            onClick={() => setOpen(false)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 6l12 12M6 18L18 6"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" className="w-10 h-10 rounded-full" />
+          <span className="font-mono text-sm text-pdep-200 truncate">
+            {username}
+          </span>
+        </div>
+
+        <nav className="flex flex-col py-2">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+            >
+              {l.label}
+            </Link>
+          ))}
+          {!isAdmin && (
+            <Link
+              href="/perfil"
+              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            >
+              Editar perfil
+            </Link>
+          )}
+          <button
+            type="button"
+            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            Salir
+          </button>
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/src/app/nav.tsx
+++ b/src/app/nav.tsx
@@ -1,9 +1,23 @@
 import { getCurrentUser } from "@/lib/session";
 import Link from "next/link";
-import { UserMenu } from "./logout-button";
+import { NavMenu, type NavLink } from "./nav-menu";
 
 export async function Nav() {
   const user = await getCurrentUser();
+
+  const links: NavLink[] = user
+    ? [
+        { href: "/dashboard", label: "Mis TPs" },
+        ...(user.isAdmin
+          ? [
+              { href: "/admin/assignments", label: "Assignments" },
+              { href: "/admin/grupos", label: "Grupos" },
+              { href: "/admin/comisiones", label: "Comisiones" },
+              { href: "/admin/alumnos", label: "Alumnos" },
+            ]
+          : []),
+      ]
+    : [];
 
   return (
     <nav className="bg-pdep-900 text-white">
@@ -12,47 +26,14 @@ export async function Nav() {
           PdeP <span className="font-light text-pdep-200">Classroom</span>
         </Link>
 
-        <div className="flex items-center gap-6 text-sm">
-          {user && (
-            <>
-              <Link
-                href="/dashboard"
-                className="hover:text-pdep-200 transition-colors"
-              >
-                Mis TPs
-              </Link>
-              {user.isAdmin && (
-                <>
-                  <Link
-                    href="/admin/assignments"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Assignments
-                  </Link>
-                  <Link
-                    href="/admin/grupos"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Grupos
-                  </Link>
-                  <Link
-                    href="/admin/comisiones"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Comisiones
-                  </Link>
-                  <Link
-                    href="/admin/alumnos"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Alumnos
-                  </Link>
-                </>
-              )}
-              <UserMenu username={user.githubUsername} image={user.image} isAdmin={user.isAdmin} />
-            </>
-          )}
-        </div>
+        {user && (
+          <NavMenu
+            links={links}
+            username={user.githubUsername}
+            image={user.image}
+            isAdmin={user.isAdmin}
+          />
+        )}
       </div>
     </nav>
   );

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"Development\" ]; then exit 1; else exit 0; fi"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"Development\" ]; then exit 1; else exit 0; fi"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"development\" ]; then exit 1; else exit 0; fi"
 }


### PR DESCRIPTION
## Summary

- Header responsive: drawer con hamburguesa en mobile; menú de usuario ahora es click-toggle (antes hover-only, inusable en touch).
- Nuevo `DataTable`/`DataRow`/`DataCell`: un único componente que se ve como tabla en `md+` y como card apilada en mobile (el label de cada celda pasa a ser un caption arriba del valor). Migradas las 4 tablas admin (assignments, alumnos, comisiones, entregas) y retocado el dashboard del alumno.
- Forms y filtros: los grids a 2-3 columnas colapsan a 1 en pantallas chicas, botones submit apilan, `legajo` con teclado numérico, chips de filtros con wrap.
- Config: CodeRabbit pasa a comentar sin bloquear y se apagan las *finishing touches* (no abre PRs paralelos). Vercel deploya solo en `master` y `Development` via `ignoreCommand`. `vercel-build` corre `db:migration:up` antes de `next build`.

## Test plan

- [ ] Verificar en DevTools ≤ 375px:
  - [ ] Header: hamburguesa abre drawer, cierra con ESC, backdrop, o al navegar
  - [ ] `/dashboard`: cards apilan, botón ocupa todo el ancho
  - [ ] `/registro` y `/perfil`: form en 1 columna, legajo con teclado numérico
  - [ ] `/admin/assignments`, `/admin/alumnos`, `/admin/comisiones`: filas se leen como cards con heading arriba
  - [ ] Detalle de un assignment con entregas: búsqueda ocupa todo el ancho, filas apilan
  - [ ] Forms admin (nuevo/editar assignment/comisión): grids colapsan
- [ ] Verificar en desktop que todo sigue viéndose igual que antes
- [ ] Chequear en Vercel que las env vars de DB estén para `Production` y `Preview`
- [ ] Confirmar en Vercel Project Settings que Production Branch = `master`
- [ ] Entrar al dashboard de CodeRabbit y apagar cualquier feature "Pro" de auto-fix que no esté controlada por yaml (si existe)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Notas de Lanzamiento

* **New Features**
  * Menú de navegación móvil con drawer y controles de usuario accesibles.
  * Nuevos componentes de tabla de datos reutilizables y mensaje de estado vacío compartido.

* **Refactor**
  * Mejorada responsividad en paneles, formularios y tarjetas; botones y enlaces adaptativos.
  * Menú de usuario ahora controlado, se cierra con Escape y al hacer clic fuera.

* **Tests**
  * Nuevas pruebas para componentes de tabla y ajustes en pruebas de listas.

* **Chores**
  * Script de despliegue actualizado para ejecutar migraciones antes del build.
  * Ajustes en la automatización de revisiones (etiquetado/assignación desactivados).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->