### PR TITLE
Fase 4: coherencia legajo↔github en Sheets y DB

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,7 @@
 language: "es"
 
 reviews:
-  request_changes_workflow: true
+  request_changes_workflow: false
   high_level_summary: true
   poem: false
   review_status: true
@@ -18,6 +18,17 @@ reviews:
     base_branches:
       - "master"
       - "Development"
+
+  finishing_touches:
+    docstrings:
+      enabled: false
+    unit_tests:
+      enabled: false
+    simplify:
+      enabled: false
+
+  auto_apply_labels: false
+  auto_assign_reviewers: false
 
 chat:
   auto_reply: true

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -17,7 +17,7 @@ reviews:
     drafts: false
     base_branches:
       - "master"
-      - "Development"
+      - "development"
 
   finishing_touches:
     docstrings:

--- a/.env.example
+++ b/.env.example
@@ -22,6 +22,24 @@ GOOGLE_SERVICE_ACCOUNT_KEY=    # base64 del JSON
 
 GOOGLE_SHEET_PLANIFICACION_ID=
 
+# ── Google Group ─────────────────────────────────────────────
+# Al hacer el alta de un alumno lo suscribimos automáticamente a este
+# grupo. Si GOOGLE_GROUP_EMAIL está vacío, la feature queda desactivada.
+#
+# Requisitos de Google Workspace:
+#   1) Habilitar Domain-Wide Delegation en la service account de
+#      GOOGLE_SERVICE_ACCOUNT_KEY y autorizar el scope
+#      https://www.googleapis.com/auth/admin.directory.group.member
+#   2) Configurar GOOGLE_WORKSPACE_ADMIN_EMAIL con un usuario admin del
+#      workspace — la service account lo impersona para poder agregar
+#      miembros al grupo.
+#
+# Si seteás GOOGLE_GROUP_EMAIL sin GOOGLE_WORKSPACE_ADMIN_EMAIL, el
+# server falla al arrancar (ver src/instrumentation.ts) — misconfig
+# intencional para no dejar que el error le aparezca al alumno.
+GOOGLE_GROUP_EMAIL=
+GOOGLE_WORKSPACE_ADMIN_EMAIL=
+
 # ── NextAuth ─────────────────────────────────────────────────
 NEXTAUTH_SECRET=               # npx auth secret
 

--- a/README.md
+++ b/README.md
@@ -526,6 +526,56 @@ El flujo de registro reemplaza la carga manual en la planilla:
 
 La planilla sigue siendo la fuente de verdad — la app solo escribe ahí.
 
+## Suscripción automática a Google Group
+
+Al completarse el alta de un alumno, lo suscribimos al Google Group de la materia — así el docente no tiene que agregarlo a mano y el alumno empieza a recibir los mails del grupo desde el primer día.
+
+El feature es **opcional**: si las variables de entorno no están configuradas, el endpoint de registro no hace nada con Groups. Si están configuradas y la suscripción falla (permisos, red, etc.), el alta del alumno **igual se completa** y se le muestra un aviso al alumno para que avise al docente. El detalle del error queda en los logs del server.
+
+Si un alumno ya era miembro del grupo (por ejemplo, se registró, lo dieron de baja y se vuelve a registrar), la API de Google responde 409 y tratamos ese caso como éxito silencioso — la UI no le muestra nada especial.
+
+### Variables de entorno
+
+| Variable | Rol |
+|---|---|
+| `GOOGLE_GROUP_EMAIL` | Email del grupo al que suscribimos a los alumnos (ej: `pdep-2026@googlegroups.com`). Dejalo vacío para desactivar el feature. |
+| `GOOGLE_WORKSPACE_ADMIN_EMAIL` | Usuario admin del Workspace que la service account impersona para poder agregar miembros al grupo. Obligatorio si `GOOGLE_GROUP_EMAIL` está seteada. |
+
+Si seteás `GOOGLE_GROUP_EMAIL` sin `GOOGLE_WORKSPACE_ADMIN_EMAIL`, el server falla al arrancar (ver [`src/instrumentation.ts`](src/instrumentation.ts)) — preferimos romper el boot antes que dejar que la misconfig le caiga al alumno en la cara.
+
+### Setup en Google (primera vez)
+
+Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` — no hace falta crear una nueva. Lo que sí hay que hacer:
+
+1. **Habilitar la Admin SDK API** en el proyecto de Google Cloud donde vive la service account.
+   - Google Cloud Console → APIs & Services → Library → "Admin SDK API" → Enable.
+
+2. **Habilitar Domain-Wide Delegation** para la service account.
+   - Google Cloud Console → IAM & Admin → Service Accounts → click en la SA → pestaña "Details" → "Show domain-wide delegation" → habilitar → copiar el **Client ID** numérico que aparece.
+
+3. **Autorizar el scope en el Workspace**.
+   - Google Admin Console (`admin.google.com`) → Security → API controls → Domain-wide Delegation → Add new.
+   - Pegar el Client ID de la service account.
+   - Scope: `https://www.googleapis.com/auth/admin.directory.group.member`.
+   - Authorize.
+
+4. **Elegir el admin a impersonar**.
+   - Cualquier usuario del Workspace con permisos para administrar el grupo (típicamente un docente con rol de admin). Ese email va en `GOOGLE_WORKSPACE_ADMIN_EMAIL`.
+
+5. **Setear las env vars** en `.env.local` (desarrollo) y en el panel de Vercel (producción):
+   ```bash
+   GOOGLE_GROUP_EMAIL=pdep-2026@googlegroups.com
+   GOOGLE_WORKSPACE_ADMIN_EMAIL=docente-admin@utn.edu.ar
+   ```
+
+6. **Reiniciar el server**. Si la config quedó bien, el boot pasa sin ruido y el próximo registro va a suscribir al alumno.
+
+### Troubleshooting
+
+- **El server no arranca con error "GOOGLE_WORKSPACE_ADMIN_EMAIL no está configurada"** → setea la variable o vacía `GOOGLE_GROUP_EMAIL` para desactivar el feature.
+- **El registro completa OK pero el alumno ve el aviso ámbar** → revisá los logs del server; probablemente falte habilitar la Admin SDK API, el scope, o el admin impersonado no tiene permiso sobre el grupo.
+- **La API devuelve 403 "Not Authorized to access this resource/api"** → típicamente el scope no está autorizado en el Workspace, o la Domain-Wide Delegation quedó con el Client ID equivocado.
+
 ## TODOs sugeridos
 
 - [x] Migrar persistencia de JSON a PostgreSQL + MikroORM
@@ -537,10 +587,11 @@ La planilla sigue siendo la fuente de verdad — la app solo escribe ahí.
 - [x] Sincronización de alumnos desde Sheets a la DB por comisión
 - [x] Configuración de columnas de la planilla por comisión
 - [x] Eliminar repos de un assignment desde el panel admin
+- [ ] Cuando elimina repos de un assignment dar la posibilidad de hacer un backup y descargar un zip
 - [ ] Notificaciones por mail cuando se publica un assignment
 - [ ] Autograding con GitHub Actions en los templates
 - [ ] Export de estado de entregas a Google Sheets (cerrar el loop con la planilla)
-- [ ] Suscribir a los alumnos al grupo de Google Groups automáticamente
+- [x] Suscribir a los alumnos al grupo de Google Groups automáticamente
 
 ## API de GitHub — Estabilidad
 

--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 ### Troubleshooting
 
 - **El server no arranca con error "GOOGLE_WORKSPACE_ADMIN_EMAIL no está configurada"** → setea la variable o vacía `GOOGLE_GROUP_EMAIL` para desactivar el feature.
-- **El registro completa OK pero el alumno ve el aviso ámbar** → revisá los logs del server; probablemente falte habilitar la Admin SDK API, el scope, o el admin impersonado no tiene permiso sobre el grupo.
+- **El registro completa OK pero el alumno ve el aviso ámbar** → buscá el log con el prefijo `Error al suscribir al Google Group` **en Vercel → Project → Deployments → el deploy activo → Runtime Logs** (en local, aparece en la terminal donde corrés `next dev`). El log incluye `github=<handle>` del alumno y el detalle devuelto por la API. Causas típicas: falta habilitar la Admin SDK API, el scope no está autorizado, o el admin impersonado no tiene permiso sobre el grupo.
 - **La API devuelve 403 "Not Authorized to access this resource/api"** → típicamente el scope no está autorizado en el Workspace, o la Domain-Wide Delegation quedó con el Client ID equivocado.
 
 ## TODOs sugeridos

--- a/README.md
+++ b/README.md
@@ -593,6 +593,15 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 - [ ] Export de estado de entregas a Google Sheets (cerrar el loop con la planilla)
 - [x] Suscribir a los alumnos al grupo de Google Groups automáticamente
 
+## Refactor en curso
+
+- [x] **Fase 4** ([#11](https://github.com/Juancete/Pdep-Classroom/issues/11)) — `upsertarAlumnoEnSheets` no debe quejarse al editar + coherencia legajo↔github
+- [ ] **Fase 2** ([#13](https://github.com/Juancete/Pdep-Classroom/issues/13)) — Validación de `githubUsername` en registro/perfil con error inline en el form
+- [ ] **Fase 1** ([#9](https://github.com/Juancete/Pdep-Classroom/issues/9)) — Reificar polimorfismo de `Assignment` (individual/grupal) para eliminar los IFs
+- [ ] **Fase 3** ([#10](https://github.com/Juancete/Pdep-Classroom/issues/10)) — Unificar registro y perfil en un servicio común
+- [ ] **Fase 5** ([#14](https://github.com/Juancete/Pdep-Classroom/issues/14)) — Upsert de grupos desde planilla, modelado genérico (no atado a paradigma)
+- [ ] **Fase 6** ([#12](https://github.com/Juancete/Pdep-Classroom/issues/12)) — Renombrar/comentar `DEFAULT_COLUMN_CONFIG` como sugerencia de UX
+
 ## API de GitHub — Estabilidad
 
 La REST API v3 de GitHub tiene política de versionado conservadora. Todos los endpoints que usa esta app existen desde 2019+ y no van a cambiar:

--- a/migrations/.snapshot-neondb.json
+++ b/migrations/.snapshot-neondb.json
@@ -117,6 +117,22 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
       "name": "alumno",
@@ -160,6 +176,19 @@
             "comision_id"
           ],
           "constraintName": "alumno_comision_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
           "localTableName": "public.alumno",
           "referencedTableName": "public.comision",
           "referencedColumnNames": [
@@ -555,7 +584,7 @@
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,93 +22,13 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
+        "anio": {
+          "name": "anio",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -116,61 +36,74 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "integer"
+        },
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "json"
         }
       },
-      "name": "alumno",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_github_username_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_legajo_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
+          "keyName": "comision_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "alumno_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "columnNames": [
-            "comision_id"
-          ],
-          "constraintName": "alumno_comision_id_foreign",
-          "localTableName": "public.alumno",
-          "referencedTableName": "public.comision",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -311,7 +244,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz(6)",
+          "type": "timestamptz",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -343,15 +276,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int4",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": 32,
-          "scale": 0,
+          "precision": null,
+          "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -363,43 +296,209 @@
       "indexes": [
         {
           "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "assignment_pkey",
-          "unique": true,
-          "primary": true
-        },
-        {
-          "columnNames": [
             "tipo"
           ],
           "composite": false,
-          "constraint": false,
           "keyName": "assignment_tipo_index",
-          "unique": false,
-          "primary": false
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "assignment_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "constraintName": "assignment_comision_id_foreign",
           "columnNames": [
             "comision_id"
           ],
-          "constraintName": "assignment_comision_id_foreign",
           "localTableName": "public.assignment",
-          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        }
+      },
+      "name": "alumno",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "keyName": "alumno_legajo_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "keyName": "alumno_github_username_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "keyName": "alumno_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "constraintName": "alumno_comision_id_foreign",
+          "columnNames": [
+            "comision_id"
+          ],
+          "localTableName": "public.alumno",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -440,48 +539,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "assignment_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
-          "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "assignment_alumnos_assignment_id_foreign": {
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "columnNames": [
             "assignment_id"
           ],
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.assignment",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "assignment_alumnos_alumno_id_foreign": {
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.assignment_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -501,24 +599,8 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -533,9 +615,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "bool",
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -544,18 +626,22 @@
           "length": null,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,
@@ -563,27 +649,72 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
-      "name": "comision",
+      "name": "grupo",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "comision_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "constraintName": "grupo_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -610,6 +741,22 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -683,41 +830,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz(6)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
         "repo_deleted": {
           "name": "repo_deleted",
-          "type": "bool",
+          "type": "boolean",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -730,202 +845,81 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "boolean"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "entrega_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
+        "entrega_assignment_id_foreign": {
+          "constraintName": "entrega_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
         "entrega_alumno_id_foreign": {
+          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
-          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        },
-        "entrega_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "entrega_assignment_id_foreign",
-          "localTableName": "public.entrega",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
+          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "creado_por": {
-          "name": "creado_por",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        }
-      },
-      "name": "grupo",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "grupo_pkey",
-          "unique": true,
-          "primary": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "grupo_assignment_id_foreign",
-          "localTableName": "public.grupo",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -966,48 +960,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "grupo_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
-          "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "grupo_alumnos_grupo_id_foreign": {
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.grupo",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "grupo_alumnos_alumno_id_foreign": {
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.grupo_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     }
   ],
   "nativeEnums": {}

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,24 +22,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int",
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
+          "unique": true,
+          "length": 255,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "integer"
+          "mappedType": "string"
         },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -54,29 +54,61 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "boolean",
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": null,
+          "length": 255,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "boolean"
+          "mappedType": "string"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -84,26 +116,90 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
-      "name": "comision",
+      "name": "alumno",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "comision_pkey",
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_github_username_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_legajo_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "alumno_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
+          "constraintName": "alumno_comision_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -244,7 +340,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -276,15 +372,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -296,209 +392,43 @@
       "indexes": [
         {
           "columnNames": [
-            "tipo"
-          ],
-          "composite": false,
-          "keyName": "assignment_tipo_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "assignment_pkey",
-          "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "tipo"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "assignment_tipo_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
           "constraintName": "assignment_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
           "localTableName": "public.assignment",
+          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        }
-      },
-      "name": "alumno",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "keyName": "alumno_legajo_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "keyName": "alumno_github_username_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "alumno_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "constraintName": "alumno_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -539,47 +469,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_assignment_id_foreign": {
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.assignment_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "assignment_alumnos_alumno_id_foreign": {
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "assignment_alumnos_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
+          "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -599,60 +530,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
+        "anio": {
+          "name": "anio",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "integer"
         },
-        "creado_por": {
-          "name": "creado_por",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -667,9 +562,25 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
+        "activa": {
+          "name": "activa",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -681,40 +592,27 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "json"
         }
       },
-      "name": "grupo",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "comision_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "constraintName": "grupo_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -741,22 +639,6 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -830,25 +712,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "repo_deleted": {
-          "name": "repo_deleted",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "false",
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
-        },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -861,65 +727,234 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "repo_deleted": {
+          "name": "repo_deleted",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "entrega_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "entrega_assignment_id_foreign": {
-          "constraintName": "entrega_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.entrega",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "entrega_alumno_id_foreign": {
-          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "entrega_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "entrega_assignment_id_foreign",
+          "localTableName": "public.entrega",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
-          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
+          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
+        },
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        }
+      },
+      "name": "grupo",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "grupo_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "grupo_assignment_id_foreign",
+          "localTableName": "public.grupo",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -960,47 +995,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "grupo_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_grupo_id_foreign": {
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
-          "columnNames": [
-            "grupo_id"
-          ],
-          "localTableName": "public.grupo_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "grupo_alumnos_alumno_id_foreign": {
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "grupo_alumnos_grupo_id_foreign": {
+          "columnNames": [
+            "grupo_id"
+          ],
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
+          "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260415133558_make_column_config_not_null.ts
+++ b/migrations/Migration20260415133558_make_column_config_not_null.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260415133558_make_column_config_not_null extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "comision" alter column "column_config" type jsonb using ("column_config"::jsonb);`);
+    this.addSql(`alter table "comision" alter column "column_config" set not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "comision" alter column "column_config" type jsonb using ("column_config"::jsonb);`);
+    this.addSql(`alter table "comision" alter column "column_config" drop not null;`);
+  }
+
+}

--- a/migrations/Migration20260415133558_make_column_config_not_null.ts
+++ b/migrations/Migration20260415133558_make_column_config_not_null.ts
@@ -4,6 +4,7 @@ export class Migration20260415133558_make_column_config_not_null extends Migrati
 
   override async up(): Promise<void> {
     this.addSql(`alter table "comision" alter column "column_config" type jsonb using ("column_config"::jsonb);`);
+    this.addSql(`update "comision" set "column_config" = '{"sheetName":"Alumnos","headerRows":1,"legajo":0,"apellido":1,"nombre":2,"githubUsername":3,"email":4}'::jsonb where "column_config" is null;`);
     this.addSql(`alter table "comision" alter column "column_config" set not null;`);
   }
 

--- a/migrations/Migration20260417230133_add_registro_confirmado_en_to_alumno.ts
+++ b/migrations/Migration20260417230133_add_registro_confirmado_en_to_alumno.ts
@@ -1,0 +1,16 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260417230133_add_registro_confirmado_en_to_alumno extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "alumno" add column "registro_confirmado_en_id" uuid null;`);
+    this.addSql(`alter table "alumno" add constraint "alumno_registro_confirmado_en_id_foreign" foreign key ("registro_confirmado_en_id") references "comision" ("id") on update cascade on delete set null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" drop constraint "alumno_registro_confirmado_en_id_foreign";`);
+
+    this.addSql(`alter table "alumno" drop column "registro_confirmado_en_id";`);
+  }
+
+}

--- a/next.config.js
+++ b/next.config.js
@@ -6,6 +6,7 @@ const nextConfig = {
       "@mikro-orm/postgresql",
       "@mikro-orm/migrations",
     ],
+    instrumentationHook: true,
   },
 
   images: {

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
+    "vercel-build": "npm run db:migration:up && next build",
     "start": "next start",
     "lint": "next lint",
     "test": "vitest",

--- a/src/app/admin/alumnos/page.test.tsx
+++ b/src/app/admin/alumnos/page.test.tsx
@@ -69,12 +69,12 @@ describe("Admin Alumnos page", () => {
   });
 
   describe("con alumnos", () => {
-    it("muestra la tabla cuando hay alumnos", async () => {
+    it("no muestra el estado vacío cuando hay alumnos", async () => {
       mockGetAlumnos.mockResolvedValue([makeAlumno()]);
 
       const element = await AdminAlumnosPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay alumnos ingresados");
     });
 
     it("muestra la cantidad de alumnos en el subtítulo", async () => {

--- a/src/app/admin/alumnos/page.tsx
+++ b/src/app/admin/alumnos/page.tsx
@@ -2,6 +2,15 @@ import { requireAdmin } from "@/lib/session";
 import { getAlumnos } from "@/lib/sheets";
 import { getComisionActiva } from "@/lib/repositories";
 import Link from "next/link";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminAlumnosPage() {
   await requireAdmin();
@@ -33,55 +42,43 @@ export default async function AdminAlumnosPage() {
       </p>
 
       {alumnos.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay alumnos ingresados.
-        </div>
+        <DataEmpty>No hay alumnos ingresados.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Legajo
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Nombre
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  GitHub
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Email
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {alumnos.map((a) => (
-                <tr key={a.legajo} className="hover:bg-gray-50">
-                  <td className="px-4 py-2.5 font-mono text-xs">
-                    {a.legajo}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    {a.apellido}, {a.nombre}
-                  </td>
-                  <td className="px-4 py-2.5">
-                    <a
-                      href={`https://github.com/${a.githubUsername}`}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="font-mono text-xs text-pdep-600 hover:underline"
-                    >
-                      {a.githubUsername}
-                    </a>
-                  </td>
-                  <td className="px-4 py-2.5 text-gray-500 text-xs">
+        <DataTable columns="1.5fr 100px 1.2fr 2fr">
+          <DataHeader>
+            <DataHeaderCell>Nombre</DataHeaderCell>
+            <DataHeaderCell>Legajo</DataHeaderCell>
+            <DataHeaderCell>GitHub</DataHeaderCell>
+            <DataHeaderCell>Email</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {alumnos.map((a) => (
+              <DataRow key={a.legajo}>
+                <DataCell label="Nombre" heading>
+                  {a.apellido}, {a.nombre}
+                </DataCell>
+                <DataCell label="Legajo">
+                  <span className="font-mono text-xs">{a.legajo}</span>
+                </DataCell>
+                <DataCell label="GitHub">
+                  <a
+                    href={`https://github.com/${a.githubUsername}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-mono text-xs text-pdep-600 hover:underline break-all"
+                  >
+                    {a.githubUsername}
+                  </a>
+                </DataCell>
+                <DataCell label="Email">
+                  <span className="text-gray-500 text-xs break-all">
                     {a.email}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  </span>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/assignments/[id]/entregas-table.test.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.test.tsx
@@ -80,14 +80,14 @@ describe("EntregasTable", () => {
     expect(html).toContain("No hay entregas todavía");
   });
 
-  it("no muestra la tabla cuando no hay entregas", () => {
+  it("no muestra filas cuando no hay entregas", () => {
     const html = renderToStaticMarkup(<EntregasTable entregas={[]} />);
-    expect(html).not.toContain("<table");
+    expect(html).not.toContain("data-cols");
   });
 
-  it("muestra la tabla cuando hay entregas", () => {
+  it("muestra filas cuando hay entregas", () => {
     const html = renderToStaticMarkup(<EntregasTable entregas={[makeRow()]} />);
-    expect(html).toContain("<table");
+    expect(html).toContain("García, Juan");
   });
 
   it("muestra las cabeceras de la tabla", () => {

--- a/src/app/admin/assignments/[id]/entregas-table.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.tsx
@@ -1,6 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+} from "@/app/components/DataTable";
 
 export type EntregaRow = {
   id: string;
@@ -28,7 +36,7 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
 
   return (
     <div>
-      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex items-center justify-between gap-4">
+      <div className="px-4 py-3 border-b border-gray-200 bg-gray-50 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         <h2 className="font-medium text-gray-700 shrink-0">
           Entregas aceptadas
         </h2>
@@ -38,7 +46,7 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
           value={q}
           onChange={(e) => setQ(e.target.value)}
           placeholder="Buscar por usuario o repo..."
-          className="border border-gray-300 rounded-md px-3 py-1 text-sm w-64 focus:outline-none focus:ring-2 focus:ring-pdep-400"
+          className="border border-gray-300 rounded-md px-3 py-1 text-sm w-full sm:w-64 focus:outline-none focus:ring-2 focus:ring-pdep-400"
         />
       </div>
 
@@ -49,35 +57,29 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
             : "No hay entregas todavía."}
         </div>
       ) : (
-        <table className="w-full text-sm">
-          <thead className="bg-gray-50 border-b border-gray-200">
-            <tr>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Usuario(s)
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Nombre completo
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Repositorio
-              </th>
-              <th className="text-left px-4 py-3 font-medium text-gray-600">
-                Fecha
-              </th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
+        <DataTable columns="1.5fr 1.2fr 1.5fr 120px" bare>
+          <DataHeader>
+            <DataHeaderCell>Nombre completo</DataHeaderCell>
+            <DataHeaderCell>Usuario(s)</DataHeaderCell>
+            <DataHeaderCell>Repositorio</DataHeaderCell>
+            <DataHeaderCell>Fecha</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
             {filtradas.map((e) => (
-              <tr key={e.id} className="hover:bg-gray-50">
-                <td className="px-4 py-3 font-mono text-xs">
-                  {e.githubUsernames.join(", ")}
-                </td>
-                <td className="px-4 py-3 text-xs text-gray-700">
+              <DataRow key={e.id}>
+                <DataCell label="Nombre completo" heading>
                   {e.nombreCompleto}
-                </td>
-                <td className="px-4 py-3">
+                </DataCell>
+                <DataCell label="Usuario(s)">
+                  <span className="font-mono text-xs break-all">
+                    {e.githubUsernames.join(", ")}
+                  </span>
+                </DataCell>
+                <DataCell label="Repositorio">
                   {e.repoDeleted ? (
-                    <span className="text-red-400 text-xs">Repositorio borrado</span>
+                    <span className="text-red-400 text-xs">
+                      Repositorio borrado
+                    </span>
                   ) : e.repoUrl ? (
                     <a
                       href={e.repoUrl}
@@ -103,14 +105,14 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
                   ) : (
                     <span className="text-gray-400 text-xs">Sin repo</span>
                   )}
-                </td>
-                <td className="px-4 py-3 text-gray-500 text-xs">
-                  {e.createdAt}
-                </td>
-              </tr>
+                </DataCell>
+                <DataCell label="Fecha">
+                  <span className="text-gray-500 text-xs">{e.createdAt}</span>
+                </DataCell>
+              </DataRow>
             ))}
-          </tbody>
-        </table>
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -222,7 +222,7 @@ export function AssignmentForm({
       </div>
 
       {/* Paradigma y Tipo en fila */}
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-1">
             Paradigma *
@@ -304,11 +304,11 @@ export function AssignmentForm({
       </div>
 
       {/* Submit */}
-      <div className="flex gap-3 pt-2">
+      <div className="flex flex-col sm:flex-row gap-3 pt-2">
         <SubmitButton label={submitLabel} />
         <a
           href="/admin/assignments"
-          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors"
+          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors text-center"
         >
           Cancelar
         </a>

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -90,20 +90,20 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("No hay assignments todavía");
     });
 
-    it("no muestra la tabla cuando no hay assignments", async () => {
+    it("no muestra filas cuando no hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([]);
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
-      expect(html).not.toContain("<table");
+      expect(html).not.toContain("Kata Funcional");
     });
   });
 
   describe("con assignments", () => {
-    it("muestra la tabla cuando hay assignments", async () => {
+    it("no muestra el estado vacío cuando hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay assignments todavía");
     });
 
     it("muestra el título del assignment", async () => {

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -46,13 +46,13 @@ export default async function AdminAssignmentsPage() {
       {sorted.length === 0 ? (
         <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px auto">
+        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px 180px">
           <DataHeader>
             <DataHeaderCell>Título</DataHeaderCell>
             <DataHeaderCell>Paradigma</DataHeaderCell>
             <DataHeaderCell>Tipo</DataHeaderCell>
             <DataHeaderCell>Template</DataHeaderCell>
-            <DataHeaderCell align="right">Entregas</DataHeaderCell>
+            <DataHeaderCell>Entregas</DataHeaderCell>
             <DataHeaderCell>Deadline</DataHeaderCell>
             <DataHeaderCell>Acciones</DataHeaderCell>
           </DataHeader>
@@ -75,7 +75,7 @@ export default async function AdminAssignmentsPage() {
                     {a.templateRepo}
                   </span>
                 </DataCell>
-                <DataCell label="Entregas" align="right">
+                <DataCell label="Entregas">
                   <span className="font-mono">
                     {entregasCounts.get(a.id) ?? 0}
                   </span>

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -1,22 +1,39 @@
 import { requireAdmin } from "@/lib/session";
-import { getAssignments, getEntregaCountsByAssignment, getActiveRepoCountsByAssignment } from "@/lib/repositories";
+import {
+  getAssignments,
+  getEntregaCountsByAssignment,
+  getActiveRepoCountsByAssignment,
+} from "@/lib/repositories";
 import Link from "next/link";
 import { DeleteAssignmentButton } from "./delete-button";
 import { DeleteReposButton } from "./delete-repos-button";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminAssignmentsPage() {
   await requireAdmin();
 
-  // Una query para assignments, una para conteos — en paralelo
   const [assignments, entregasCounts, activeRepoCounts] = await Promise.all([
     getAssignments(),
     getEntregaCountsByAssignment(),
     getActiveRepoCountsByAssignment(),
   ]);
 
+  const sorted = [...assignments].sort(
+    (a, b) =>
+      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+  );
+
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <h1 className="text-2xl font-bold">Assignments</h1>
         <Link
           href="/admin/assignments/new"
@@ -26,91 +43,75 @@ export default async function AdminAssignmentsPage() {
         </Link>
       </div>
 
-      {assignments.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay assignments todavía. Creá el primero.
-        </div>
+      {sorted.length === 0 ? (
+        <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Título
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Paradigma
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Tipo
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Template
-                </th>
-                <th className="text-right px-4 py-3 font-medium text-gray-600">
-                  Entregas
-                </th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">
-                  Deadline
-                </th>
-                <th className="px-4 py-3 font-medium text-gray-600">
-                  Acciones
-                </th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {assignments
-                .sort(
-                  (a, b) =>
-                    new Date(b.createdAt).getTime() -
-                    new Date(a.createdAt).getTime()
-                )
-                .map((a) => (
-                  <tr key={a.id} className="hover:bg-gray-50">
-                    <td className="px-4 py-3 font-medium">{a.titulo}</td>
-                    <td className="px-4 py-3">
-                      <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">
-                        {a.paradigma}
-                      </span>
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">{a.tipo}</td>
-                    <td className="px-4 py-3 font-mono text-xs text-gray-500">
-                      {a.templateRepo}
-                    </td>
-                    <td className="px-4 py-3 text-right font-mono">
-                      {entregasCounts.get(a.id) ?? 0}
-                    </td>
-                    <td className="px-4 py-3 text-gray-500">
-                      {a.deadline
-                        ? new Date(a.deadline).toLocaleDateString("es-AR")
-                        : "—"}
-                    </td>
-                    <td className="px-4 py-3">
-                      <div className="flex items-center gap-3">
-                        <Link
-                          href={`/admin/assignments/${a.id}`}
-                          className="text-gray-500 hover:text-gray-700 text-xs font-medium"
-                        >
-                          Ver
-                        </Link>
-                        <Link
-                          href={`/admin/assignments/${a.id}/edit`}
-                          className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
-                        >
-                          Editar
-                        </Link>
-                        <DeleteReposButton
-                          assignmentId={a.id}
-                          activeRepoCount={activeRepoCounts.get(a.id) ?? 0}
-                        />
-                        <DeleteAssignmentButton id={a.id} titulo={a.titulo} />
-                      </div>
-                    </td>
-                  </tr>
-                ))}
-            </tbody>
-          </table>
-        </div>
+        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px auto">
+          <DataHeader>
+            <DataHeaderCell>Título</DataHeaderCell>
+            <DataHeaderCell>Paradigma</DataHeaderCell>
+            <DataHeaderCell>Tipo</DataHeaderCell>
+            <DataHeaderCell>Template</DataHeaderCell>
+            <DataHeaderCell align="right">Entregas</DataHeaderCell>
+            <DataHeaderCell>Deadline</DataHeaderCell>
+            <DataHeaderCell>Acciones</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {sorted.map((a) => (
+              <DataRow key={a.id}>
+                <DataCell label="Título" heading>
+                  {a.titulo}
+                </DataCell>
+                <DataCell label="Paradigma">
+                  <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">
+                    {a.paradigma}
+                  </span>
+                </DataCell>
+                <DataCell label="Tipo">
+                  <span className="text-gray-500">{a.tipo}</span>
+                </DataCell>
+                <DataCell label="Template">
+                  <span className="font-mono text-xs text-gray-500 break-all">
+                    {a.templateRepo}
+                  </span>
+                </DataCell>
+                <DataCell label="Entregas" align="right">
+                  <span className="font-mono">
+                    {entregasCounts.get(a.id) ?? 0}
+                  </span>
+                </DataCell>
+                <DataCell label="Deadline">
+                  <span className="text-gray-500">
+                    {a.deadline
+                      ? new Date(a.deadline).toLocaleDateString("es-AR")
+                      : "—"}
+                  </span>
+                </DataCell>
+                <DataCell label="">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <Link
+                      href={`/admin/assignments/${a.id}`}
+                      className="text-gray-500 hover:text-gray-700 text-xs font-medium"
+                    >
+                      Ver
+                    </Link>
+                    <Link
+                      href={`/admin/assignments/${a.id}/edit`}
+                      className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
+                    >
+                      Editar
+                    </Link>
+                    <DeleteReposButton
+                      assignmentId={a.id}
+                      activeRepoCount={activeRepoCounts.get(a.id) ?? 0}
+                    />
+                    <DeleteAssignmentButton id={a.id} titulo={a.titulo} />
+                  </div>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -14,11 +14,27 @@ vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
 }));
 
+const { FakeLegajoConflictError } = vi.hoisted(() => {
+  class FakeLegajoConflictError extends Error {
+    constructor(
+      public readonly legajo: string,
+      public readonly otroGithubUsername: string
+    ) {
+      super(
+        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
+      );
+      this.name = "LegajoConflictError";
+    }
+  }
+  return { FakeLegajoConflictError };
+});
+
 vi.mock("@/lib/repositories", () => ({
   createComision: (...args: unknown[]) => mockCreateComision(...args),
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
   upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
+  LegajoConflictError: FakeLegajoConflictError,
 }));
 
 vi.mock("@/lib/sheets", () => ({
@@ -234,5 +250,19 @@ describe("sincronizarAlumnos", () => {
     mockGetAlumnos.mockResolvedValue([]);
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
     expect(result).toEqual({ status: "ok", sincronizados: 0 });
+  });
+
+  it("retorna error controlado si upsertAlumnos lanza LegajoConflictError", async () => {
+    mockGetAlumnos.mockResolvedValue([
+      { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" },
+    ]);
+    mockUpsertAlumnos.mockRejectedValue(new FakeLegajoConflictError("111", "otra-persona"));
+
+    const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
+
+    expect(result).toEqual({
+      status: "error",
+      message: "El legajo 111 ya está registrado con el usuario @otra-persona. Verificá que sea el tuyo.",
+    });
   });
 });

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -6,7 +6,7 @@ const mockRequireAdmin = vi.fn();
 const mockCreateComision = vi.fn();
 const mockUpdateComision = vi.fn();
 const mockGetComision = vi.fn();
-const mockUpsertAlumno = vi.fn();
+const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnos = vi.fn();
 
@@ -18,7 +18,7 @@ vi.mock("@/lib/repositories", () => ({
   createComision: (...args: unknown[]) => mockCreateComision(...args),
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
-  upsertAlumno: (...args: unknown[]) => mockUpsertAlumno(...args),
+  upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
 }));
 
 vi.mock("@/lib/sheets", () => ({
@@ -182,7 +182,7 @@ describe("sincronizarAlumnos", () => {
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetComision.mockResolvedValue(comisionMock);
     mockGetAlumnos.mockResolvedValue([]);
-    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockUpsertAlumnos.mockResolvedValue(0);
   });
 
   it("siempre llama a requireAdmin", async () => {
@@ -212,20 +212,22 @@ describe("sincronizarAlumnos", () => {
       { legajo: "222", nombre: "Beto", apellido: "Ruiz", githubUsername: "beto", email: "b@b.com" },
     ];
     mockGetAlumnos.mockResolvedValue(alumnos);
+    mockUpsertAlumnos.mockResolvedValue(2);
 
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
 
     expect(result).toEqual({ status: "ok", sincronizados: 2 });
-    expect(mockUpsertAlumno).toHaveBeenCalledTimes(2);
+    expect(mockUpsertAlumnos).toHaveBeenCalledOnce();
   });
 
-  it("llama a upsertAlumno con la comisión incluida", async () => {
+  it("llama a upsertAlumnos con la comisión incluida en cada alumno", async () => {
     const alumno = { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" };
     mockGetAlumnos.mockResolvedValue([alumno]);
+    mockUpsertAlumnos.mockResolvedValue(1);
 
     await sincronizarAlumnos({ status: "idle" }, makeSync());
 
-    expect(mockUpsertAlumno).toHaveBeenCalledWith({ ...alumno, comision: comisionMock });
+    expect(mockUpsertAlumnos).toHaveBeenCalledWith([{ ...alumno, comision: comisionMock }]);
   });
 
   it("retorna 0 sincronizados si la planilla está vacía", async () => {

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { requireAdmin } from "@/lib/session";
-import { createComision, updateComision, getComision, upsertAlumno } from "@/lib/repositories";
+import { createComision, updateComision, getComision, upsertAlumnos } from "@/lib/repositories";
 import { getAlumnos } from "@/lib/sheets";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
@@ -121,11 +121,7 @@ export async function sincronizarAlumnos(
     return { status: "error", message: `No se pudo leer la planilla: ${(e as Error).message}` };
   }
 
-  let sincronizados = 0;
-  for (const alumno of alumnos) {
-    await upsertAlumno({ ...alumno, comision });
-    sincronizados++;
-  }
+  const sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
 
   revalidatePath("/admin/comisiones");
   return { status: "ok", sincronizados };

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -1,7 +1,7 @@
 "use server";
 
 import { requireAdmin } from "@/lib/session";
-import { createComision, updateComision, getComision, upsertAlumnos } from "@/lib/repositories";
+import { createComision, updateComision, getComision, upsertAlumnos, LegajoConflictError } from "@/lib/repositories";
 import { getAlumnos } from "@/lib/sheets";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
@@ -121,7 +121,15 @@ export async function sincronizarAlumnos(
     return { status: "error", message: `No se pudo leer la planilla: ${(e as Error).message}` };
   }
 
-  const sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
+  let sincronizados: number;
+  try {
+    sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
+  } catch (e) {
+    if (e instanceof LegajoConflictError) {
+      return { status: "error", message: e.message };
+    }
+    throw e;
+  }
 
   revalidatePath("/admin/comisiones");
   return { status: "ok", sincronizados };

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -125,7 +125,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         </p>
 
         {/* Nombre de la hoja y filas de encabezado */}
-        <div className="grid grid-cols-2 gap-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">
               Nombre de la hoja
@@ -155,7 +155,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         </div>
 
         {/* Selectores de columna */}
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
           <ColSelect name="col_legajo" label="Legajo" defaultValue={cfg.legajo} error={errors.col_legajo?.[0]} />
           <ColSelect name="col_apellido" label="Apellido" defaultValue={cfg.apellido} error={errors.col_apellido?.[0]} />
           <ColSelect name="col_nombre" label="Nombre" defaultValue={cfg.nombre} error={errors.col_nombre?.[0]} />
@@ -165,11 +165,11 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
       </fieldset>
 
       {/* Submit */}
-      <div className="flex gap-3 pt-2">
+      <div className="flex flex-col sm:flex-row gap-3 pt-2">
         <SubmitButton label={submitLabel} />
         <a
           href="/admin/comisiones"
-          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors"
+          className="px-5 py-2 rounded-lg text-sm font-medium text-gray-600 border border-gray-300 hover:bg-gray-50 transition-colors text-center"
         >
           Cancelar
         </a>

--- a/src/app/admin/comisiones/page.test.tsx
+++ b/src/app/admin/comisiones/page.test.tsx
@@ -64,20 +64,20 @@ describe("Admin Comisiones page", () => {
       expect(html).toContain("No hay comisiones todavía");
     });
 
-    it("no muestra la tabla cuando no hay comisiones", async () => {
+    it("no muestra ninguna fila cuando no hay comisiones", async () => {
       mockGetComisiones.mockResolvedValue([]);
       const element = await AdminComisionesPage();
       const html = renderToStaticMarkup(element);
-      expect(html).not.toContain("<table");
+      expect(html).not.toContain("Editar");
     });
   });
 
   describe("con comisiones", () => {
-    it("muestra la tabla cuando hay comisiones", async () => {
+    it("no muestra el estado vacío cuando hay comisiones", async () => {
       mockGetComisiones.mockResolvedValue([makeComision()]);
       const element = await AdminComisionesPage();
       const html = renderToStaticMarkup(element);
-      expect(html).toContain("<table");
+      expect(html).not.toContain("No hay comisiones todavía");
     });
 
     it("muestra el año de la comisión", async () => {

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -1,6 +1,15 @@
 import { requireAdmin } from "@/lib/session";
 import { getComisiones } from "@/lib/repositories";
 import { DeleteComisionButton } from "./delete-button";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "@/app/components/DataTable";
 
 export default async function AdminComisionesPage() {
   await requireAdmin();
@@ -8,7 +17,7 @@ export default async function AdminComisionesPage() {
 
   return (
     <div>
-      <div className="flex items-center justify-between mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-3 mb-6">
         <h1 className="text-2xl font-bold">Comisiones</h1>
         <a
           href="/admin/comisiones/new"
@@ -19,53 +28,51 @@ export default async function AdminComisionesPage() {
       </div>
 
       {comisiones.length === 0 ? (
-        <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
-          No hay comisiones todavía.
-        </div>
+        <DataEmpty>No hay comisiones todavía.</DataEmpty>
       ) : (
-        <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
-          <table className="w-full text-sm">
-            <thead className="bg-gray-50 border-b border-gray-200">
-              <tr>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Año</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Planilla</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Estado</th>
-                <th className="text-left px-4 py-3 font-medium text-gray-600">Acciones</th>
-              </tr>
-            </thead>
-            <tbody className="divide-y divide-gray-100">
-              {comisiones.map((c) => (
-                <tr key={c.id} className="hover:bg-gray-50">
-                  <td className="px-4 py-3 font-semibold">{c.anio}</td>
-                  <td className="px-4 py-3 font-mono text-xs text-gray-500 max-w-xs truncate">
+        <DataTable columns="100px 2fr 140px auto">
+          <DataHeader>
+            <DataHeaderCell>Año</DataHeaderCell>
+            <DataHeaderCell>Planilla</DataHeaderCell>
+            <DataHeaderCell>Estado</DataHeaderCell>
+            <DataHeaderCell>Acciones</DataHeaderCell>
+          </DataHeader>
+          <DataBody>
+            {comisiones.map((c) => (
+              <DataRow key={c.id}>
+                <DataCell label="Año" heading>
+                  {c.anio}
+                </DataCell>
+                <DataCell label="Planilla">
+                  <span className="font-mono text-xs text-gray-500 break-all md:truncate md:block">
                     {c.spreadsheetId}
-                  </td>
-                  <td className="px-4 py-3">
-                    {c.activa ? (
-                      <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
-                        <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
-                        Activa
-                      </span>
-                    ) : (
-                      <span className="text-xs text-gray-400">Inactiva</span>
-                    )}
-                  </td>
-                  <td className="px-4 py-3">
-                    <div className="flex items-center gap-3">
-                      <a
-                        href={`/admin/comisiones/${c.id}/edit`}
-                        className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
-                      >
-                        Editar
-                      </a>
-                      <DeleteComisionButton id={c.id} anio={c.anio} />
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
+                  </span>
+                </DataCell>
+                <DataCell label="Estado">
+                  {c.activa ? (
+                    <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
+                      <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
+                      Activa
+                    </span>
+                  ) : (
+                    <span className="text-xs text-gray-400">Inactiva</span>
+                  )}
+                </DataCell>
+                <DataCell label="">
+                  <div className="flex items-center gap-3 flex-wrap">
+                    <a
+                      href={`/admin/comisiones/${c.id}/edit`}
+                      className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
+                    >
+                      Editar
+                    </a>
+                    <DeleteComisionButton id={c.id} anio={c.anio} />
+                  </div>
+                </DataCell>
+              </DataRow>
+            ))}
+          </DataBody>
+        </DataTable>
       )}
     </div>
   );

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -58,7 +58,7 @@ export default async function AdminComisionesPage() {
                     <span className="text-xs text-gray-400">Inactiva</span>
                   )}
                 </DataCell>
-                <DataCell label="">
+                <DataCell label="Acciones">
                   <div className="flex items-center gap-3 flex-wrap">
                     <a
                       href={`/admin/comisiones/${c.id}/edit`}

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -30,7 +30,7 @@ export default async function AdminComisionesPage() {
       {comisiones.length === 0 ? (
         <DataEmpty>No hay comisiones todavía.</DataEmpty>
       ) : (
-        <DataTable columns="100px 2fr 140px auto">
+        <DataTable columns="100px 2fr 140px 160px">
           <DataHeader>
             <DataHeaderCell>Año</DataHeaderCell>
             <DataHeaderCell>Planilla</DataHeaderCell>

--- a/src/app/admin/grupos/page.tsx
+++ b/src/app/admin/grupos/page.tsx
@@ -27,7 +27,7 @@ export default async function AdminGruposPage({
       </p>
 
       {/* Filtro por paradigma */}
-      <div className="flex gap-2 mb-6">
+      <div className="flex flex-wrap gap-2 mb-6">
         <a
           href="/admin/grupos"
           className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -11,9 +11,13 @@ vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", () => ({
-  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-}));
+vi.mock("@/lib/sheets", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
+  return {
+    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+    validateRegistro: actual.validateRegistro,
+  };
+});
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -84,7 +88,7 @@ describe("PATCH /api/perfil", () => {
 
   it("usa el githubUsername del usuario autenticado (no del body)", async () => {
     await PATCH(makeRequest({ ...validBody, githubUsername: "attacker" }));
-    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    const [inputPasado] = mockUpsertAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
@@ -96,23 +100,13 @@ describe("PATCH /api/perfil", () => {
     );
   });
 
-  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "email inválido" });
+  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
+    mockUpsertAlumno.mockRejectedValue(
+      new FakeLegajoConflictError("12345", "otro-alumno")
+    );
     const res = await PATCH(makeRequest(validBody));
     expect(res.status).toBe(400);
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-  });
-
-  it("propaga el field de Sheets en la respuesta (ej: legajo ya pertenece a otro github)", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({
-      ok: false,
-      error: "El legajo 12345 ya está registrado con el usuario @otro. Verificá que sea el tuyo.",
-      field: "legajo",
-    });
-    const res = await PATCH(makeRequest(validBody));
-    const json = await res.json();
-    expect(res.status).toBe(400);
-    expect(json.field).toBe("legajo");
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 400 con field=legajo si el upsert en DB detecta conflicto de legajo", async () => {
@@ -124,6 +118,13 @@ describe("PATCH /api/perfil", () => {
     expect(res.status).toBe(400);
     expect(json.field).toBe("legajo");
     expect(json.error).toContain("otro-alumno");
+  });
+
+  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
+    const res = await PATCH(makeRequest({ ...validBody, email: "no-es-email" }));
+    expect(res.status).toBe(400);
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -87,12 +87,12 @@ describe("PATCH /api/perfil", () => {
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
-  it("maneja ausencia de comisión activa pasando undefined", async () => {
+  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    await PATCH(makeRequest(validBody));
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
-    );
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(409);
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockGetComisionActiva = vi.fn();
+const mockUpsertAlumno = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/sheets", () => ({
+  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+}));
+
+import { PATCH } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/perfil", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  legajo: "12345",
+  apellido: "García",
+  nombre: "Juan",
+  email: "juan@gmail.com",
+};
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/perfil", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      name: "Juan",
+      image: "",
+      isAdmin: false,
+    });
+    mockGetComisionActiva.mockResolvedValue({
+      id: "c1",
+      spreadsheetId: "sheet-xyz",
+      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    });
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockUpsertAlumno.mockResolvedValue(undefined);
+  });
+
+  it("actualiza Sheets y DB en un mismo request", async () => {
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledTimes(1);
+    expect(mockUpsertAlumno).toHaveBeenCalledTimes(1);
+  });
+
+  it("usa el githubUsername del usuario autenticado (no del body)", async () => {
+    await PATCH(makeRequest({ ...validBody, githubUsername: "attacker" }));
+    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    expect(inputPasado.githubUsername).toBe("juangarcia");
+  });
+
+  it("vuelve a setear registroConfirmadoEn a la comisión activa (mantiene consistencia)", async () => {
+    const comision = await mockGetComisionActiva();
+    await PATCH(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ registroConfirmadoEn: comision })
+    );
+  });
+
+  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "email inválido" });
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(400);
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("maneja ausencia de comisión activa pasando undefined", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    await PATCH(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
+    );
+  });
+
+  it("devuelve 500 si algo tira un error inesperado", async () => {
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    const res = await PATCH(makeRequest(validBody));
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -15,9 +15,25 @@ vi.mock("@/lib/sheets", () => ({
   upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
 }));
 
+const { FakeLegajoConflictError } = vi.hoisted(() => {
+  class FakeLegajoConflictError extends Error {
+    constructor(
+      public readonly legajo: string,
+      public readonly otroGithubUsername: string
+    ) {
+      super(
+        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
+      );
+      this.name = "LegajoConflictError";
+    }
+  }
+  return { FakeLegajoConflictError };
+});
+
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  LegajoConflictError: FakeLegajoConflictError,
 }));
 
 import { PATCH } from "./route";
@@ -85,6 +101,29 @@ describe("PATCH /api/perfil", () => {
     const res = await PATCH(makeRequest(validBody));
     expect(res.status).toBe(400);
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("propaga el field de Sheets en la respuesta (ej: legajo ya pertenece a otro github)", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({
+      ok: false,
+      error: "El legajo 12345 ya está registrado con el usuario @otro. Verificá que sea el tuyo.",
+      field: "legajo",
+    });
+    const res = await PATCH(makeRequest(validBody));
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.field).toBe("legajo");
+  });
+
+  it("devuelve 400 con field=legajo si el upsert en DB detecta conflicto de legajo", async () => {
+    mockUpsertAlumno.mockRejectedValue(
+      new FakeLegajoConflictError("12345", "otro-alumno")
+    );
+    const res = await PATCH(makeRequest(validBody));
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.field).toBe("legajo");
+    expect(json.error).toContain("otro-alumno");
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -16,10 +16,17 @@ export async function PATCH(req: Request) {
     };
 
     const comisionActiva = await getComisionActiva();
+    if (!comisionActiva) {
+      return NextResponse.json(
+        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
+        { status: 409 }
+      );
+    }
+
     const result = await upsertarAlumnoEnSheets(
       input,
-      comisionActiva?.spreadsheetId,
-      comisionActiva?.columnConfig
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
     );
 
     if (!result.ok) {
@@ -32,8 +39,8 @@ export async function PATCH(req: Request) {
       apellido: input.apellido,
       githubUsername: input.githubUsername,
       email: input.email,
-      comision: comisionActiva ?? undefined,
-      registroConfirmadoEn: comisionActiva ?? undefined,
+      comision: comisionActiva,
+      registroConfirmadoEn: comisionActiva,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
+import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
@@ -23,17 +23,9 @@ export async function PATCH(req: Request) {
       );
     }
 
-    const result = await upsertarAlumnoEnSheets(
-      input,
-      comisionActiva.spreadsheetId,
-      comisionActiva.columnConfig
-    );
-
-    if (!result.ok) {
-      return NextResponse.json(
-        { error: result.error, field: result.field },
-        { status: 400 }
-      );
+    const validationError = validateRegistro(input);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
     }
 
     try {
@@ -54,6 +46,19 @@ export async function PATCH(req: Request) {
         );
       }
       throw e;
+    }
+
+    const result = await upsertarAlumnoEnSheets(
+      input,
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
+    );
+
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 }
+      );
     }
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,17 +1,23 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { actualizarAlumno, type ActualizarInput } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
+import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
+
+type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
 export async function PATCH(req: Request) {
   try {
     const user = await requireUser();
-    const body = (await req.json()) as ActualizarInput;
+    const body = (await req.json()) as PerfilInput;
+
+    const input: RegistroInput = {
+      ...body,
+      githubUsername: user.githubUsername,
+    };
 
     const comisionActiva = await getComisionActiva();
-    const result = await actualizarAlumno(
-      user.githubUsername,
-      body,
+    const result = await upsertarAlumnoEnSheets(
+      input,
       comisionActiva?.spreadsheetId,
       comisionActiva?.columnConfig
     );
@@ -19,6 +25,16 @@ export async function PATCH(req: Request) {
     if (!result.ok) {
       return NextResponse.json({ error: result.error }, { status: 400 });
     }
+
+    await upsertAlumno({
+      legajo: input.legajo,
+      nombre: input.nombre,
+      apellido: input.apellido,
+      githubUsername: input.githubUsername,
+      email: input.email,
+      comision: comisionActiva ?? undefined,
+      registroConfirmadoEn: comisionActiva ?? undefined,
+    });
 
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
-import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
+import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -30,18 +30,31 @@ export async function PATCH(req: Request) {
     );
 
     if (!result.ok) {
-      return NextResponse.json({ error: result.error }, { status: 400 });
+      return NextResponse.json(
+        { error: result.error, field: result.field },
+        { status: 400 }
+      );
     }
 
-    await upsertAlumno({
-      legajo: input.legajo,
-      nombre: input.nombre,
-      apellido: input.apellido,
-      githubUsername: input.githubUsername,
-      email: input.email,
-      comision: comisionActiva,
-      registroConfirmadoEn: comisionActiva,
-    });
+    try {
+      await upsertAlumno({
+        legajo: input.legajo,
+        nombre: input.nombre,
+        apellido: input.apellido,
+        githubUsername: input.githubUsername,
+        email: input.email,
+        comision: comisionActiva,
+        registroConfirmadoEn: comisionActiva,
+      });
+    } catch (e) {
+      if (e instanceof LegajoConflictError) {
+        return NextResponse.json(
+          { error: e.message, field: "legajo" },
+          { status: 400 }
+        );
+      }
+      throw e;
+    }
 
     return NextResponse.json({ ok: true });
   } catch (e) {

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -100,17 +100,12 @@ describe("POST /api/registro", () => {
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
-  it("maneja ausencia de comisión activa pasando undefined a los helpers", async () => {
+  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    await POST(makeRequest(validBody));
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
-      expect.any(Object),
-      undefined,
-      undefined
-    );
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
-    );
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(409);
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockGetComisionActiva = vi.fn();
+const mockUpsertAlumno = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/sheets", () => ({
+  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+}));
+
+import { POST } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/registro", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  legajo: "12345",
+  apellido: "García",
+  nombre: "Juan",
+  email: "juan@gmail.com",
+  githubUsername: "attacker", // se ignora — se reemplaza por el del user autenticado
+};
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("POST /api/registro", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      name: "Juan",
+      image: "",
+      isAdmin: false,
+    });
+    mockGetComisionActiva.mockResolvedValue({
+      id: "c1",
+      spreadsheetId: "sheet-xyz",
+      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    });
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockUpsertAlumno.mockResolvedValue(undefined);
+  });
+
+  it("fuerza el githubUsername del usuario autenticado (ignora el del body)", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    expect(inputPasado.githubUsername).toBe("juangarcia");
+  });
+
+  it("llama a upsertarAlumnoEnSheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
+    const comision = await mockGetComisionActiva();
+    await POST(makeRequest(validBody));
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      expect.any(Object),
+      "sheet-xyz",
+      comision.columnConfig
+    );
+  });
+
+  it("llama a upsertAlumno con comision y registroConfirmadoEn = comisión activa", async () => {
+    const comision = await mockGetComisionActiva();
+    await POST(makeRequest(validBody));
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({
+        legajo: "12345",
+        githubUsername: "juangarcia",
+        email: "juan@gmail.com",
+        comision,
+        registroConfirmadoEn: comision,
+      })
+    );
+  });
+
+  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toBe("Legajo duplicado");
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("maneja ausencia de comisión activa pasando undefined a los helpers", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    await POST(makeRequest(validBody));
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      expect.any(Object),
+      undefined,
+      undefined
+    );
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({ comision: undefined, registroConfirmadoEn: undefined })
+    );
+  });
+
+  it("devuelve 500 si algo tira un error inesperado", async () => {
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(500);
+    const json = await res.json();
+    expect(json.error).toBe("boom");
+  });
+});

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -6,6 +6,7 @@ const mockRequireUser = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
+const mockAgregarMiembroAGrupo = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -18,6 +19,10 @@ vi.mock("@/lib/sheets", () => ({
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
 }));
 
 import { POST } from "./route";
@@ -58,6 +63,7 @@ describe("POST /api/registro", () => {
     });
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
     mockUpsertAlumno.mockResolvedValue(undefined);
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
   });
 
   it("fuerza el githubUsername del usuario autenticado (ignora el del body)", async () => {
@@ -114,5 +120,63 @@ describe("POST /api/registro", () => {
     expect(res.status).toBe(500);
     const json = await res.json();
     expect(json.error).toBe("boom");
+  });
+
+  // ── Suscripción al Google Group ────────────────────────────
+
+  describe("suscripción al Google Group", () => {
+    it("llama a agregarMiembroAGrupo con el email del alumno tras un registro exitoso", async () => {
+      await POST(makeRequest(validBody));
+      expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("juan@gmail.com");
+    });
+
+    it("devuelve groupSubscription: 'added' en el body cuando la suscripción funciona", async () => {
+      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json).toEqual({ ok: true, groupSubscription: "added" });
+    });
+
+    it("devuelve groupSubscription: 'already_member' cuando el alumno ya estaba en el grupo", async () => {
+      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.groupSubscription).toBe("already_member");
+    });
+
+    it("devuelve groupSubscription: 'skipped' cuando la feature está desactivada", async () => {
+      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.groupSubscription).toBe("skipped");
+    });
+
+    it("no rompe el registro si la suscripción falla (responde 200 con status 'error')", async () => {
+      mockAgregarMiembroAGrupo.mockResolvedValue({
+        status: "error",
+        error: "Sin permisos",
+      });
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.groupSubscription).toBe("error");
+      // El alta en DB ya ocurrió antes de intentar la suscripción
+      expect(mockUpsertAlumno).toHaveBeenCalledOnce();
+    });
+
+    it("no intenta suscribir si la escritura en Sheets falla", async () => {
+      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
+      await POST(makeRequest(validBody));
+      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
+    });
+
+    it("no intenta suscribir si no hay comisión activa", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
+      await POST(makeRequest(validBody));
+      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -167,6 +167,22 @@ describe("POST /api/registro", () => {
       expect(mockUpsertAlumno).toHaveBeenCalledOnce();
     });
 
+    it("enmascara el email en el log de error para no exponer PII", async () => {
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      mockAgregarMiembroAGrupo.mockResolvedValue({
+        status: "error",
+        error: "Sin permisos",
+      });
+      await POST(makeRequest(validBody));
+      const loggedLines = errorSpy.mock.calls.flat().join(" ");
+      // El email completo no debe aparecer, pero sí el dominio y un
+      // identificador útil para el admin (githubUsername).
+      expect(loggedLines).not.toContain("juan@gmail.com");
+      expect(loggedLines).toContain("@gmail.com");
+      expect(loggedLines).toContain("juangarcia");
+      errorSpy.mockRestore();
+    });
+
     it("no intenta suscribir si la escritura en Sheets falla", async () => {
       mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
       await POST(makeRequest(validBody));

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -12,9 +12,13 @@ vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", () => ({
-  upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-}));
+vi.mock("@/lib/sheets", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
+  return {
+    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
+    validateRegistro: actual.validateRegistro,
+  };
+});
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -113,25 +117,13 @@ describe("POST /api/registro", () => {
     );
   });
 
-  it("no llama a upsertAlumno si la escritura en Sheets falla", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
+  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
+    mockUpsertAlumno.mockRejectedValue(
+      new FakeLegajoConflictError("12345", "otro-alumno")
+    );
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(400);
-    const json = await res.json();
-    expect(json.error).toBe("Legajo duplicado");
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-  });
-
-  it("propaga el field de Sheets en la respuesta para que el form lo pinte inline", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({
-      ok: false,
-      error: "El legajo 12345 ya está registrado con el usuario @otro. Verificá que sea el tuyo.",
-      field: "legajo",
-    });
-    const res = await POST(makeRequest(validBody));
-    const json = await res.json();
-    expect(res.status).toBe(400);
-    expect(json.field).toBe("legajo");
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 400 con field=legajo si el upsert en DB detecta que el legajo pertenece a otro github", async () => {
@@ -143,6 +135,13 @@ describe("POST /api/registro", () => {
     expect(res.status).toBe(400);
     expect(json.field).toBe("legajo");
     expect(json.error).toContain("otro-alumno");
+  });
+
+  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
+    const res = await POST(makeRequest({ ...validBody, email: "no-es-email" }));
+    expect(res.status).toBe(400);
+    expect(mockUpsertAlumno).not.toHaveBeenCalled();
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -16,9 +16,25 @@ vi.mock("@/lib/sheets", () => ({
   upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
 }));
 
+const { FakeLegajoConflictError } = vi.hoisted(() => {
+  class FakeLegajoConflictError extends Error {
+    constructor(
+      public readonly legajo: string,
+      public readonly otroGithubUsername: string
+    ) {
+      super(
+        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
+      );
+      this.name = "LegajoConflictError";
+    }
+  }
+  return { FakeLegajoConflictError };
+});
+
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  LegajoConflictError: FakeLegajoConflictError,
 }));
 
 vi.mock("@/lib/googleGroups", () => ({
@@ -104,6 +120,29 @@ describe("POST /api/registro", () => {
     const json = await res.json();
     expect(json.error).toBe("Legajo duplicado");
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
+  });
+
+  it("propaga el field de Sheets en la respuesta para que el form lo pinte inline", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({
+      ok: false,
+      error: "El legajo 12345 ya está registrado con el usuario @otro. Verificá que sea el tuyo.",
+      field: "legajo",
+    });
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.field).toBe("legajo");
+  });
+
+  it("devuelve 400 con field=legajo si el upsert en DB detecta que el legajo pertenece a otro github", async () => {
+    mockUpsertAlumno.mockRejectedValue(
+      new FakeLegajoConflictError("12345", "otro-alumno")
+    );
+    const res = await POST(makeRequest(validBody));
+    const json = await res.json();
+    expect(res.status).toBe(400);
+    expect(json.field).toBe("legajo");
+    expect(json.error).toContain("otro-alumno");
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
-import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
+import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 
 // Enmascara la parte local del email para no escupir PII a los logs,
@@ -39,18 +39,31 @@ export async function POST(req: Request) {
     );
 
     if (!result.ok) {
-      return NextResponse.json({ error: result.error }, { status: 400 });
+      return NextResponse.json(
+        { error: result.error, field: result.field },
+        { status: 400 }
+      );
     }
 
-    await upsertAlumno({
-      legajo: body.legajo,
-      nombre: body.nombre,
-      apellido: body.apellido,
-      githubUsername: body.githubUsername,
-      email: body.email,
-      comision: comisionActiva,
-      registroConfirmadoEn: comisionActiva,
-    });
+    try {
+      await upsertAlumno({
+        legajo: body.legajo,
+        nombre: body.nombre,
+        apellido: body.apellido,
+        githubUsername: body.githubUsername,
+        email: body.email,
+        comision: comisionActiva,
+        registroConfirmadoEn: comisionActiva,
+      });
+    } catch (e) {
+      if (e instanceof LegajoConflictError) {
+        return NextResponse.json(
+          { error: e.message, field: "legajo" },
+          { status: 400 }
+        );
+      }
+      throw e;
+    }
 
     // El alta ya quedó persistida — una falla al suscribir al grupo no
     // debe romper el registro. Informamos el resultado para que la UI lo

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { registrarAlumno, type RegistroInput } from "@/lib/sheets";
+import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
 
 export async function POST(req: Request) {
@@ -12,7 +12,7 @@ export async function POST(req: Request) {
     body.githubUsername = user.githubUsername;
 
     const comisionActiva = await getComisionActiva();
-    const result = await registrarAlumno(
+    const result = await upsertarAlumnoEnSheets(
       body,
       comisionActiva?.spreadsheetId,
       comisionActiva?.columnConfig
@@ -29,6 +29,7 @@ export async function POST(req: Request) {
       githubUsername: body.githubUsername,
       email: body.email,
       comision: comisionActiva ?? undefined,
+      registroConfirmadoEn: comisionActiva ?? undefined,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -4,6 +4,18 @@ import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 
+// Enmascara la parte local del email para no escupir PII a los logs,
+// preservando dominio y primeras 2 letras para que un admin pueda
+// reconocer al alumno (combinado con el githubUsername del log).
+function maskEmail(email: string): string {
+  const at = email.indexOf("@");
+  if (at <= 0) return "***";
+  const user = email.slice(0, at);
+  const domain = email.slice(at);
+  const visible = user.slice(0, 2);
+  return `${visible}${"*".repeat(Math.max(user.length - 2, 1))}${domain}`;
+}
+
 export async function POST(req: Request) {
   try {
     const user = await requireUser();
@@ -46,7 +58,7 @@ export async function POST(req: Request) {
     const groupSubscription = await agregarMiembroAGrupo(body.email);
     if (groupSubscription.status === "error") {
       console.error(
-        `Error al suscribir ${body.email} al Google Group: ${groupSubscription.error}`
+        `Error al suscribir al Google Group: github=${body.githubUsername} email=${maskEmail(body.email)} — ${groupSubscription.error}`
       );
     }
 

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno } from "@/lib/repositories";
+import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 
 export async function POST(req: Request) {
   try {
@@ -39,7 +40,17 @@ export async function POST(req: Request) {
       registroConfirmadoEn: comisionActiva,
     });
 
-    return NextResponse.json({ ok: true });
+    // El alta ya quedó persistida — una falla al suscribir al grupo no
+    // debe romper el registro. Informamos el resultado para que la UI lo
+    // muestre si corresponde y logueamos el detalle server-side.
+    const groupSubscription = await agregarMiembroAGrupo(body.email);
+    if (groupSubscription.status === "error") {
+      console.error(
+        `Error al suscribir ${body.email} al Google Group: ${groupSubscription.error}`
+      );
+    }
+
+    return NextResponse.json({ ok: true, groupSubscription: groupSubscription.status });
   } catch (e) {
     const msg = e instanceof Error ? e.message : "Error interno";
     return NextResponse.json({ error: msg }, { status: 500 });

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { upsertarAlumnoEnSheets, type RegistroInput } from "@/lib/sheets";
+import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 
@@ -32,19 +32,14 @@ export async function POST(req: Request) {
       );
     }
 
-    const result = await upsertarAlumnoEnSheets(
-      body,
-      comisionActiva.spreadsheetId,
-      comisionActiva.columnConfig
-    );
-
-    if (!result.ok) {
-      return NextResponse.json(
-        { error: result.error, field: result.field },
-        { status: 400 }
-      );
+    // Validar inputs antes de tocar DB o Sheets.
+    const validationError = validateRegistro(body);
+    if (validationError) {
+      return NextResponse.json({ error: validationError }, { status: 400 });
     }
 
+    // DB primero: valida legajo↔github atómicamente. Si falla, Sheets no
+    // se toca — evita el TOCTOU del check previo contra Sheets.
     try {
       await upsertAlumno({
         legajo: body.legajo,
@@ -63,6 +58,19 @@ export async function POST(req: Request) {
         );
       }
       throw e;
+    }
+
+    const result = await upsertarAlumnoEnSheets(
+      body,
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
+    );
+
+    if (!result.ok) {
+      return NextResponse.json(
+        { error: result.error },
+        { status: 400 }
+      );
     }
 
     // El alta ya quedó persistida — una falla al suscribir al grupo no

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -12,10 +12,17 @@ export async function POST(req: Request) {
     body.githubUsername = user.githubUsername;
 
     const comisionActiva = await getComisionActiva();
+    if (!comisionActiva) {
+      return NextResponse.json(
+        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
+        { status: 409 }
+      );
+    }
+
     const result = await upsertarAlumnoEnSheets(
       body,
-      comisionActiva?.spreadsheetId,
-      comisionActiva?.columnConfig
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
     );
 
     if (!result.ok) {
@@ -28,8 +35,8 @@ export async function POST(req: Request) {
       apellido: body.apellido,
       githubUsername: body.githubUsername,
       email: body.email,
-      comision: comisionActiva ?? undefined,
-      registroConfirmadoEn: comisionActiva ?? undefined,
+      comision: comisionActiva,
+      registroConfirmadoEn: comisionActiva,
     });
 
     return NextResponse.json({ ok: true });

--- a/src/app/components/AlumnoForm.test.tsx
+++ b/src/app/components/AlumnoForm.test.tsx
@@ -61,6 +61,21 @@ describe("AlumnoForm", () => {
       renderForm({ submitLabel: "Registrarme" });
       expect(screen.getByRole("button", { name: "Registrarme" })).toBeInTheDocument();
     });
+
+    it("muestra la explicación sobre el email leído asiduamente", () => {
+      renderForm();
+      expect(
+        screen.getByText(/email que leas asiduamente/i)
+      ).toBeInTheDocument();
+    });
+
+    it("el input de email tiene pattern RFC-lite para validar en el cliente", () => {
+      renderForm();
+      const emailInput = screen.getByDisplayValue("juan@example.com");
+      expect(emailInput).toHaveAttribute("pattern", "[^\\s@]+@[^\\s@]+\\.[^\\s@]+");
+      expect(emailInput).toHaveAttribute("type", "email");
+      expect(emailInput).toBeRequired();
+    });
   });
 
   describe("submit exitoso", () => {

--- a/src/app/components/AlumnoForm.test.tsx
+++ b/src/app/components/AlumnoForm.test.tsx
@@ -117,6 +117,60 @@ describe("AlumnoForm", () => {
     });
   });
 
+  describe("warning de suscripción al grupo", () => {
+    function mockRegistroOk(groupSubscription?: string) {
+      const body = groupSubscription
+        ? { ok: true, groupSubscription }
+        : { ok: true };
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(JSON.stringify(body), { status: 200 })
+      );
+    }
+
+    const WARNING_PATTERN = /no pudimos suscribirte al grupo/i;
+
+    it("muestra el warning cuando groupSubscription === 'error'", async () => {
+      mockRegistroOk("error");
+      renderForm();
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(WARNING_PATTERN)
+      );
+    });
+
+    it("no muestra el warning cuando groupSubscription === 'added'", async () => {
+      mockRegistroOk("added");
+      renderForm({ successMessage: "Listo" });
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => screen.getByText("Listo"));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("no muestra el warning cuando groupSubscription === 'already_member'", async () => {
+      mockRegistroOk("already_member");
+      renderForm({ successMessage: "Listo" });
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => screen.getByText("Listo"));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("no muestra el warning cuando groupSubscription === 'skipped'", async () => {
+      mockRegistroOk("skipped");
+      renderForm({ successMessage: "Listo" });
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => screen.getByText("Listo"));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("no muestra el warning cuando la respuesta no trae groupSubscription (ej. /api/perfil)", async () => {
+      mockRegistroOk();
+      renderForm({ successMessage: "Listo" });
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => screen.getByText("Listo"));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
   describe("submit con error del servidor", () => {
     it("muestra el mensaje de error de la API", async () => {
       vi.mocked(fetch).mockResolvedValue(

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -39,6 +39,7 @@ export function AlumnoForm({
 }: Props) {
   const { loading, error, call } = useApiCall();
   const [success, setSuccess] = useState(false);
+  const [groupWarning, setGroupWarning] = useState(false);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault();
@@ -58,17 +59,32 @@ export function AlumnoForm({
       });
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? "Error al guardar");
+      const hasGroupWarning = json.groupSubscription === "error";
+      setGroupWarning(hasGroupWarning);
       setSuccess(true);
+      // Damos más tiempo antes de redirigir si hay que mostrar el warning
+      // para que el alumno alcance a leerlo.
       if (onSuccessRedirect) {
-        setTimeout(() => { window.location.href = onSuccessRedirect; }, 1500);
+        const delay = hasGroupWarning ? 5000 : 1500;
+        setTimeout(() => { window.location.href = onSuccessRedirect; }, delay);
       }
     });
   }
 
   if (success) {
     return (
-      <div className="bg-green-50 border border-green-200 rounded-lg p-6 text-center">
-        <p className="text-green-700 font-medium">{successMessage}</p>
+      <div className="space-y-3">
+        <div className="bg-green-50 border border-green-200 rounded-lg p-6 text-center">
+          <p className="text-green-700 font-medium">{successMessage}</p>
+        </div>
+        {groupWarning && (
+          <div
+            role="alert"
+            className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-sm text-amber-800"
+          >
+            No pudimos suscribirte al grupo del curso. Avisale a un docente para que te agregue manualmente.
+          </div>
+        )}
       </div>
     );
   }

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -90,6 +90,7 @@ export function AlumnoForm({
           name="legajo"
           required
           pattern="\d{4,8}"
+          inputMode="numeric"
           placeholder="12345678"
           defaultValue={defaultValues.legajo}
           className={INPUT_CLASS}

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -128,9 +128,15 @@ export function AlumnoForm({
           name="email"
           type="email"
           required
+          pattern="[^\s@]+@[^\s@]+\.[^\s@]+"
+          title="Ingresá un email con formato válido (usuario@dominio.com)"
           defaultValue={defaultValues.email}
           className={INPUT_CLASS}
         />
+        <p className="text-xs text-gray-500 mt-1">
+          Ingresá un email que leas asiduamente — por este canal mandamos
+          avisos importantes del curso.
+        </p>
       </div>
 
       {error && (

--- a/src/app/components/DataTable.test.tsx
+++ b/src/app/components/DataTable.test.tsx
@@ -55,7 +55,7 @@ describe("DataTable", () => {
     expect(screen.getByText("Tipo")).toHaveClass("md:hidden");
   });
 
-  it("DataHeader solo se muestra en md+ (hidden md:grid)", () => {
+  it("DataHeader solo se muestra en md+", () => {
     const { container } = render(
       <DataTable columns="1fr 1fr">
         <DataHeader>
@@ -64,7 +64,7 @@ describe("DataTable", () => {
         </DataHeader>
       </DataTable>
     );
-    const header = container.querySelector(".hidden.md\\:grid");
+    const header = container.querySelector(".hidden.md\\:block");
     expect(header).toBeInTheDocument();
     expect(screen.getByText("Título")).toBeInTheDocument();
     expect(screen.getByText("Entregas")).toHaveClass("text-right");
@@ -82,6 +82,28 @@ describe("DataTable", () => {
     );
     expect(screen.queryByText("Título")).not.toBeInTheDocument();
     expect(screen.getByText("Mi TP").className).toContain("font-semibold");
+  });
+
+  it("expone roles ARIA tabulares para screen readers", () => {
+    render(
+      <DataTable columns="1fr 1fr">
+        <DataHeader>
+          <DataHeaderCell>A</DataHeaderCell>
+          <DataHeaderCell>B</DataHeaderCell>
+        </DataHeader>
+        <DataBody>
+          <DataRow>
+            <DataCell label="A">a1</DataCell>
+            <DataCell label="B">b1</DataCell>
+          </DataRow>
+        </DataBody>
+      </DataTable>
+    );
+    expect(screen.getByRole("table")).toBeInTheDocument();
+    expect(screen.getAllByRole("rowgroup")).toHaveLength(2);
+    expect(screen.getAllByRole("row")).toHaveLength(2);
+    expect(screen.getAllByRole("columnheader")).toHaveLength(2);
+    expect(screen.getAllByRole("cell")).toHaveLength(2);
   });
 
   it("DataEmpty muestra el mensaje vacío", () => {

--- a/src/app/components/DataTable.test.tsx
+++ b/src/app/components/DataTable.test.tsx
@@ -1,0 +1,108 @@
+import { render, screen } from "@testing-library/react";
+import {
+  DataTable,
+  DataHeader,
+  DataHeaderCell,
+  DataBody,
+  DataRow,
+  DataCell,
+  DataEmpty,
+} from "./DataTable";
+
+describe("DataTable", () => {
+  it("propaga la definición de columnas al estilo CSS del container", () => {
+    const { container } = render(
+      <DataTable columns="2fr 1fr 100px">
+        <div>x</div>
+      </DataTable>
+    );
+    const root = container.firstChild as HTMLElement;
+    expect(root.style.getPropertyValue("--data-cols")).toBe("2fr 1fr 100px");
+  });
+
+  it("DataCell muestra el label y el valor", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Paradigma">Funcional</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.getByText("Paradigma")).toBeInTheDocument();
+    expect(screen.getByText("Funcional")).toBeInTheDocument();
+  });
+
+  it("DataCell sin label no renderiza el prefijo", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="">Acciones</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.queryByText(/:/)).not.toBeInTheDocument();
+    expect(screen.getByText("Acciones")).toBeInTheDocument();
+  });
+
+  it("el label de DataCell se oculta en md+ (md:hidden)", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Tipo">grupal</DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.getByText("Tipo")).toHaveClass("md:hidden");
+  });
+
+  it("DataHeader solo se muestra en md+ (hidden md:grid)", () => {
+    const { container } = render(
+      <DataTable columns="1fr 1fr">
+        <DataHeader>
+          <DataHeaderCell>Título</DataHeaderCell>
+          <DataHeaderCell align="right">Entregas</DataHeaderCell>
+        </DataHeader>
+      </DataTable>
+    );
+    const header = container.querySelector(".hidden.md\\:grid");
+    expect(header).toBeInTheDocument();
+    expect(screen.getByText("Título")).toBeInTheDocument();
+    expect(screen.getByText("Entregas")).toHaveClass("text-right");
+  });
+
+  it("DataCell con heading oculta el label y destaca el valor", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataRow>
+          <DataCell label="Título" heading>
+            Mi TP
+          </DataCell>
+        </DataRow>
+      </DataTable>
+    );
+    expect(screen.queryByText("Título")).not.toBeInTheDocument();
+    expect(screen.getByText("Mi TP").className).toContain("font-semibold");
+  });
+
+  it("DataEmpty muestra el mensaje vacío", () => {
+    render(<DataEmpty>No hay nada todavía</DataEmpty>);
+    expect(screen.getByText("No hay nada todavía")).toBeInTheDocument();
+  });
+
+  it("DataBody envuelve las filas", () => {
+    render(
+      <DataTable columns="1fr">
+        <DataBody>
+          <DataRow>
+            <DataCell label="X">a</DataCell>
+          </DataRow>
+          <DataRow>
+            <DataCell label="X">b</DataCell>
+          </DataRow>
+        </DataBody>
+      </DataTable>
+    );
+    expect(screen.getByText("a")).toBeInTheDocument();
+    expect(screen.getByText("b")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -13,15 +13,22 @@ interface DataTableProps {
   columns: string;
   children: ReactNode;
   className?: string;
+  /** Si true, no aplica el contenedor (bg/borde/rounded). Usalo cuando el padre envuelve. */
+  bare?: boolean;
 }
 
-export function DataTable({ columns, children, className = "" }: DataTableProps) {
+export function DataTable({
+  columns,
+  children,
+  className = "",
+  bare = false,
+}: DataTableProps) {
   const style = { ["--data-cols" as string]: columns } as CSSProperties;
+  const containerClass = bare
+    ? ""
+    : "bg-white border border-gray-200 rounded-lg overflow-hidden";
   return (
-    <div
-      className={`bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
-      style={style}
-    >
+    <div className={`${containerClass} ${className}`} style={style}>
       {children}
     </div>
   );

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -1,0 +1,110 @@
+import type { CSSProperties, ReactNode } from "react";
+
+type Align = "left" | "right" | "center";
+
+function alignClass(align: Align, prefix = "") {
+  if (align === "right") return `${prefix}text-right`;
+  if (align === "center") return `${prefix}text-center`;
+  return "";
+}
+
+interface DataTableProps {
+  /** grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px auto" */
+  columns: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function DataTable({ columns, children, className = "" }: DataTableProps) {
+  const style = { ["--data-cols" as string]: columns } as CSSProperties;
+  return (
+    <div
+      className={`bg-white border border-gray-200 rounded-lg overflow-hidden ${className}`}
+      style={style}
+    >
+      {children}
+    </div>
+  );
+}
+
+const ROW_TEMPLATE = { gridTemplateColumns: "var(--data-cols)" } as CSSProperties;
+
+export function DataHeader({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="hidden md:grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
+      style={ROW_TEMPLATE}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function DataHeaderCell({
+  children,
+  align = "left",
+}: {
+  children: ReactNode;
+  align?: Align;
+}) {
+  return <div className={alignClass(align)}>{children}</div>;
+}
+
+export function DataBody({ children }: { children: ReactNode }) {
+  return <div className="divide-y divide-gray-100">{children}</div>;
+}
+
+export function DataRow({ children }: { children: ReactNode }) {
+  return (
+    <div
+      className="block md:grid md:gap-3 md:items-center px-4 py-4 md:py-3 hover:bg-gray-50 space-y-3 md:space-y-0 text-sm"
+      style={ROW_TEMPLATE}
+    >
+      {children}
+    </div>
+  );
+}
+
+interface DataCellProps {
+  /** Prefijo del valor en mobile (oculto en md+). Vacío = no se muestra. */
+  label: string;
+  children: ReactNode;
+  align?: Align;
+  className?: string;
+  /**
+   * En mobile, destaca el valor como título de la card (más grande, bold)
+   * y oculta el label. En desktop se comporta como una celda normal.
+   */
+  heading?: boolean;
+}
+
+export function DataCell({
+  label,
+  children,
+  align = "left",
+  className = "",
+  heading = false,
+}: DataCellProps) {
+  const showLabel = label && !heading;
+  const valueClass = heading
+    ? "text-base font-semibold text-gray-900 md:text-sm md:font-medium"
+    : "";
+  return (
+    <div className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
+      {showLabel && (
+        <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-0.5 md:hidden">
+          {label}
+        </div>
+      )}
+      <div className={valueClass}>{children}</div>
+    </div>
+  );
+}
+
+export function DataEmpty({ children }: { children: ReactNode }) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-8 text-center text-gray-500">
+      {children}
+    </div>
+  );
+}

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -28,7 +28,7 @@ export function DataTable({
     ? ""
     : "bg-white border border-gray-200 rounded-lg overflow-hidden";
   return (
-    <div className={`${containerClass} ${className}`} style={style}>
+    <div role="table" className={`${containerClass} ${className}`} style={style}>
       {children}
     </div>
   );
@@ -38,11 +38,14 @@ const ROW_TEMPLATE = { gridTemplateColumns: "var(--data-cols)" } as CSSPropertie
 
 export function DataHeader({ children }: { children: ReactNode }) {
   return (
-    <div
-      className="hidden md:grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
-      style={ROW_TEMPLATE}
-    >
-      {children}
+    <div role="rowgroup" className="hidden md:block">
+      <div
+        role="row"
+        className="grid gap-3 bg-gray-50 border-b border-gray-200 px-4 py-3 text-xs font-medium text-gray-600 uppercase tracking-wide items-center"
+        style={ROW_TEMPLATE}
+      >
+        {children}
+      </div>
     </div>
   );
 }
@@ -54,16 +57,25 @@ export function DataHeaderCell({
   children: ReactNode;
   align?: Align;
 }) {
-  return <div className={alignClass(align)}>{children}</div>;
+  return (
+    <div role="columnheader" className={alignClass(align)}>
+      {children}
+    </div>
+  );
 }
 
 export function DataBody({ children }: { children: ReactNode }) {
-  return <div className="divide-y divide-gray-100">{children}</div>;
+  return (
+    <div role="rowgroup" className="divide-y divide-gray-100">
+      {children}
+    </div>
+  );
 }
 
 export function DataRow({ children }: { children: ReactNode }) {
   return (
     <div
+      role="row"
       className="block md:grid md:gap-3 md:items-center px-4 py-4 md:py-3 hover:bg-gray-50 space-y-3 md:space-y-0 text-sm"
       style={ROW_TEMPLATE}
     >
@@ -97,7 +109,7 @@ export function DataCell({
     ? "text-base font-semibold text-gray-900 md:text-sm md:font-medium"
     : "";
   return (
-    <div className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
+    <div role="cell" className={`min-w-0 ${alignClass(align, "md:")} ${className}`}>
       {showLabel && (
         <div className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 mb-0.5 md:hidden">
           {label}

--- a/src/app/components/DataTable.tsx
+++ b/src/app/components/DataTable.tsx
@@ -9,7 +9,11 @@ function alignClass(align: Align, prefix = "") {
 }
 
 interface DataTableProps {
-  /** grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px auto" */
+  /**
+   * grid-template-columns aplicado en md+; ej: "2fr 1fr 1fr 100px 180px".
+   * Evitá `auto`: el header y las filas son grids separados, y `auto` se
+   * resuelve distinto en cada uno, desalineando las columnas.
+   */
   columns: string;
   children: ReactNode;
   className?: string;
@@ -58,7 +62,7 @@ export function DataHeaderCell({
   align?: Align;
 }) {
   return (
-    <div role="columnheader" className={alignClass(align)}>
+    <div role="columnheader" className={`min-w-0 ${alignClass(align)}`}>
       {children}
     </div>
   );

--- a/src/app/dashboard/accept-button.tsx
+++ b/src/app/dashboard/accept-button.tsx
@@ -23,7 +23,7 @@ export function AcceptButton({ assignmentId }: { assignmentId: string }) {
       <button
         onClick={handleAccept}
         disabled={loading}
-        className="inline-flex items-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-1.5 rounded-lg font-medium hover:bg-pdep-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+        className="inline-flex items-center justify-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed w-full sm:w-auto"
       >
         {loading ? (
           <>

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -7,6 +7,7 @@ import { IndividualAssignment, Entrega } from "@/domain/entities";
 
 const mockRequireUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
+const mockGetComisionActiva = vi.fn();
 const mockGetAssignments = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
@@ -17,17 +18,11 @@ vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("next/cache", () => ({
-  unstable_cache: (fn: (...args: unknown[]) => unknown) => fn,
-}));
-
-vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
-}));
-
 vi.mock("@/lib/repositories", () => ({
   getAssignments: () => mockGetAssignments(),
   getEntregasDeUsuario: (username: string) => mockGetEntregaDeUsuario(username),
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  getComisionActiva: () => mockGetComisionActiva(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -89,10 +84,12 @@ describe("Dashboard page", () => {
     });
     mockGetAssignments.mockResolvedValue([]);
     mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+    mockGetComisionActiva.mockResolvedValue({ id: "c1" });
+    mockGetAlumnoByGithub.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
-    it("redirige a /registro si el alumno no está registrado y no es admin", async () => {
+    it("redirige a /registro si el alumno no existe en la DB y no es admin", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetAlumnoByGithub.mockResolvedValue(null);
 
@@ -100,7 +97,22 @@ describe("Dashboard page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/registro");
     });
 
-    it("no redirige a /registro si el alumno está registrado", async () => {
+    it("redirige a /registro si el alumno confirmó en otra comisión (recursante)", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetComisionActiva.mockResolvedValue({ id: "c2" });
+      mockGetAlumnoByGithub.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Test",
+        apellido: "User",
+        githubUsername: "testuser",
+        email: "test@example.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+
+      await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
+    });
+
+    it("redirige a /registro si el alumno nunca confirmó (registroConfirmadoEn null)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetAlumnoByGithub.mockResolvedValue({
         legajo: "12345",
@@ -108,8 +120,32 @@ describe("Dashboard page", () => {
         apellido: "User",
         githubUsername: "testuser",
         email: "test@example.com",
-        comision: "miércoles noche",
+        registroConfirmadoEn: null,
       });
+
+      await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
+    });
+
+    it("no redirige si el alumno confirmó para la comisión activa", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Test",
+        apellido: "User",
+        githubUsername: "testuser",
+        email: "test@example.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+
+      const element = await DashboardPage();
+      expect(element).toBeDefined();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("no redirige si no hay comisión activa (deja pasar aunque no haya confirmado)", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetComisionActiva.mockResolvedValue(null);
+      mockGetAlumnoByGithub.mockResolvedValue(null);
 
       const element = await DashboardPage();
       expect(element).toBeDefined();
@@ -262,7 +298,7 @@ describe("Dashboard page", () => {
 
     it("consulta las entregas usando el username del usuario actual", async () => {
       mockRequireUser.mockResolvedValue(
-        makeUser({ githubUsername: "miusuario" })
+        makeUser({ githubUsername: "miusuario", isAdmin: true })
       );
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "tp-1" })]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -57,10 +57,10 @@ export default async function DashboardPage() {
           {assignmentsConEntrega.map(({ assignment, entrega }) => (
             <div
               key={assignment.id}
-              className="bg-white border border-gray-200 rounded-lg p-5 flex items-center justify-between"
+              className="bg-white border border-gray-200 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
             >
-              <div>
-                <div className="flex items-center gap-2 mb-1">
+              <div className="min-w-0">
+                <div className="flex flex-wrap items-center gap-2 mb-1">
                   <h3 className="font-semibold">{assignment.titulo}</h3>
                   <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full font-medium">
                     {assignment.paradigma}
@@ -86,13 +86,13 @@ export default async function DashboardPage() {
                 )}
               </div>
 
-              <div className="flex-shrink-0 ml-4">
+              <div className="flex-shrink-0 w-full sm:w-auto">
                 {entrega ? (
                   <a
                     href={entrega.repoUrl}
                     target="_blank"
                     rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1.5 text-sm bg-green-50 text-green-700 border border-green-200 px-3 py-1.5 rounded-lg font-medium hover:bg-green-100 transition-colors"
+                    className="inline-flex items-center justify-center gap-1.5 text-sm bg-green-50 text-green-700 border border-green-200 px-3 py-2 rounded-lg font-medium hover:bg-green-100 transition-colors w-full sm:w-auto"
                   >
                     <svg
                       className="w-4 h-4"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,24 +1,30 @@
 import { requireUser } from "@/lib/session";
-import { getAssignments, getEntregasDeUsuario } from "@/lib/repositories";
-import { getAlumnoByGithub } from "@/lib/sheets";
+import {
+  getAssignments,
+  getEntregasDeUsuario,
+  getAlumnoByGithub,
+  getComisionActiva,
+} from "@/lib/repositories";
 import { AcceptButton } from "./accept-button";
 import { redirect } from "next/navigation";
-import { unstable_cache } from "next/cache";
-
-// Cachea la verificación de alumno por 5 minutos — evita un round-trip a Sheets en cada render
-const getAlumnoCached = unstable_cache(
-  async (username: string) => getAlumnoByGithub(username),
-  ["alumno-by-github"],
-  { revalidate: 300 }
-);
 
 export default async function DashboardPage() {
   const user = await requireUser();
 
-  // Si no es admin y no está registrado, mandar a registro
+  // Los admins no pasan por el gate de registro; pueden entrar sin estar como alumnos.
   if (!user.isAdmin) {
-    const alumno = await getAlumnoCached(user.githubUsername);
-    if (!alumno) redirect("/registro");
+    const [alumno, comisionActiva] = await Promise.all([
+      getAlumnoByGithub(user.githubUsername),
+      getComisionActiva(),
+    ]);
+    // Sin comisión activa no podemos pedirle nada — se deja pasar.
+    // Con comisión activa, bloquear hasta que el alumno la haya confirmado.
+    if (
+      comisionActiva &&
+      alumno?.registroConfirmadoEn?.id !== comisionActiva.id
+    ) {
+      redirect("/registro");
+    }
   }
 
   // Dos queries paralelas: assignments + todas las entregas del usuario

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,15 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Nav } from "./nav";
 
 export const metadata: Metadata = {
   title: "PdeP Classroom",
   description: "Gestión de TPs - Paradigmas de Programación - UTN FRBA",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({
@@ -16,7 +21,7 @@ export default function RootLayout({
     <html lang="es">
       <body className="font-sans">
         <Nav />
-        <main className="max-w-5xl mx-auto px-4 py-8">{children}</main>
+        <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8">{children}</main>
       </body>
     </html>
   );

--- a/src/app/logout-button.test.tsx
+++ b/src/app/logout-button.test.tsx
@@ -8,6 +8,12 @@ vi.mock("next-auth/react", () => ({
 
 import { UserMenu } from "./logout-button";
 
+async function openMenu(username: string) {
+  const user = userEvent.setup();
+  await user.click(screen.getByRole("button", { name: new RegExp(username) }));
+  return user;
+}
+
 describe("UserMenu", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -26,28 +32,47 @@ describe("UserMenu", () => {
     expect(img).toHaveAttribute("src", "https://github.com/juangarcia.png");
   });
 
-  it("llama a signOut con callbackUrl '/' al hacer click en Salir", async () => {
-    const user = userEvent.setup();
+  it("no muestra el menú hasta hacer click en el trigger", () => {
     render(<UserMenu username="juangarcia" image="" />);
+    expect(screen.queryByRole("menu")).not.toBeInTheDocument();
+  });
 
-    await user.click(screen.getByRole("button", { name: "Salir" }));
+  it("abre el menú al hacer click en el trigger", async () => {
+    render(<UserMenu username="juangarcia" image="" />);
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
+  it("llama a signOut con callbackUrl '/' al hacer click en Salir", async () => {
+    render(<UserMenu username="juangarcia" image="" />);
+    const user = await openMenu("juangarcia");
+
+    await user.click(screen.getByRole("menuitem", { name: "Salir" }));
 
     expect(mockSignOut).toHaveBeenCalledOnce();
     expect(mockSignOut).toHaveBeenCalledWith({ callbackUrl: "/" });
   });
 
-  it("muestra el link Editar perfil para alumnos", () => {
+  it("muestra el link Editar perfil para alumnos", async () => {
     render(<UserMenu username="juangarcia" image="" isAdmin={false} />);
-    expect(screen.getByRole("link", { name: "Editar perfil" })).toHaveAttribute("href", "/perfil");
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menuitem", { name: "Editar perfil" })).toHaveAttribute(
+      "href",
+      "/perfil"
+    );
   });
 
-  it("no muestra el link Editar perfil para admins", () => {
+  it("no muestra el link Editar perfil para admins", async () => {
     render(<UserMenu username="admin" image="" isAdmin={true} />);
-    expect(screen.queryByRole("link", { name: "Editar perfil" })).not.toBeInTheDocument();
+    await openMenu("admin");
+    expect(
+      screen.queryByRole("menuitem", { name: "Editar perfil" })
+    ).not.toBeInTheDocument();
   });
 
-  it("muestra Editar perfil por defecto (sin isAdmin)", () => {
+  it("muestra Editar perfil por defecto (sin isAdmin)", async () => {
     render(<UserMenu username="juangarcia" image="" />);
-    expect(screen.getByRole("link", { name: "Editar perfil" })).toBeInTheDocument();
+    await openMenu("juangarcia");
+    expect(screen.getByRole("menuitem", { name: "Editar perfil" })).toBeInTheDocument();
   });
 });

--- a/src/app/logout-button.tsx
+++ b/src/app/logout-button.tsx
@@ -2,6 +2,7 @@
 
 import { signOut } from "next-auth/react";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
 
 interface Props {
   username: string;
@@ -10,32 +11,66 @@ interface Props {
 }
 
 export function UserMenu({ username, image, isAdmin = false }: Props) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onPointer = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", onPointer);
+    document.addEventListener("keydown", onKey);
+    return () => {
+      document.removeEventListener("mousedown", onPointer);
+      document.removeEventListener("keydown", onKey);
+    };
+  }, [open]);
+
   return (
-    <div className="relative group">
-      <button className="flex items-center gap-2 cursor-pointer">
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        className="flex items-center gap-2 cursor-pointer"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+      >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={image} alt="" className="w-7 h-7 rounded-full" />
         <span className="font-mono text-xs text-pdep-200">{username}</span>
       </button>
 
-      <div className="absolute right-0 top-full pt-2 hidden group-hover:block">
-        <div className="bg-pdep-800 border border-pdep-700 rounded-lg shadow-lg py-1 min-w-[140px]">
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 top-full mt-2 bg-pdep-800 border border-pdep-700 rounded-lg shadow-lg py-1 min-w-[160px]"
+        >
           {!isAdmin && (
             <Link
               href="/perfil"
+              role="menuitem"
+              onClick={() => setOpen(false)}
               className="block px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
             >
               Editar perfil
             </Link>
           )}
           <button
+            type="button"
+            role="menuitem"
             onClick={() => signOut({ callbackUrl: "/" })}
             className="w-full text-left px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
           >
             Salir
           </button>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/app/logout-button.tsx
+++ b/src/app/logout-button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { signOut } from "next-auth/react";
+import Link from "next/link";
 
 interface Props {
   username: string;
@@ -20,12 +21,12 @@ export function UserMenu({ username, image, isAdmin = false }: Props) {
       <div className="absolute right-0 top-full pt-2 hidden group-hover:block">
         <div className="bg-pdep-800 border border-pdep-700 rounded-lg shadow-lg py-1 min-w-[140px]">
           {!isAdmin && (
-            <a
+            <Link
               href="/perfil"
               className="block px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
             >
               Editar perfil
-            </a>
+            </Link>
           )}
           <button
             onClick={() => signOut({ callbackUrl: "/" })}

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -78,83 +78,84 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         </svg>
       </button>
 
-      {open && (
-        <>
-          <div
-            className="md:hidden fixed inset-0 bg-black/50 z-40"
+      <div
+        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      <aside
+        id="mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menú de navegación"
+        inert={!open}
+        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+          <span className="font-bold text-white">Menú</span>
+          <button
+            type="button"
+            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+            aria-label="Cerrar menú"
             onClick={() => setOpen(false)}
-            aria-hidden="true"
-          />
-
-          <aside
-            id="mobile-drawer"
-            role="dialog"
-            aria-modal="true"
-            aria-label="Menú de navegación"
-            className="md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl"
           >
-            <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
-              <span className="font-bold text-white">Menú</span>
-              <button
-                type="button"
-                className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
-                aria-label="Cerrar menú"
-                onClick={() => setOpen(false)}
-              >
-                <svg
-                  xmlns="http://www.w3.org/2000/svg"
-                  fill="none"
-                  viewBox="0 0 24 24"
-                  strokeWidth={2}
-                  stroke="currentColor"
-                  className="w-6 h-6"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    d="M6 6l12 12M6 18L18 6"
-                  />
-                </svg>
-              </button>
-            </div>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 6l12 12M6 18L18 6"
+              />
+            </svg>
+          </button>
+        </div>
 
-            <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={image} alt="" className="w-10 h-10 rounded-full" />
-              <span className="font-mono text-sm text-pdep-200 truncate">
-                {username}
-              </span>
-            </div>
+        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" className="w-10 h-10 rounded-full" />
+          <span className="font-mono text-sm text-pdep-200 truncate">
+            {username}
+          </span>
+        </div>
 
-            <nav className="flex flex-col py-2">
-              {links.map((l) => (
-                <Link
-                  key={l.href}
-                  href={l.href}
-                  className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
-                >
-                  {l.label}
-                </Link>
-              ))}
-              {!isAdmin && (
-                <Link
-                  href="/perfil"
-                  className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-                >
-                  Editar perfil
-                </Link>
-              )}
-              <button
-                type="button"
-                className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-                onClick={() => signOut({ callbackUrl: "/" })}
-              >
-                Salir
-              </button>
-            </nav>
-          </aside>
-        </>
-      )}
+        <nav className="flex flex-col py-2">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+            >
+              {l.label}
+            </Link>
+          ))}
+          {!isAdmin && (
+            <Link
+              href="/perfil"
+              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            >
+              Editar perfil
+            </Link>
+          )}
+          <button
+            type="button"
+            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            Salir
+          </button>
+        </nav>
+      </aside>
     </>
   );
 }

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -78,83 +78,83 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         </svg>
       </button>
 
-      <div
-        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
-          open ? "opacity-100" : "opacity-0 pointer-events-none"
-        }`}
-        onClick={() => setOpen(false)}
-        aria-hidden="true"
-      />
-
-      <aside
-        id="mobile-drawer"
-        role="dialog"
-        aria-modal="true"
-        aria-label="Menú de navegación"
-        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
-          open ? "translate-x-0" : "translate-x-full"
-        }`}
-      >
-        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
-          <span className="font-bold text-white">Menú</span>
-          <button
-            type="button"
-            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
-            aria-label="Cerrar menú"
+      {open && (
+        <>
+          <div
+            className="md:hidden fixed inset-0 bg-black/50 z-40"
             onClick={() => setOpen(false)}
-          >
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              fill="none"
-              viewBox="0 0 24 24"
-              strokeWidth={2}
-              stroke="currentColor"
-              className="w-6 h-6"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                d="M6 6l12 12M6 18L18 6"
-              />
-            </svg>
-          </button>
-        </div>
+            aria-hidden="true"
+          />
 
-        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={image} alt="" className="w-10 h-10 rounded-full" />
-          <span className="font-mono text-sm text-pdep-200 truncate">
-            {username}
-          </span>
-        </div>
-
-        <nav className="flex flex-col py-2">
-          {links.map((l) => (
-            <Link
-              key={l.href}
-              href={l.href}
-              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
-            >
-              {l.label}
-            </Link>
-          ))}
-          {!isAdmin && (
-            <Link
-              href="/perfil"
-              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-            >
-              Editar perfil
-            </Link>
-          )}
-          <button
-            type="button"
-            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
-            onClick={() => signOut({ callbackUrl: "/" })}
+          <aside
+            id="mobile-drawer"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Menú de navegación"
+            className="md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl"
           >
-            Salir
-          </button>
-        </nav>
-      </aside>
+            <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+              <span className="font-bold text-white">Menú</span>
+              <button
+                type="button"
+                className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+                aria-label="Cerrar menú"
+                onClick={() => setOpen(false)}
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth={2}
+                  stroke="currentColor"
+                  className="w-6 h-6"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    d="M6 6l12 12M6 18L18 6"
+                  />
+                </svg>
+              </button>
+            </div>
+
+            <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={image} alt="" className="w-10 h-10 rounded-full" />
+              <span className="font-mono text-sm text-pdep-200 truncate">
+                {username}
+              </span>
+            </div>
+
+            <nav className="flex flex-col py-2">
+              {links.map((l) => (
+                <Link
+                  key={l.href}
+                  href={l.href}
+                  className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+                >
+                  {l.label}
+                </Link>
+              ))}
+              {!isAdmin && (
+                <Link
+                  href="/perfil"
+                  className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+                >
+                  Editar perfil
+                </Link>
+              )}
+              <button
+                type="button"
+                className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+                onClick={() => signOut({ callbackUrl: "/" })}
+              >
+                Salir
+              </button>
+            </nav>
+          </aside>
+        </>
+      )}
     </>
   );
 }

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -28,14 +28,45 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
 
   useEffect(() => {
     if (!open) return;
+    const drawer = document.getElementById("mobile-drawer");
+    if (!drawer) return;
+
+    const previousActive = document.activeElement as HTMLElement | null;
+    const focusableSelector =
+      'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])';
+    const getFocusables = () =>
+      Array.from(drawer.querySelectorAll<HTMLElement>(focusableSelector));
+
+    getFocusables()[0]?.focus();
+
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") {
+        setOpen(false);
+        return;
+      }
+      if (e.key !== "Tab") return;
+      const items = getFocusables();
+      if (items.length === 0) return;
+      const first = items[0];
+      const last = items[items.length - 1];
+      const active = document.activeElement;
+      if (e.shiftKey && active === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && active === last) {
+        e.preventDefault();
+        first.focus();
+      }
     };
+
     document.addEventListener("keydown", onKey);
     document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
       document.body.style.overflow = "";
+      if (previousActive && document.contains(previousActive)) {
+        previousActive.focus();
+      }
     };
   }, [open]);
 

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -1,0 +1,160 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { signOut } from "next-auth/react";
+import { UserMenu } from "./logout-button";
+
+export interface NavLink {
+  href: string;
+  label: string;
+}
+
+interface Props {
+  links: NavLink[];
+  username: string;
+  image: string;
+  isAdmin: boolean;
+}
+
+export function NavMenu({ links, username, image, isAdmin }: Props) {
+  const [open, setOpen] = useState(false);
+  const pathname = usePathname();
+
+  useEffect(() => {
+    setOpen(false);
+  }, [pathname]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("keydown", onKey);
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  return (
+    <>
+      <div className="hidden md:flex items-center gap-6 text-sm">
+        {links.map((l) => (
+          <Link
+            key={l.href}
+            href={l.href}
+            className="hover:text-pdep-200 transition-colors"
+          >
+            {l.label}
+          </Link>
+        ))}
+        <UserMenu username={username} image={image} isAdmin={isAdmin} />
+      </div>
+
+      <button
+        type="button"
+        className="md:hidden p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+        aria-label="Abrir menú"
+        aria-expanded={open}
+        aria-controls="mobile-drawer"
+        onClick={() => setOpen(true)}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="w-6 h-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
+          />
+        </svg>
+      </button>
+
+      <div
+        className={`md:hidden fixed inset-0 bg-black/50 z-40 transition-opacity ${
+          open ? "opacity-100" : "opacity-0 pointer-events-none"
+        }`}
+        onClick={() => setOpen(false)}
+        aria-hidden="true"
+      />
+
+      <aside
+        id="mobile-drawer"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Menú de navegación"
+        className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
+          open ? "translate-x-0" : "translate-x-full"
+        }`}
+      >
+        <div className="flex items-center justify-between h-14 px-4 border-b border-pdep-800">
+          <span className="font-bold text-white">Menú</span>
+          <button
+            type="button"
+            className="p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+            aria-label="Cerrar menú"
+            onClick={() => setOpen(false)}
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={2}
+              stroke="currentColor"
+              className="w-6 h-6"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M6 6l12 12M6 18L18 6"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-3 px-4 py-4 border-b border-pdep-800">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={image} alt="" className="w-10 h-10 rounded-full" />
+          <span className="font-mono text-sm text-pdep-200 truncate">
+            {username}
+          </span>
+        </div>
+
+        <nav className="flex flex-col py-2">
+          {links.map((l) => (
+            <Link
+              key={l.href}
+              href={l.href}
+              className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
+            >
+              {l.label}
+            </Link>
+          ))}
+          {!isAdmin && (
+            <Link
+              href="/perfil"
+              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            >
+              Editar perfil
+            </Link>
+          )}
+          <button
+            type="button"
+            className="text-left px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+            onClick={() => signOut({ callbackUrl: "/" })}
+          >
+            Salir
+          </button>
+        </nav>
+      </aside>
+    </>
+  );
+}

--- a/src/app/nav.tsx
+++ b/src/app/nav.tsx
@@ -1,9 +1,23 @@
 import { getCurrentUser } from "@/lib/session";
 import Link from "next/link";
-import { UserMenu } from "./logout-button";
+import { NavMenu, type NavLink } from "./nav-menu";
 
 export async function Nav() {
   const user = await getCurrentUser();
+
+  const links: NavLink[] = user
+    ? [
+        { href: "/dashboard", label: "Mis TPs" },
+        ...(user.isAdmin
+          ? [
+              { href: "/admin/assignments", label: "Assignments" },
+              { href: "/admin/grupos", label: "Grupos" },
+              { href: "/admin/comisiones", label: "Comisiones" },
+              { href: "/admin/alumnos", label: "Alumnos" },
+            ]
+          : []),
+      ]
+    : [];
 
   return (
     <nav className="bg-pdep-900 text-white">
@@ -12,47 +26,14 @@ export async function Nav() {
           PdeP <span className="font-light text-pdep-200">Classroom</span>
         </Link>
 
-        <div className="flex items-center gap-6 text-sm">
-          {user && (
-            <>
-              <Link
-                href="/dashboard"
-                className="hover:text-pdep-200 transition-colors"
-              >
-                Mis TPs
-              </Link>
-              {user.isAdmin && (
-                <>
-                  <Link
-                    href="/admin/assignments"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Assignments
-                  </Link>
-                  <Link
-                    href="/admin/grupos"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Grupos
-                  </Link>
-                  <Link
-                    href="/admin/comisiones"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Comisiones
-                  </Link>
-                  <Link
-                    href="/admin/alumnos"
-                    className="hover:text-pdep-200 transition-colors"
-                  >
-                    Alumnos
-                  </Link>
-                </>
-              )}
-              <UserMenu username={user.githubUsername} image={user.image} isAdmin={user.isAdmin} />
-            </>
-          )}
-        </div>
+        {user && (
+          <NavMenu
+            links={links}
+            username={user.githubUsername}
+            image={user.image}
+            isAdmin={user.isAdmin}
+          />
+        )}
       </div>
     </nav>
   );

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -7,7 +7,6 @@ import type { Alumno } from "@/domain/entities";
 
 const mockAuth = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
-const mockGetComisionActiva = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -16,12 +15,8 @@ vi.mock("@/lib/auth", () => ({
   auth: () => mockAuth(),
 }));
 
-vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
-}));
-
 vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -29,11 +24,12 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/app/components/AlumnoForm", () => ({
-  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; legajo: string } }) => (
+  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; legajo?: string; email?: string } }) => (
     <div
       data-testid="alumno-form"
       data-github={defaultValues.githubUsername}
-      data-legajo={defaultValues.legajo}
+      data-legajo={defaultValues.legajo ?? ""}
+      data-email={defaultValues.email ?? ""}
     />
   ),
 }));
@@ -76,7 +72,6 @@ describe("Perfil page", () => {
     mockRedirect.mockImplementation((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     });
-    mockGetComisionActiva.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
@@ -87,7 +82,7 @@ describe("Perfil page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login");
     });
 
-    it("redirige a /registro si el alumno no está en la planilla", async () => {
+    it("redirige a /registro si el alumno no está en la DB", async () => {
       mockAuth.mockResolvedValue(makeSession("nuevo"));
       mockGetAlumnoByGithub.mockResolvedValue(null);
 
@@ -119,31 +114,12 @@ describe("Perfil page", () => {
       const html = renderToStaticMarkup(element);
       expect(html).toContain('data-github="juangarcia"');
       expect(html).toContain('data-legajo="12345"');
+      expect(html).toContain('data-email="juan@example.com"');
     });
 
-    it("consulta getAlumnoByGithub con el username de la sesión", async () => {
+    it("consulta getAlumnoByGithub de la DB con el username de la sesión", async () => {
       await PerfilPage();
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
-        "juangarcia",
-        undefined,
-        undefined
-      );
-    });
-
-    it("usa el spreadsheetId y columnConfig de la comisión activa", async () => {
-      const comision = {
-        spreadsheetId: "sheet-abc",
-        columnConfig: { sheetName: "Listado", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4, comision: 5 },
-      };
-      mockGetComisionActiva.mockResolvedValue(comision);
-
-      await PerfilPage();
-
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
-        "juangarcia",
-        "sheet-abc",
-        comision.columnConfig
-      );
+      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("juangarcia");
     });
   });
 });

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,6 +1,5 @@
 import { auth } from "@/lib/auth";
-import { getAlumnoByGithub } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { getAlumnoByGithub } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
 import type { PdepUser } from "@/types";
@@ -12,13 +11,7 @@ export default async function PerfilPage() {
   const pdepUser = (session as unknown as { pdepUser: PdepUser }).pdepUser;
   const githubUsername = pdepUser.githubUsername;
 
-  const comisionActiva = await getComisionActiva();
-  const alumno = await getAlumnoByGithub(
-    githubUsername,
-    comisionActiva?.spreadsheetId,
-    comisionActiva?.columnConfig
-  );
-
+  const alumno = await getAlumnoByGithub(githubUsername);
   if (!alumno) redirect("/registro");
 
   return (

--- a/src/app/registro/page.test.tsx
+++ b/src/app/registro/page.test.tsx
@@ -5,9 +5,9 @@ import type { PdepUser } from "@/types";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockAuth = vi.fn();
-const mockGetAlumnoByGithub = vi.fn();
+const mockGetAlumnoDeSheets = vi.fn();
+const mockGetAlumnoDeDB = vi.fn();
 const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -17,12 +17,12 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 vi.mock("@/lib/sheets", () => ({
-  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoDeSheets(...args),
 }));
 
 vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoDeDB(...args),
   getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (...args: unknown[]) => mockUpsertAlumno(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -30,12 +30,21 @@ vi.mock("next/navigation", () => ({
 }));
 
 vi.mock("@/app/components/AlumnoForm", () => ({
-  AlumnoForm: ({ defaultValues }: { defaultValues: { githubUsername: string; email: string; nombre: string; apellido: string } }) => (
+  AlumnoForm: ({
+    defaultValues,
+    submitLabel,
+  }: {
+    defaultValues: { githubUsername: string; email: string; nombre: string; apellido: string; legajo?: string };
+    submitLabel: string;
+  }) => (
     <div
       data-testid="alumno-form"
       data-github={defaultValues.githubUsername}
       data-email={defaultValues.email}
       data-nombre={defaultValues.nombre}
+      data-apellido={defaultValues.apellido}
+      data-legajo={defaultValues.legajo ?? ""}
+      data-submit-label={submitLabel}
     />
   ),
 }));
@@ -67,7 +76,8 @@ describe("Registro page", () => {
       throw new Error(`REDIRECT:${url}`);
     });
     mockGetComisionActiva.mockResolvedValue(null);
-    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockGetAlumnoDeDB.mockResolvedValue(null);
+    mockGetAlumnoDeSheets.mockResolvedValue(null);
   });
 
   describe("redirecciones", () => {
@@ -78,132 +88,208 @@ describe("Registro page", () => {
       expect(mockRedirect).toHaveBeenCalledWith("/login");
     });
 
-    it("redirige a /dashboard si el alumno ya está registrado", async () => {
-      mockAuth.mockResolvedValue(makeSession("juangarcia"));
-      mockGetAlumnoByGithub.mockResolvedValue({
+    it("redirige a /dashboard si el alumno ya confirmó sus datos para la comisión activa", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
         legajo: "12345",
         nombre: "Juan",
-        apellido: "Garcia",
-        githubUsername: "juangarcia",
-        email: "juan@example.com",
-        comision: "miércoles noche",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
       });
 
       await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      expect(mockRedirect).toHaveBeenCalledWith("/dashboard");
     });
 
-    it("hace upsert en la DB cuando el alumno es reconocido desde la planilla", async () => {
-      const alumno = {
+    it("NO redirige a /dashboard si el alumno confirmó en una comisión distinta (recursante)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
         legajo: "12345",
         nombre: "Juan",
-        apellido: "Garcia",
-        githubUsername: "juangarcia",
-        email: "juan@example.com",
-      };
-      mockAuth.mockResolvedValue(makeSession("juangarcia"));
-      mockGetAlumnoByGithub.mockResolvedValue(alumno);
-
-      await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      // comisionActiva es null en el mock → comision: undefined en el upsert
-      expect(mockUpsertAlumno).toHaveBeenCalledWith({ ...alumno, comision: undefined });
-    });
-
-    it("hace upsert con la comisión activa cuando existe", async () => {
-      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
-      mockGetComisionActiva.mockResolvedValue(comision);
-      const alumno = { legajo: "12345", nombre: "Juan", apellido: "G", githubUsername: "j", email: "j@j.com" };
-      mockAuth.mockResolvedValue(makeSession("j"));
-      mockGetAlumnoByGithub.mockResolvedValue(alumno);
-
-      await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
-      expect(mockUpsertAlumno).toHaveBeenCalledWith({ ...alumno, comision });
-    });
-
-    it("no hace upsert si el alumno no está en la planilla", async () => {
-      mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
 
       await RegistroPage();
-      expect(mockUpsertAlumno).not.toHaveBeenCalled();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("NO redirige a /dashboard si el alumno nunca confirmó (registroConfirmadoEn null)", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: null,
+      });
+
+      await RegistroPage();
+      expect(mockRedirect).not.toHaveBeenCalled();
+    });
+
+    it("NO redirige si no hay comisión activa aunque el alumno exista en DB", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: null,
+      });
+
+      await RegistroPage();
+      expect(mockRedirect).not.toHaveBeenCalled();
     });
   });
 
-  describe("render cuando el alumno no está registrado", () => {
-    beforeEach(() => {
+  describe("prefill del formulario", () => {
+    it("usa los datos de DB cuando el alumno existe (recursante — gana DB)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "99999",
+        nombre: "Juan Carlos",
+        apellido: "García",
+        githubUsername: "juan",
+        email: "personal@gmail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
+      // Sheets tiene otro email y otro legajo (el admin rearmó la planilla) — debe ganar DB
+      mockGetAlumnoDeSheets.mockResolvedValue({
+        legajo: "11111",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "institucional@utn.edu.ar",
+      });
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-legajo="99999"');
+      expect(html).toContain('data-email="personal@gmail.com"');
+      expect(html).toContain('data-nombre="Juan Carlos"');
+      expect(html).toContain('data-apellido="García"');
+    });
+
+    it("usa los datos de Sheets cuando no hay DB (nuevo alumno pre-cargado por admin)", async () => {
+      const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("nuevo"));
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue({
+        legajo: "54321",
+        nombre: "María",
+        apellido: "Pérez",
+        githubUsername: "nuevo",
+        email: "maria@utn.edu.ar",
+      });
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-legajo="54321"');
+      expect(html).toContain('data-email="maria@utn.edu.ar"');
+      expect(html).toContain('data-nombre="María"');
+      expect(html).toContain('data-apellido="Pérez"');
+    });
+
+    it("cae a la sesión cuando no hay DB ni Sheets (nuevo sin pre-carga)", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
       mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
-    });
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue(null);
 
-    it("muestra el título de registro", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain("Registro");
-    });
-
-    it("muestra el nombre de usuario de GitHub vinculado", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain("nuevouser");
-    });
-
-    it("renderiza el AlumnoForm", async () => {
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
-      expect(html).toContain('data-testid="alumno-form"');
-    });
-
-    it("pasa el githubUsername correcto al AlumnoForm", async () => {
       const element = await RegistroPage();
       const html = renderToStaticMarkup(element);
       expect(html).toContain('data-github="nuevouser"');
-    });
-
-    it("pasa el email de la sesión al AlumnoForm", async () => {
-      const session = makeSession("nuevouser");
-      mockAuth.mockResolvedValue(session);
-
-      const element = await RegistroPage();
-      const html = renderToStaticMarkup(element);
       expect(html).toContain('data-email="test@example.com"');
+      expect(html).toContain('data-nombre="Test"');
+      expect(html).toContain('data-apellido="User"');
+      expect(html).toContain('data-legajo=""');
     });
 
-    it("pasa el nombre spliteado de la sesión al AlumnoForm", async () => {
+    it("no crashea si el nombre de sesión está vacío", async () => {
       const session = makeSession("nuevouser");
+      session.user.name = "";
       mockAuth.mockResolvedValue(session);
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+      mockGetAlumnoDeSheets.mockResolvedValue(null);
 
       const element = await RegistroPage();
       const html = renderToStaticMarkup(element);
-      // "Test User" → nombre: "Test", apellido: "User"
-      expect(html).toContain('data-nombre="Test"');
+      expect(html).toContain('data-nombre=""');
+      expect(html).toContain('data-apellido=""');
+    });
+  });
+
+  describe("copy y submit label", () => {
+    it("muestra 'Registrarme' para alumno nuevo", async () => {
+      mockAuth.mockResolvedValue(makeSession("nuevo"));
+      mockGetAlumnoDeDB.mockResolvedValue(null);
+
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-submit-label="Registrarme"');
+      expect(html).toContain("Completá tus datos");
     });
 
-    it("consulta por el username correcto en sheets", async () => {
-      await RegistroPage();
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("nuevouser", undefined, undefined);
-    });
+    it("muestra 'Confirmar datos' para recursante (ya está en DB pero no confirmó esta comisión)", async () => {
+      const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
+      mockGetComisionActiva.mockResolvedValue(comision);
+      mockAuth.mockResolvedValue(makeSession("juan"));
+      mockGetAlumnoDeDB.mockResolvedValue({
+        legajo: "12345",
+        nombre: "Juan",
+        apellido: "G",
+        githubUsername: "juan",
+        email: "juan@mail.com",
+        registroConfirmadoEn: { id: "c1" },
+      });
 
-    it("usa el spreadsheetId y columnConfig de la comisión activa", async () => {
+      const element = await RegistroPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-submit-label="Confirmar datos"');
+      expect(html).toContain("Confirmá tus datos");
+    });
+  });
+
+  describe("consulta a Sheets", () => {
+    it("consulta Sheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
       const comision = {
+        id: "c1",
         spreadsheetId: "sheet-xyz",
-        columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4, comision: 5 },
+        columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
       };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("nuevouser"));
-      mockGetAlumnoByGithub.mockResolvedValue(null);
 
       await RegistroPage();
 
-      expect(mockGetAlumnoByGithub).toHaveBeenCalledWith(
+      expect(mockGetAlumnoDeSheets).toHaveBeenCalledWith(
         "nuevouser",
         "sheet-xyz",
         comision.columnConfig
       );
     });
 
-    it("no redirige a /login ni /dashboard", async () => {
+    it("consulta la DB con el username de la sesión", async () => {
+      mockAuth.mockResolvedValue(makeSession("miuser"));
+
       await RegistroPage();
-      expect(mockRedirect).not.toHaveBeenCalled();
+      expect(mockGetAlumnoDeDB).toHaveBeenCalledWith("miuser");
     });
   });
 });

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -30,11 +30,14 @@ export default async function RegistroPage() {
   // Prefill: gana lo que el alumno confirmó alguna vez (DB); si no, lo que
   // pre-cargó el admin en la planilla (Sheets); y como último recurso, lo que
   // viene del perfil de GitHub de la sesión.
-  const alumnoSheets = await getAlumnoDeSheets(
-    githubUsername,
-    comisionActiva?.spreadsheetId,
-    comisionActiva?.columnConfig
-  );
+  // Sin comisión activa no hay planilla que leer; caemos al prefill de DB/sesión.
+  const alumnoSheets = comisionActiva
+    ? await getAlumnoDeSheets(
+        githubUsername,
+        comisionActiva.spreadsheetId,
+        comisionActiva.columnConfig
+      )
+    : undefined;
 
   const nameParts = (session.user?.name ?? "").split(" ").filter(Boolean);
   const defaultNombre = nameParts.slice(0, -1).join(" ") || nameParts[0] || "";

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -1,9 +1,11 @@
 import { auth } from "@/lib/auth";
-import { getAlumnoByGithub } from "@/lib/sheets";
-import { getComisionActiva } from "@/lib/repositories";
+import { getAlumnoByGithub as getAlumnoDeSheets } from "@/lib/sheets";
+import {
+  getAlumnoByGithub as getAlumnoDeDB,
+  getComisionActiva,
+} from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
-import { upsertAlumno } from "@/lib/repositories";
 import type { PdepUser } from "@/types";
 
 export default async function RegistroPage() {
@@ -14,46 +16,61 @@ export default async function RegistroPage() {
   const githubUsername = pdepUser.githubUsername;
 
   const comisionActiva = await getComisionActiva();
+  const alumnoDB = await getAlumnoDeDB(githubUsername);
 
-  const existente = await getAlumnoByGithub(
+  // Si ya confirmó los datos para esta comisión, no tiene nada que hacer acá.
+  if (
+    alumnoDB &&
+    comisionActiva &&
+    alumnoDB.registroConfirmadoEn?.id === comisionActiva.id
+  ) {
+    redirect("/dashboard");
+  }
+
+  // Prefill: gana lo que el alumno confirmó alguna vez (DB); si no, lo que
+  // pre-cargó el admin en la planilla (Sheets); y como último recurso, lo que
+  // viene del perfil de GitHub de la sesión.
+  const alumnoSheets = await getAlumnoDeSheets(
     githubUsername,
     comisionActiva?.spreadsheetId,
     comisionActiva?.columnConfig
   );
-  if (existente) {
-    await upsertAlumno({ ...existente, comision: comisionActiva ?? undefined });
-    redirect("/dashboard");
-  }
 
-  // Split del nombre de GitHub en nombre/apellido como sugerencia
-  const parts = (session.user?.name ?? "").split(" ");
-  const defaultNombre = parts.slice(0, -1).join(" ") || parts[0] || "";
-  const defaultApellido = parts.length > 1 ? parts[parts.length - 1] : "";
+  const nameParts = (session.user?.name ?? "").split(" ").filter(Boolean);
+  const defaultNombre = nameParts.slice(0, -1).join(" ") || nameParts[0] || "";
+  const defaultApellido = nameParts.length > 1 ? nameParts[nameParts.length - 1] : "";
+
+  const defaultValues = {
+    githubUsername,
+    legajo: alumnoDB?.legajo ?? alumnoSheets?.legajo ?? "",
+    apellido: alumnoDB?.apellido ?? alumnoSheets?.apellido ?? defaultApellido,
+    nombre: alumnoDB?.nombre ?? alumnoSheets?.nombre ?? defaultNombre,
+    email: alumnoDB?.email ?? alumnoSheets?.email ?? session.user?.email ?? "",
+  };
+
+  const esRecursante = Boolean(alumnoDB);
 
   return (
     <div className="max-w-md mx-auto">
       <h1 className="text-2xl font-bold mb-2">Registro</h1>
       <p className="text-gray-500 text-sm mb-6">
-        Completá tus datos para registrarte en el curso. Tu usuario de GitHub
-        ya está vinculado:{" "}
+        {esRecursante
+          ? "Confirmá tus datos para esta cursada. "
+          : "Completá tus datos para registrarte en el curso. "}
+        Tu usuario de GitHub ya está vinculado:{" "}
         <span className="font-mono font-medium text-gray-700">
           {githubUsername}
         </span>
       </p>
 
       <AlumnoForm
-        defaultValues={{
-          githubUsername,
-          email: session.user?.email ?? "",
-          nombre: defaultNombre,
-          apellido: defaultApellido,
-        }}
+        defaultValues={defaultValues}
         apiEndpoint="/api/registro"
         method="POST"
         extraBody={{ githubUsername }}
         onSuccessRedirect="/dashboard"
-        submitLabel="Registrarme"
-        successMessage="¡Registro exitoso! Redirigiendo al dashboard…"
+        submitLabel={esRecursante ? "Confirmar datos" : "Registrarme"}
+        successMessage="¡Listo! Redirigiendo al dashboard…"
       />
     </div>
   );

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -51,6 +51,9 @@ export default async function RegistroPage() {
     email: alumnoDB?.email ?? alumnoSheets?.email ?? session.user?.email ?? "",
   };
 
+  // Alumno registrado en la DB pero no en la comisión... Entonces le saco los datos 
+  // para confirmar nuevamente los datos de la nueva cursada
+  // pudo haber cambiado email, etc
   const esRecursante = Boolean(alumnoDB);
 
   return (

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -25,6 +25,11 @@ export class Alumno {
   @ManyToOne(() => Comision, { nullable: true })
   comision?: Comision;
 
+  // Marca la comisión en la que el alumno confirmó sus datos por última vez.
+  // Si no coincide con la comisión activa, se le pide re-confirmar en /registro.
+  @ManyToOne(() => Comision, { nullable: true })
+  registroConfirmadoEn?: Comision;
+
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;
   }

--- a/src/domain/entities/Comision.ts
+++ b/src/domain/entities/Comision.ts
@@ -23,7 +23,7 @@ export class Comision {
   @Property({ type: 'boolean', default: false })
   activa: boolean = false;
 
-  @Property({ type: "json", nullable: true })
+  @Property({ type: "json" })
   columnConfig: ColumnConfig = { ...DEFAULT_COLUMN_CONFIG };
 
   @OneToMany("Assignment", "comision")

--- a/src/instrumentation.test.ts
+++ b/src/instrumentation.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { assertGoogleGroupsConfig } from "./instrumentation";
+
+// ── Tests ────────────────────────────────────────────────────
+// Esta assertion corre al boot desde register() para frenar el server
+// si la config es incoherente — antes de que un alumno reciba el error
+// de misconfig como respuesta del registro.
+
+describe("assertGoogleGroupsConfig", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("no tira si ninguna env var está seteada (feature desactivada)", () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+
+  it("no tira si ambas env vars están seteadas", () => {
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+
+  it("tira si GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no", () => {
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
+    expect(() => assertGoogleGroupsConfig()).toThrow(/GOOGLE_WORKSPACE_ADMIN_EMAIL/);
+  });
+
+  it("no tira si GOOGLE_WORKSPACE_ADMIN_EMAIL está seteada pero GOOGLE_GROUP_EMAIL no (feature desactivada)", () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+});

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,8 @@
+// Next.js ejecuta `register()` una única vez cuando el server arranca.
+// Lo usamos para validar combinaciones de env vars que si están rotas
+// preferimos que el deploy falle ahora y no en la primera request.
+export async function register() {
+  if (process.env.NEXT_RUNTIME !== "nodejs") return;
+  const { assertGoogleGroupsConfig } = await import("@/lib/googleGroups");
+  assertGoogleGroupsConfig();
+}

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,8 +1,25 @@
 // Next.js ejecuta `register()` una única vez cuando el server arranca.
 // Lo usamos para validar combinaciones de env vars que si están rotas
 // preferimos que el deploy falle ahora y no en la primera request.
+//
+// Importante: este archivo NO puede importar módulos que dependan de
+// googleapis (u otros paquetes Node-only). Next bundlea instrumentation
+// también para el Edge runtime, que no tiene los módulos nativos
+// `https`/`net`/`http` que esas librerías usan — y webpack analiza los
+// imports estáticamente aunque el código esté detrás de un guard de
+// runtime. Por eso la validación vive inline acá.
 export async function register() {
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
-  const { assertGoogleGroupsConfig } = await import("@/lib/googleGroups");
   assertGoogleGroupsConfig();
+}
+
+export function assertGoogleGroupsConfig(): void {
+  const groupEmail = process.env.GOOGLE_GROUP_EMAIL?.trim();
+  const adminEmail = process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim();
+  if (groupEmail && !adminEmail) {
+    throw new Error(
+      "Configuración inválida: GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no. " +
+        "La suscripción al grupo requiere domain-wide delegation — configurá ambas o ninguna."
+    );
+  }
 }

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -1,0 +1,43 @@
+import GitHub from "next-auth/providers/github";
+import type { NextAuthConfig } from "next-auth";
+import type { PdepUser } from "@/types";
+
+const adminUsernames = (process.env.ADMIN_GITHUB_USERNAMES ?? "")
+  .split(",")
+  .map((u) => u.trim().toLowerCase())
+  .filter(Boolean);
+
+export const authConfig: NextAuthConfig = {
+  providers: [
+    GitHub({
+      clientId: process.env.GITHUB_CLIENT_ID!,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+      authorization: { params: { scope: "read:user" } },
+    }),
+  ],
+
+  callbacks: {
+    async jwt({ token, profile }) {
+      if (profile) {
+        token.githubUsername = (profile as { login?: string }).login ?? "";
+      }
+      return token;
+    },
+
+    async session({ session, token }) {
+      const ghUser = (token.githubUsername as string) ?? "";
+      const pdepUser: PdepUser = {
+        githubUsername: ghUser,
+        name: session.user?.name ?? ghUser,
+        image: session.user?.image ?? "",
+        isAdmin: adminUsernames.includes(ghUser.toLowerCase()),
+      };
+      (session as unknown as { pdepUser: PdepUser }).pdepUser = pdepUser;
+      return session;
+    },
+  },
+
+  pages: {
+    signIn: "/login",
+  },
+};

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,46 +1,4 @@
 import NextAuth from "next-auth";
-import GitHub from "next-auth/providers/github";
-import type { PdepUser } from "@/types";
+import { authConfig } from "./auth.config";
 
-const adminUsernames = (process.env.ADMIN_GITHUB_USERNAMES ?? "")
-  .split(",")
-  .map((u) => u.trim().toLowerCase())
-  .filter(Boolean);
-
-export const { handlers, signIn, signOut, auth } = NextAuth({
-  providers: [
-    GitHub({
-      clientId: process.env.GITHUB_CLIENT_ID!,
-      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
-      // Pedimos scope de lectura para saber el username
-      authorization: { params: { scope: "read:user" } },
-    }),
-  ],
-
-  callbacks: {
-    async jwt({ token, profile }) {
-      // En el primer login, guardamos el username de GitHub
-      if (profile) {
-        token.githubUsername = (profile as { login?: string }).login ?? "";
-      }
-      return token;
-    },
-
-    async session({ session, token }) {
-      const ghUser = (token.githubUsername as string) ?? "";
-      const pdepUser: PdepUser = {
-        githubUsername: ghUser,
-        name: session.user?.name ?? ghUser,
-        image: session.user?.image ?? "",
-        isAdmin: adminUsernames.includes(ghUser.toLowerCase()),
-      };
-      // Inyectamos en la session
-      (session as unknown as { pdepUser: PdepUser }).pdepUser = pdepUser;
-      return session;
-    },
-  },
-
-  pages: {
-    signIn: "/login",
-  },
-});
+export const { handlers, signIn, signOut, auth } = NextAuth(authConfig);

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockMembersInsert = vi.fn();
+const mockJWT = vi.fn();
+
+vi.mock("googleapis", () => ({
+  google: {
+    auth: {
+      JWT: function (...args: unknown[]) {
+        return mockJWT(...args);
+      },
+    },
+    admin: () => ({
+      members: { insert: (...args: unknown[]) => mockMembersInsert(...args) },
+    }),
+  },
+}));
+
+import { agregarMiembroAGrupo, assertGoogleGroupsConfig } from "./googleGroups";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+// Service account JSON mínimo, base64. El contenido no importa más allá
+// de poder parsearlo como JSON válido.
+const FAKE_SA_KEY = Buffer.from(
+  JSON.stringify({
+    client_email: "sa@proyecto.iam.gserviceaccount.com",
+    private_key: "FAKE_PRIVATE_KEY",
+  })
+).toString("base64");
+
+// Emula un error tipo `GaxiosError` de la Admin SDK.
+function gaxiosError(code: number, reason: string, message = "boom") {
+  return Object.assign(new Error(message), {
+    code,
+    errors: [{ reason, message }],
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("agregarMiembroAGrupo", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = FAKE_SA_KEY;
+    mockMembersInsert.mockResolvedValue({ data: {} });
+    mockJWT.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL no está configurada", async () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "skipped" });
+    expect(mockMembersInsert).not.toHaveBeenCalled();
+  });
+
+  it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL está vacío", async () => {
+    process.env.GOOGLE_GROUP_EMAIL = "   ";
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "skipped" });
+    expect(mockMembersInsert).not.toHaveBeenCalled();
+  });
+
+  it("agrega el miembro al grupo con role MEMBER (happy path)", async () => {
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "added" });
+    expect(mockMembersInsert).toHaveBeenCalledWith({
+      groupKey: "pdep@googlegroups.com",
+      requestBody: { email: "juan@gmail.com", role: "MEMBER" },
+    });
+  });
+
+  it("impersona al admin del workspace (domain-wide delegation)", async () => {
+    await agregarMiembroAGrupo("juan@gmail.com");
+    expect(mockJWT).toHaveBeenCalledWith(
+      expect.objectContaining({
+        email: "sa@proyecto.iam.gserviceaccount.com",
+        subject: "admin@utn.edu.ar",
+        scopes: ["https://www.googleapis.com/auth/admin.directory.group.member"],
+      })
+    );
+  });
+
+  it("retorna 'already_member' cuando la API devuelve 409", async () => {
+    mockMembersInsert.mockRejectedValue(gaxiosError(409, "duplicate"));
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "already_member" });
+  });
+
+  it("retorna 'already_member' cuando el reason es 'duplicate' (aunque el code no sea 409)", async () => {
+    mockMembersInsert.mockRejectedValue(gaxiosError(400, "duplicate"));
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "already_member" });
+  });
+
+  it("retorna 'error' con mensaje cuando la API falla con otro código", async () => {
+    mockMembersInsert.mockRejectedValue(gaxiosError(403, "forbidden", "Sin permisos"));
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "error", error: "Sin permisos" });
+  });
+
+});
+
+// ── assertGoogleGroupsConfig ─────────────────────────────────
+// Esta función corre al boot desde instrumentation.ts — acá testeamos
+// que tire cuando la config es incoherente, para que el deploy falle
+// antes de que un alumno reciba un error en su cara.
+
+describe("assertGoogleGroupsConfig", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("no tira si ninguna env var está seteada (feature desactivada)", () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+
+  it("no tira si ambas env vars están seteadas", () => {
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+
+  it("tira si GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no", () => {
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
+    expect(() => assertGoogleGroupsConfig()).toThrow(
+      /GOOGLE_WORKSPACE_ADMIN_EMAIL/
+    );
+  });
+
+  it("no tira si GOOGLE_WORKSPACE_ADMIN_EMAIL está seteada pero GOOGLE_GROUP_EMAIL no (feature desactivada)", () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    expect(() => assertGoogleGroupsConfig()).not.toThrow();
+  });
+});

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -18,7 +18,7 @@ vi.mock("googleapis", () => ({
   },
 }));
 
-import { agregarMiembroAGrupo, assertGoogleGroupsConfig } from "./googleGroups";
+import { agregarMiembroAGrupo } from "./googleGroups";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -133,43 +133,4 @@ describe("agregarMiembroAGrupo", () => {
     expect(result).toEqual({ status: "error", error: "Sin permisos" });
   });
 
-});
-
-// ── assertGoogleGroupsConfig ─────────────────────────────────
-// Esta función corre al boot desde instrumentation.ts — acá testeamos
-// que tire cuando la config es incoherente, para que el deploy falle
-// antes de que un alumno reciba un error en su cara.
-
-describe("assertGoogleGroupsConfig", () => {
-  const ENV_BACKUP = { ...process.env };
-
-  afterEach(() => {
-    process.env = { ...ENV_BACKUP };
-  });
-
-  it("no tira si ninguna env var está seteada (feature desactivada)", () => {
-    delete process.env.GOOGLE_GROUP_EMAIL;
-    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
-    expect(() => assertGoogleGroupsConfig()).not.toThrow();
-  });
-
-  it("no tira si ambas env vars están seteadas", () => {
-    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
-    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
-    expect(() => assertGoogleGroupsConfig()).not.toThrow();
-  });
-
-  it("tira si GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no", () => {
-    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
-    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
-    expect(() => assertGoogleGroupsConfig()).toThrow(
-      /GOOGLE_WORKSPACE_ADMIN_EMAIL/
-    );
-  });
-
-  it("no tira si GOOGLE_WORKSPACE_ADMIN_EMAIL está seteada pero GOOGLE_GROUP_EMAIL no (feature desactivada)", () => {
-    delete process.env.GOOGLE_GROUP_EMAIL;
-    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
-    expect(() => assertGoogleGroupsConfig()).not.toThrow();
-  });
 });

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -74,10 +74,19 @@ describe("agregarMiembroAGrupo", () => {
   it("agrega el miembro al grupo con role MEMBER (happy path)", async () => {
     const result = await agregarMiembroAGrupo("juan@gmail.com");
     expect(result).toEqual({ status: "added" });
-    expect(mockMembersInsert).toHaveBeenCalledWith({
-      groupKey: "pdep@googlegroups.com",
-      requestBody: { email: "juan@gmail.com", role: "MEMBER" },
-    });
+    expect(mockMembersInsert).toHaveBeenCalledWith(
+      {
+        groupKey: "pdep@googlegroups.com",
+        requestBody: { email: "juan@gmail.com", role: "MEMBER" },
+      },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("pasa un AbortSignal con timeout para que la llamada no se cuelgue", async () => {
+    await agregarMiembroAGrupo("juan@gmail.com");
+    const opts = mockMembersInsert.mock.calls[0][1];
+    expect(opts.signal).toBeInstanceOf(AbortSignal);
   });
 
   it("impersona al admin del workspace (domain-wide delegation)", async () => {

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -91,14 +91,38 @@ describe("agregarMiembroAGrupo", () => {
     );
   });
 
-  it("retorna 'already_member' cuando la API devuelve 409", async () => {
+  it("retorna 'already_member' cuando la API devuelve 409 en err.code", async () => {
     mockMembersInsert.mockRejectedValue(gaxiosError(409, "duplicate"));
     const result = await agregarMiembroAGrupo("juan@gmail.com");
     expect(result).toEqual({ status: "already_member" });
   });
 
-  it("retorna 'already_member' cuando el reason es 'duplicate' (aunque el code no sea 409)", async () => {
+  it("retorna 'already_member' cuando la API devuelve 409 en err.status", async () => {
+    // googleapis a veces expone el status por err.status en vez de err.code
+    const err = Object.assign(new Error("Conflict"), { status: 409 });
+    mockMembersInsert.mockRejectedValue(err);
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "already_member" });
+  });
+
+  it("retorna 'already_member' cuando el reason 'duplicate' viene top-level en err.errors", async () => {
     mockMembersInsert.mockRejectedValue(gaxiosError(400, "duplicate"));
+    const result = await agregarMiembroAGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "already_member" });
+  });
+
+  it("retorna 'already_member' cuando el reason 'duplicate' viene anidado en response.data.error.errors", async () => {
+    const err = Object.assign(new Error("Member already exists"), {
+      code: 400,
+      response: {
+        data: {
+          error: {
+            errors: [{ reason: "duplicate", message: "Member already exists" }],
+          },
+        },
+      },
+    });
+    mockMembersInsert.mockRejectedValue(err);
     const result = await agregarMiembroAGrupo("juan@gmail.com");
     expect(result).toEqual({ status: "already_member" });
   });

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -1,0 +1,87 @@
+import { google } from "googleapis";
+
+// ── Config desde env ────────────────────────────────────────
+
+function getGroupEmail(): string | null {
+  return process.env.GOOGLE_GROUP_EMAIL?.trim() || null;
+}
+
+function getAdminSubject(): string | null {
+  return process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim() || null;
+}
+
+// Se llama al boot desde instrumentation.ts para frenar el deploy si la
+// config está incoherente — evita que un alumno reciba el error de
+// misconfig como respuesta del registro.
+export function assertGoogleGroupsConfig(): void {
+  const groupEmail = getGroupEmail();
+  const adminSubject = getAdminSubject();
+  if (groupEmail && !adminSubject) {
+    throw new Error(
+      "Configuración inválida: GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no. " +
+        "La suscripción al grupo requiere domain-wide delegation — configurá ambas o ninguna."
+    );
+  }
+}
+
+// ── Cliente de Admin Directory API ──────────────────────────
+// Agregar miembros a un Google Group requiere Domain-Wide Delegation:
+// el service account impersona a un admin del workspace.
+
+function getDirectoryClient() {
+  const subject = getAdminSubject();
+  if (!subject) {
+    throw new Error("GOOGLE_WORKSPACE_ADMIN_EMAIL no está configurada");
+  }
+
+  const keyJson = Buffer.from(
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY ?? "",
+    "base64"
+  ).toString("utf-8");
+  const credentials = JSON.parse(keyJson);
+
+  const auth = new google.auth.JWT({
+    email: credentials.client_email,
+    key: credentials.private_key,
+    scopes: ["https://www.googleapis.com/auth/admin.directory.group.member"],
+    subject,
+  });
+
+  return google.admin({ version: "directory_v1", auth });
+}
+
+// ── Suscribir alumno al grupo ───────────────────────────────
+
+export type AgregarMiembroResult =
+  | { status: "added" }
+  | { status: "already_member" }
+  | { status: "skipped" }
+  | { status: "error"; error: string };
+
+// Detecta el caso "el miembro ya existía en el grupo" a partir de la respuesta
+// de la API. Google devuelve 409 + reason "duplicate" para este caso.
+function isDuplicateError(e: unknown): boolean {
+  const err = e as { code?: number; errors?: { reason?: string }[] };
+  if (err.code === 409) return true;
+  return Boolean(err.errors?.some((x) => x.reason === "duplicate"));
+}
+
+export async function agregarMiembroAGrupo(
+  memberEmail: string
+): Promise<AgregarMiembroResult> {
+  const groupEmail = getGroupEmail();
+  if (!groupEmail) return { status: "skipped" };
+
+  try {
+    const admin = getDirectoryClient();
+    await admin.members.insert({
+      groupKey: groupEmail,
+      requestBody: { email: memberEmail, role: "MEMBER" },
+    });
+    return { status: "added" };
+  } catch (e) {
+    if (isDuplicateError(e)) return { status: "already_member" };
+    const msg = e instanceof Error ? e.message : "Error al suscribir al grupo";
+    return { status: "error", error: msg };
+  }
+}

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -72,10 +72,13 @@ export async function agregarMiembroAGrupo(
 
   try {
     const admin = getDirectoryClient();
-    await admin.members.insert({
-      groupKey: groupEmail,
-      requestBody: { email: memberEmail, role: "MEMBER" },
-    });
+    await admin.members.insert(
+      {
+        groupKey: groupEmail,
+        requestBody: { email: memberEmail, role: "MEMBER" },
+      },
+      { signal: AbortSignal.timeout(10_000) }
+    );
     return { status: "added" };
   } catch (e) {
     if (isDuplicateError(e)) return { status: "already_member" };

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -10,20 +10,6 @@ function getAdminSubject(): string | null {
   return process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim() || null;
 }
 
-// Se llama al boot desde instrumentation.ts para frenar el deploy si la
-// config está incoherente — evita que un alumno reciba el error de
-// misconfig como respuesta del registro.
-export function assertGoogleGroupsConfig(): void {
-  const groupEmail = getGroupEmail();
-  const adminSubject = getAdminSubject();
-  if (groupEmail && !adminSubject) {
-    throw new Error(
-      "Configuración inválida: GOOGLE_GROUP_EMAIL está seteada pero GOOGLE_WORKSPACE_ADMIN_EMAIL no. " +
-        "La suscripción al grupo requiere domain-wide delegation — configurá ambas o ninguna."
-    );
-  }
-}
-
 // ── Cliente de Admin Directory API ──────────────────────────
 // Agregar miembros a un Google Group requiere Domain-Wide Delegation:
 // el service account impersona a un admin del workspace.

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -59,11 +59,23 @@ export type AgregarMiembroResult =
   | { status: "error"; error: string };
 
 // Detecta el caso "el miembro ya existía en el grupo" a partir de la respuesta
-// de la API. Google devuelve 409 + reason "duplicate" para este caso.
+// de la API. Google devuelve 409 + reason "duplicate" para este caso, pero
+// googleapis expone el status por varias rutas (err.code, err.status) y los
+// errores detallados pueden venir top-level o anidados en response.data.error.
 function isDuplicateError(e: unknown): boolean {
-  const err = e as { code?: number; errors?: { reason?: string }[] };
-  if (err.code === 409) return true;
-  return Boolean(err.errors?.some((x) => x.reason === "duplicate"));
+  const err = e as {
+    code?: number;
+    status?: number;
+    errors?: { reason?: string }[];
+    response?: { data?: { error?: { errors?: { reason?: string }[] } } };
+  };
+  if (err.code === 409 || err.status === 409) return true;
+  const hasDuplicateReason = (errors?: { reason?: string }[]) =>
+    Boolean(errors?.some((x) => x.reason === "duplicate"));
+  return (
+    hasDuplicateReason(err.errors) ||
+    hasDuplicateReason(err.response?.data?.error?.errors)
+  );
 }
 
 export async function agregarMiembroAGrupo(

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -2,6 +2,33 @@ import { getEM } from "@/lib/db";
 import { Alumno } from "@/domain/entities";
 import type { Comision } from "@/domain/entities";
 
+// El legajo es la PK del alumno en la cursada: dos alumnos no pueden compartirlo.
+// La UNIQUE constraint de la DB ya lo garantiza, pero lanzamos este error antes
+// del flush para poder devolverle al cliente un mensaje claro y el `field`
+// afectado en vez de un crash genérico del driver.
+export class LegajoConflictError extends Error {
+  constructor(
+    public readonly legajo: string,
+    public readonly otroGithubUsername: string
+  ) {
+    super(
+      `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
+    );
+    this.name = "LegajoConflictError";
+  }
+}
+
+async function assertLegajoLibreOPropio(
+  legajo: string,
+  githubUsername: string
+): Promise<void> {
+  const em = await getEM();
+  const otro = await em.findOne(Alumno, { legajo: legajo.trim() });
+  if (otro && otro.githubUsername.toLowerCase() !== githubUsername.toLowerCase().trim()) {
+    throw new LegajoConflictError(legajo.trim(), otro.githubUsername);
+  }
+}
+
 export async function getAlumnos(): Promise<Alumno[]> {
   const em = await getEM();
   return em.find(Alumno, {}, { orderBy: { apellido: "ASC", nombre: "ASC" } });
@@ -34,6 +61,7 @@ export interface AlumnoData {
 }
 
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
+  await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
   const em = await getEM();
   const alumno = new Alumno();
   alumno.legajo = data.legajo.trim();
@@ -50,6 +78,7 @@ export async function createAlumno(data: AlumnoData): Promise<Alumno> {
 
 /** Crea o actualiza el Alumno en la DB a partir de los datos de la planilla. */
 export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
+  await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
   const em = await getEM();
   const existing = await em.findOne(Alumno, {
     githubUsername: data.githubUsername.toLowerCase().trim(),

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -30,6 +30,7 @@ export interface AlumnoData {
   githubUsername: string;
   email: string;
   comision?: Comision;
+  registroConfirmadoEn?: Comision;
 }
 
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
@@ -41,6 +42,7 @@ export async function createAlumno(data: AlumnoData): Promise<Alumno> {
   alumno.githubUsername = data.githubUsername.toLowerCase().trim();
   alumno.email = data.email.toLowerCase().trim();
   alumno.comision = data.comision;
+  alumno.registroConfirmadoEn = data.registroConfirmadoEn;
   em.persist(alumno);
   await em.flush();
   return alumno;
@@ -59,6 +61,9 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
     existing.apellido = data.apellido.trim();
     existing.email = data.email.toLowerCase().trim();
     existing.comision = data.comision;
+    if (data.registroConfirmadoEn !== undefined) {
+      existing.registroConfirmadoEn = data.registroConfirmadoEn;
+    }
     await em.flush();
     return existing;
   }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -150,6 +150,10 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
       alumno.email = data.email.toLowerCase().trim();
       alumno.comision = data.comision;
       em.persist(alumno);
+      // Si el batch trae otra fila con el mismo github (typo o fila duplicada
+      // en la planilla), debe reutilizar esta instancia — sin esto, el UNIQUE
+      // de githubUsername explota en el flush con un error genérico.
+      existentesPorGithub.set(key, alumno);
     }
   }
 

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -66,6 +66,40 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   return createAlumno(data);
 }
 
+/** Crea o actualiza múltiples alumnos en un solo flush. */
+export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
+  if (dataList.length === 0) return 0;
+
+  const em = await getEM();
+  const githubUsernames = dataList.map((d) => d.githubUsername.toLowerCase().trim());
+  const existentes = await em.find(Alumno, { githubUsername: { $in: githubUsernames } });
+  const existentesPorGithub = new Map(existentes.map((a) => [a.githubUsername, a]));
+
+  for (const data of dataList) {
+    const key = data.githubUsername.toLowerCase().trim();
+    const existing = existentesPorGithub.get(key);
+    if (existing) {
+      existing.legajo = data.legajo.trim();
+      existing.nombre = data.nombre.trim();
+      existing.apellido = data.apellido.trim();
+      existing.email = data.email.toLowerCase().trim();
+      existing.comision = data.comision;
+    } else {
+      const alumno = new Alumno();
+      alumno.legajo = data.legajo.trim();
+      alumno.nombre = data.nombre.trim();
+      alumno.apellido = data.apellido.trim();
+      alumno.githubUsername = key;
+      alumno.email = data.email.toLowerCase().trim();
+      alumno.comision = data.comision;
+      em.persist(alumno);
+    }
+  }
+
+  await em.flush();
+  return dataList.length;
+}
+
 export async function countAlumnos(): Promise<number> {
   const em = await getEM();
   return em.count(Alumno, {});

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -105,7 +105,30 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   if (dataList.length === 0) return 0;
 
   const em = await getEM();
-  const githubUsernames = dataList.map((d) => d.githubUsername.toLowerCase().trim());
+
+  // Validar coherencia legajo↔github antes de persistir: el UNIQUE de la DB
+  // dispararía un error genérico del driver. Así surfaceamos LegajoConflictError
+  // con los datos específicos, igual que upsertAlumno.
+  const githubPorLegajo = new Map<string, string>();
+  for (const data of dataList) {
+    const legajo = data.legajo.trim();
+    const github = data.githubUsername.toLowerCase().trim();
+    const prev = githubPorLegajo.get(legajo);
+    if (prev && prev !== github) {
+      throw new LegajoConflictError(legajo, prev);
+    }
+    githubPorLegajo.set(legajo, github);
+  }
+  const legajos = [...githubPorLegajo.keys()];
+  const alumnosConLegajoTomado = await em.find(Alumno, { legajo: { $in: legajos } });
+  for (const alumno of alumnosConLegajoTomado) {
+    const incomingGithub = githubPorLegajo.get(alumno.legajo)!;
+    if (alumno.githubUsername.toLowerCase() !== incomingGithub) {
+      throw new LegajoConflictError(alumno.legajo, alumno.githubUsername);
+    }
+  }
+
+  const githubUsernames = [...githubPorLegajo.values()];
   const existentes = await em.find(Alumno, { githubUsername: { $in: githubUsernames } });
   const existentesPorGithub = new Map(existentes.map((a) => [a.githubUsername, a]));
 

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -60,17 +60,26 @@ export interface AlumnoData {
   registroConfirmadoEn?: Comision;
 }
 
-export async function createAlumno(data: AlumnoData): Promise<Alumno> {
-  await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
-  const em = await getEM();
-  const alumno = new Alumno();
+// Copia los campos de `data` sobre `alumno`. Para `registroConfirmadoEn`
+// se ignora `undefined` para no pisar un valor ya confirmado cuando el caller
+// (ej. sync desde Sheets) no trae ese dato.
+function applyAlumnoData(alumno: Alumno, data: AlumnoData): void {
   alumno.legajo = data.legajo.trim();
   alumno.nombre = data.nombre.trim();
   alumno.apellido = data.apellido.trim();
   alumno.githubUsername = data.githubUsername.toLowerCase().trim();
   alumno.email = data.email.toLowerCase().trim();
   alumno.comision = data.comision;
-  alumno.registroConfirmadoEn = data.registroConfirmadoEn;
+  if (data.registroConfirmadoEn !== undefined) {
+    alumno.registroConfirmadoEn = data.registroConfirmadoEn;
+  }
+}
+
+export async function createAlumno(data: AlumnoData): Promise<Alumno> {
+  await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
+  const em = await getEM();
+  const alumno = new Alumno();
+  applyAlumnoData(alumno, data);
   em.persist(alumno);
   await em.flush();
   return alumno;
@@ -85,14 +94,7 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   });
 
   if (existing) {
-    existing.legajo = data.legajo.trim();
-    existing.nombre = data.nombre.trim();
-    existing.apellido = data.apellido.trim();
-    existing.email = data.email.toLowerCase().trim();
-    existing.comision = data.comision;
-    if (data.registroConfirmadoEn !== undefined) {
-      existing.registroConfirmadoEn = data.registroConfirmadoEn;
-    }
+    applyAlumnoData(existing, data);
     await em.flush();
     return existing;
   }
@@ -136,19 +138,10 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     const key = data.githubUsername.toLowerCase().trim();
     const existing = existentesPorGithub.get(key);
     if (existing) {
-      existing.legajo = data.legajo.trim();
-      existing.nombre = data.nombre.trim();
-      existing.apellido = data.apellido.trim();
-      existing.email = data.email.toLowerCase().trim();
-      existing.comision = data.comision;
+      applyAlumnoData(existing, data);
     } else {
       const alumno = new Alumno();
-      alumno.legajo = data.legajo.trim();
-      alumno.nombre = data.nombre.trim();
-      alumno.apellido = data.apellido.trim();
-      alumno.githubUsername = key;
-      alumno.email = data.email.toLowerCase().trim();
-      alumno.comision = data.comision;
+      applyAlumnoData(alumno, data);
       em.persist(alumno);
       // Si el batch trae otra fila con el mismo github (typo o fila duplicada
       // en la planilla), debe reutilizar esta instancia — sin esto, el UNIQUE

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -4,6 +4,7 @@ export {
   getAlumnoByLegajo,
   createAlumno,
   upsertAlumno,
+  upsertAlumnos,
   countAlumnos,
 } from "./AlumnoRepository";
 export type { AlumnoData } from "./AlumnoRepository";

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -6,6 +6,7 @@ export {
   upsertAlumno,
   upsertAlumnos,
   countAlumnos,
+  LegajoConflictError,
 } from "./AlumnoRepository";
 export type { AlumnoData } from "./AlumnoRepository";
 

--- a/src/lib/sheets.test.ts
+++ b/src/lib/sheets.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { parseAlumnosRows, validateRegistro, colLetter, actualizarAlumno } from "./sheets";
+import {
+  parseAlumnosRows,
+  validateRegistro,
+  colLetter,
+  isValidEmail,
+  upsertarAlumnoEnSheets,
+} from "./sheets";
 
 // ── parseAlumnosRows ────────────────────────────────────────
 
@@ -144,6 +150,54 @@ describe("validateRegistro", () => {
     expect(validateRegistro({ ...valid, email: "" })).toContain("email");
   });
 
+  it("rechaza email sin dominio con punto", () => {
+    expect(validateRegistro({ ...valid, email: "juan@gmail" })).toContain("email");
+  });
+
+  it("rechaza email con espacios", () => {
+    expect(validateRegistro({ ...valid, email: "juan @gmail.com" })).toContain("email");
+  });
+
+  it("acepta emails con subdominios", () => {
+    expect(validateRegistro({ ...valid, email: "juan@mail.frba.utn.edu.ar" })).toBeNull();
+  });
+
+  it("acepta emails con + en la parte local", () => {
+    expect(validateRegistro({ ...valid, email: "juan+curso@gmail.com" })).toBeNull();
+  });
+
+});
+
+// ── isValidEmail (helper) ────────────────────────────────────
+
+describe("isValidEmail", () => {
+  it("acepta email estándar", () => {
+    expect(isValidEmail("juan@gmail.com")).toBe(true);
+  });
+
+  it("acepta email con subdominios", () => {
+    expect(isValidEmail("juan@mail.utn.edu.ar")).toBe(true);
+  });
+
+  it("rechaza email sin arroba", () => {
+    expect(isValidEmail("juangmail.com")).toBe(false);
+  });
+
+  it("rechaza email sin dominio con punto", () => {
+    expect(isValidEmail("juan@gmail")).toBe(false);
+  });
+
+  it("rechaza string vacío", () => {
+    expect(isValidEmail("")).toBe(false);
+  });
+
+  it("rechaza email con espacios", () => {
+    expect(isValidEmail("juan @gmail.com")).toBe(false);
+  });
+
+  it("ignora whitespace al borde (trim)", () => {
+    expect(isValidEmail("  juan@gmail.com  ")).toBe(true);
+  });
 });
 
 // ── colLetter ────────────────────────────────────────────────
@@ -158,69 +212,65 @@ describe("colLetter", () => {
   it("52 → BA", () => expect(colLetter(52)).toBe("BA"));
 });
 
-// ── actualizarAlumno – validaciones síncronas ────────────────
+// ── upsertarAlumnoEnSheets – validaciones síncronas ──────────
 
-describe("actualizarAlumno – validaciones", () => {
+describe("upsertarAlumnoEnSheets – validaciones", () => {
   const valid = {
     legajo: "12345",
     apellido: "García",
     nombre: "Juan",
+    githubUsername: "juangarcia",
     email: "juan@gmail.com",
   };
 
   it("rechaza apellido vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, apellido: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "" });
     expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza apellido con solo espacios", async () => {
-    const r = await actualizarAlumno("user", { ...valid, apellido: "   " });
+    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "   " });
     expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza nombre vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, nombre: "" });
-    expect(r).toEqual({ ok: false, error: "El nombre es obligatorio" });
-  });
-
-  it("rechaza nombre con solo espacios", async () => {
-    const r = await actualizarAlumno("user", { ...valid, nombre: "   " });
+    const r = await upsertarAlumnoEnSheets({ ...valid, nombre: "" });
     expect(r).toEqual({ ok: false, error: "El nombre es obligatorio" });
   });
 
   it("rechaza legajo vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "" });
     expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza legajo con letras", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "abc12" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
-  });
-
-  it("rechaza legajo demasiado corto", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "12" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
-  });
-
-  it("rechaza legajo demasiado largo", async () => {
-    const r = await actualizarAlumno("user", { ...valid, legajo: "123456789" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "abc12" });
     expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza email sin @", async () => {
-    const r = await actualizarAlumno("user", { ...valid, email: "juangmail.com" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juangmail.com" });
+    expect(r).toEqual({ ok: false, error: "El email no es válido" });
+  });
+
+  it("rechaza email sin punto en el dominio", async () => {
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juan@gmail" });
     expect(r).toEqual({ ok: false, error: "El email no es válido" });
   });
 
   it("rechaza email vacío", async () => {
-    const r = await actualizarAlumno("user", { ...valid, email: "" });
+    const r = await upsertarAlumnoEnSheets({ ...valid, email: "" });
     expect(r).toEqual({ ok: false, error: "El email no es válido" });
   });
 
+  it("rechaza github vacío", async () => {
+    const r = await upsertarAlumnoEnSheets({ ...valid, githubUsername: "" });
+    expect(r).toEqual({ ok: false, error: "El usuario de GitHub es obligatorio" });
+  });
+
   it("lanza error si no hay spreadsheetId configurado (input válido)", async () => {
-    await expect(
-      actualizarAlumno("user", valid, undefined)
-    ).rejects.toThrow("No hay una comisión activa");
+    await expect(upsertarAlumnoEnSheets(valid, undefined)).rejects.toThrow(
+      "No hay una comisión activa"
+    );
   });
 });

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -148,6 +148,14 @@ export interface RegistroInput {
   email: string;
 }
 
+// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
+// Suficiente para detectar typos comunes sin sobre-complicar.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
 export function validateRegistro(input: RegistroInput): string | null {
   const { legajo, apellido, nombre, githubUsername, email } = input;
 
@@ -158,11 +166,16 @@ export function validateRegistro(input: RegistroInput): string | null {
   if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
   if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
     return "El usuario de GitHub no tiene un formato válido";
-  if (!email.trim() || !email.includes("@")) return "El email no es válido";
+  if (!isValidEmail(email)) return "El email no es válido";
   return null;
 }
 
-export async function registrarAlumno(
+// ── Upsert de alumno en la planilla ─────────────────────────
+// Unifica registro (insert) y actualización (update): busca la fila por
+// githubUsername; si existe, la actualiza respetando columnas desconocidas,
+// y si no, la agrega al final.
+
+export async function upsertarAlumnoEnSheets(
   input: RegistroInput,
   spreadsheetId?: string,
   config?: Partial<ColumnConfig>
@@ -172,102 +185,56 @@ export async function registrarAlumno(
 
   const id = resolveSpreadsheetId(spreadsheetId);
   const cfg = resolveConfig(config);
+  const githubNormalizado = input.githubUsername.trim().toLowerCase();
 
-  // Verificar duplicados
+  // El legajo puede pertenecer al mismo alumno (al actualizar) o a otro (colisión).
   const porLegajo = await getAlumnoByLegajo(input.legajo, id, cfg);
-  if (porLegajo) {
+  if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubNormalizado) {
     return {
       ok: false,
       error: `El legajo ${input.legajo} ya está registrado (${porLegajo.githubUsername})`,
     };
   }
 
-  const porGithub = await getAlumnoByGithub(input.githubUsername, id, cfg);
-  if (porGithub) {
-    return {
-      ok: false,
-      error: `El usuario ${input.githubUsername} ya está registrado (legajo ${porGithub.legajo})`,
-    };
-  }
-
-  // Construir la fila según la config de columnas
+  const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, cfg);
+  const sheets = getSheetsClient(false);
   const maxCol = Math.max(
     cfg.legajo, cfg.apellido, cfg.nombre,
     cfg.githubUsername, cfg.email
   );
-  const row = new Array(maxCol + 1).fill("");
-  row[cfg.legajo] = input.legajo.trim();
-  row[cfg.apellido] = input.apellido.trim();
-  row[cfg.nombre] = input.nombre.trim();
-  row[cfg.githubUsername] = input.githubUsername.trim().toLowerCase();
-  row[cfg.email] = input.email.trim().toLowerCase();
 
-  const sheets = getSheetsClient(false);
-  await sheets.spreadsheets.values.append({
-    spreadsheetId: id,
-    range: `${cfg.sheetName}!A:${colLetter(maxCol)}`,
-    valueInputOption: "USER_ENTERED",
-    requestBody: { values: [row] },
-  });
-
-  return { ok: true };
-}
-
-// ── Actualizar datos de un alumno ya registrado ─────────────
-
-export type ActualizarInput = Omit<RegistroInput, "githubUsername">;
-
-export async function actualizarAlumno(
-  githubUsername: string,
-  updates: ActualizarInput,
-  spreadsheetId?: string,
-  config?: Partial<ColumnConfig>
-): Promise<{ ok: true } | { ok: false; error: string }> {
-  if (!updates.apellido.trim()) return { ok: false, error: "El apellido es obligatorio" };
-  if (!updates.nombre.trim()) return { ok: false, error: "El nombre es obligatorio" };
-  if (!updates.legajo || !/^\d{4,8}$/.test(updates.legajo.trim()))
-    return { ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" };
-  if (!updates.email.trim() || !updates.email.includes("@"))
-    return { ok: false, error: "El email no es válido" };
-
-  const id = resolveSpreadsheetId(spreadsheetId);
-  const cfg = resolveConfig(config);
-
-  const rowNumber = await findAlumnoRowIndex(githubUsername, id, cfg);
   if (rowNumber === null) {
-    return { ok: false, error: "No se encontró al alumno en la planilla" };
+    const row = new Array(maxCol + 1).fill("");
+    row[cfg.legajo] = input.legajo.trim();
+    row[cfg.apellido] = input.apellido.trim();
+    row[cfg.nombre] = input.nombre.trim();
+    row[cfg.githubUsername] = githubNormalizado;
+    row[cfg.email] = input.email.trim().toLowerCase();
+
+    await sheets.spreadsheets.values.append({
+      spreadsheetId: id,
+      range: `${cfg.sheetName}!A:${colLetter(maxCol)}`,
+      valueInputOption: "USER_ENTERED",
+      requestBody: { values: [row] },
+    });
+    return { ok: true };
   }
 
-  // Verificar que el legajo no esté tomado por otro alumno
-  const porLegajo = await getAlumnoByLegajo(updates.legajo, id, cfg);
-  if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubUsername.toLowerCase()) {
-    return {
-      ok: false,
-      error: `El legajo ${updates.legajo} ya está registrado (${porLegajo.githubUsername})`,
-    };
-  }
-
-  // Leer la fila completa primero para no pisar columnas desconocidas
-  const sheets = getSheetsClient(false);
-  const maxCol = Math.max(
-    cfg.legajo, cfg.apellido, cfg.nombre,
-    cfg.githubUsername, cfg.email
-  );
+  // Leemos la fila completa para no pisar columnas desconocidas que el admin
+  // pueda tener (notas, observaciones, etc).
   const range = `${cfg.sheetName}!A${rowNumber}:${colLetter(maxCol)}${rowNumber}`;
-
   const { data: existing } = await sheets.spreadsheets.values.get({
     spreadsheetId: id,
     range,
   });
   const existingRow: unknown[] = existing.values?.[0] ?? [];
-  // Expandir si hace falta
   while (existingRow.length <= maxCol) existingRow.push("");
 
-  existingRow[cfg.legajo] = updates.legajo.trim();
-  existingRow[cfg.apellido] = updates.apellido.trim();
-  existingRow[cfg.nombre] = updates.nombre.trim();
-  existingRow[cfg.email] = updates.email.trim().toLowerCase();
-  // githubUsername y comision no se tocan
+  existingRow[cfg.legajo] = input.legajo.trim();
+  existingRow[cfg.apellido] = input.apellido.trim();
+  existingRow[cfg.nombre] = input.nombre.trim();
+  existingRow[cfg.email] = input.email.trim().toLowerCase();
+  // githubUsername NO se sobrescribe: la fila se identifica por él.
 
   await sheets.spreadsheets.values.update({
     spreadsheetId: id,
@@ -275,7 +242,6 @@ export async function actualizarAlumno(
     valueInputOption: "USER_ENTERED",
     requestBody: { values: [existingRow] },
   });
-
   return { ok: true };
 }
 

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -175,11 +175,15 @@ export function validateRegistro(input: RegistroInput): string | null {
 // githubUsername; si existe, la actualiza respetando columnas desconocidas,
 // y si no, la agrega al final.
 
+export type UpsertAlumnoResult =
+  | { ok: true }
+  | { ok: false; error: string; field?: "legajo" | "githubUsername" };
+
 export async function upsertarAlumnoEnSheets(
   input: RegistroInput,
   spreadsheetId?: string,
   config?: Partial<ColumnConfig>
-): Promise<{ ok: true } | { ok: false; error: string }> {
+): Promise<UpsertAlumnoResult> {
   const validationError = validateRegistro(input);
   if (validationError) return { ok: false, error: validationError };
 
@@ -187,12 +191,14 @@ export async function upsertarAlumnoEnSheets(
   const cfg = resolveConfig(config);
   const githubNormalizado = input.githubUsername.trim().toLowerCase();
 
-  // El legajo puede pertenecer al mismo alumno (al actualizar) o a otro (colisión).
+  // El legajo debe pertenecer al mismo github o a nadie — si ya es de otro
+  // alumno es conflicto, tanto al insertar como al editar.
   const porLegajo = await getAlumnoByLegajo(input.legajo, id, cfg);
   if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubNormalizado) {
     return {
       ok: false,
-      error: `El legajo ${input.legajo} ya está registrado (${porLegajo.githubUsername})`,
+      error: `El legajo ${input.legajo} ya está registrado con el usuario @${porLegajo.githubUsername}. Verificá que sea el tuyo.`,
+      field: "legajo",
     };
   }
 

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -177,8 +177,12 @@ export function validateRegistro(input: RegistroInput): string | null {
 
 export type UpsertAlumnoResult =
   | { ok: true }
-  | { ok: false; error: string; field?: "legajo" | "githubUsername" };
+  | { ok: false; error: string };
 
+// La coherencia legajo↔github la garantiza la DB (upsertAlumno →
+// LegajoConflictError). Este upsert solo refleja en Sheets lo que ya
+// validó y persistió la DB; el caller debe invocarlo después del upsert
+// en DB para evitar escribir Sheets si hay conflicto.
 export async function upsertarAlumnoEnSheets(
   input: RegistroInput,
   spreadsheetId?: string,
@@ -190,17 +194,6 @@ export async function upsertarAlumnoEnSheets(
   const id = resolveSpreadsheetId(spreadsheetId);
   const cfg = resolveConfig(config);
   const githubNormalizado = input.githubUsername.trim().toLowerCase();
-
-  // El legajo debe pertenecer al mismo github o a nadie — si ya es de otro
-  // alumno es conflicto, tanto al insertar como al editar.
-  const porLegajo = await getAlumnoByLegajo(input.legajo, id, cfg);
-  if (porLegajo && porLegajo.githubUsername.toLowerCase() !== githubNormalizado) {
-    return {
-      ok: false,
-      error: `El legajo ${input.legajo} ya está registrado con el usuario @${porLegajo.githubUsername}. Verificá que sea el tuyo.`,
-      field: "legajo",
-    };
-  }
 
   const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, cfg);
   const sheets = getSheetsClient(false);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,9 @@
-import { auth } from "@/lib/auth";
+import NextAuth from "next-auth";
+import { authConfig } from "@/lib/auth.config";
 import { NextResponse } from "next/server";
 import type { PdepUser } from "@/types";
+
+const { auth } = NextAuth(authConfig);
 
 export default auth((req) => {
   const pdepUser = (req.auth as unknown as { pdepUser?: PdepUser } | null)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -21,7 +21,6 @@ export const DEFAULT_COLUMN_CONFIG: ColumnConfig = {
 };
 
 // ── Paradigmas ──────────────────────────────────────────────
-
 export type Paradigma = "funcional" | "logico" | "objetos";
 
 export const PARADIGMAS: Paradigma[] = ["funcional", "logico", "objetos"];

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"development\" ]; then exit 1; else exit 0; fi"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ]; then exit 1; else exit 0; fi"
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"Development\" ]; then exit 1; else exit 0; fi"
+}

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"Development\" ]; then exit 1; else exit 0; fi"
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_REF\" = \"master\" ] || [ \"$VERCEL_GIT_COMMIT_REF\" = \"development\" ]; then exit 1; else exit 0; fi"
 }


### PR DESCRIPTION
## Summary

- `upsertarAlumnoEnSheets` suma `field?: "legajo" | "githubUsername"` al return de error y explica mejor el mensaje cuando el legajo ya pertenece a otro github. La lógica ya no rompe al editar datos propios.
- Nueva clase `LegajoConflictError` en `AlumnoRepository` con chequeo pre-persist en `createAlumno` y `upsertAlumno`, aplicando la misma regla que la planilla (el legajo debe pertenecer al mismo github o a nadie) también en DB.
- Handlers de `POST /api/registro` y `PATCH /api/perfil` propagan `field` de Sheets y catchean `LegajoConflictError` devolviendo 400 con `{ error, field: "legajo" }` — dejando listo el gancho que consumirá Fase 2 en el form.
- README incorpora la sección **Refactor en curso** con las 6 fases del plan enlazadas a sus issues (#9–#14). Se limpian los TODOs inline que quedaron desperdigados en el código.

## Test plan

- [x] `pnpm test:run` — 508/508 en verde, incluyendo los 4 tests nuevos (propagación de `field` y catch de `LegajoConflictError` en ambos handlers).
- [x] `pnpm tsc --noEmit` — cero errores en archivos productivos.
- [ ] Probar en local: registrar un alumno, editar perfil con el mismo legajo (no debe romper), intentar cambiar a un legajo ya usado por otro github (debe fallar con el mensaje claro).

Closes #11

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Nuevas Funcionalidades**
  * Suscripción opcional a Google Groups tras registro (estado reportado al usuario).
  * Nuevo conjunto reutilizable de componentes DataTable y menú de navegación responsive.
  * Inicio que valida configuración de Google Groups para fallos tempranos.

* **Correcciones**
  * Manejo explícito de conflictos de legajo con respuesta clara (campo "legajo").

* **Mejoras**
  * Validación de email reforzada y lógica de registro condicionada a la comisión activa.
  * Varias mejoras de diseño y comportamiento móvil en formularios, tablas y paneles.

* **Documentación**
  * README y .env.example actualizados con la configuración de Google Workspace.

* **Tests**
  * Cobertura ampliada para registros/perfil, Google Groups, DataTable y flujos relacionados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->