### PR TITLE
Fase 1: polimorfismo de Assignment en vez de IFs por tipo

### DIFF
--- a/README.md
+++ b/README.md
@@ -592,6 +592,7 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 - [ ] Autograding con GitHub Actions en los templates
 - [ ] Export de estado de entregas a Google Sheets (cerrar el loop con la planilla)
 - [x] Suscribir a los alumnos al grupo de Google Groups automáticamente
+- [ ] Observabilidad ([#18](https://github.com/Juancete/Pdep-Classroom/issues/18)) — tabla `error_log` + pantalla `/admin/errores` + badge en el header con no leídos (PR 2 del refactor de logging, hoy los 500 solo logguean por pino a Vercel)
 
 ## Refactor en curso
 

--- a/README.md
+++ b/README.md
@@ -597,7 +597,7 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 
 - [x] **Fase 4** ([#11](https://github.com/Juancete/Pdep-Classroom/issues/11)) — `upsertarAlumnoEnSheets` no debe quejarse al editar + coherencia legajo↔github
 - [x] **Fase 2** ([#13](https://github.com/Juancete/Pdep-Classroom/issues/13)) — Validación de `githubUsername` en registro/perfil con error inline en el form
-- [ ] **Fase 1** ([#9](https://github.com/Juancete/Pdep-Classroom/issues/9)) — Reificar polimorfismo de `Assignment` (individual/grupal) para eliminar los IFs
+- [x] **Fase 1** ([#9](https://github.com/Juancete/Pdep-Classroom/issues/9)) — Reificar polimorfismo de `Assignment` (individual/grupal) para eliminar los IFs
 - [ ] **Fase 3** ([#10](https://github.com/Juancete/Pdep-Classroom/issues/10)) — Unificar registro y perfil en un servicio común
 - [ ] **Fase 5** ([#14](https://github.com/Juancete/Pdep-Classroom/issues/14)) — Upsert de grupos desde planilla, modelado genérico (no atado a paradigma)
 - [ ] **Fase 6** ([#12](https://github.com/Juancete/Pdep-Classroom/issues/12)) — Renombrar/comentar `DEFAULT_COLUMN_CONFIG` como sugerencia de UX

--- a/next.config.js
+++ b/next.config.js
@@ -5,6 +5,8 @@ const nextConfig = {
       "@mikro-orm/core",
       "@mikro-orm/postgresql",
       "@mikro-orm/migrations",
+      "pino",
+      "pino-pretty",
     ],
     instrumentationHook: true,
   },

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "googleapis": "^144.0.0",
     "next": "^14.2.0",
     "next-auth": "^5.0.0-beta.25",
+    "pino": "^10.3.1",
     "react": "^18.3.0",
     "react-dom": "^18.3.0",
     "zod": "^3.23.0"
@@ -52,6 +53,7 @@
     "eslint": "^8.57.0",
     "eslint-config-next": "^14.2.0",
     "jsdom": "^29.0.2",
+    "pino-pretty": "^13.1.3",
     "postcss": "^8.4.0",
     "tailwindcss": "^3.4.0",
     "ts-node": "^10.9.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       next-auth:
         specifier: ^5.0.0-beta.25
         version: 5.0.0-beta.30(next@14.2.35(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
       react:
         specifier: ^18.3.0
         version: 18.3.1
@@ -90,6 +93,9 @@ importers:
       jsdom:
         specifier: ^29.0.2
         version: 29.0.2
+      pino-pretty:
+        specifier: ^13.1.3
+        version: 13.1.3
       postcss:
         specifier: ^8.4.0
         version: 8.5.8
@@ -932,6 +938,9 @@ packages:
   '@panva/hkdf@1.2.1':
     resolution: {integrity: sha512-6oclG6Y3PiDFcoyk8srjLfVKyMfVCKJ27JwNPViuXziFpmdz+MZnZN/aKY0JGXgYuO/VghU0jcOAZgWXZ1Dmrw==}
 
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
   '@pkgjs/parseargs@0.11.0':
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1620,6 +1629,10 @@ packages:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
 
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
   autoprefixer@10.4.27:
     resolution: {integrity: sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==}
     engines: {node: ^10 || ^12 || >=14}
@@ -1821,6 +1834,9 @@ packages:
   dataloader@2.2.3:
     resolution: {integrity: sha512-y2krtASINtPFS1rSDjacrFgn1dcUuoREVabwlOGOe4SdxenREqwjwjElAdwvbGM7kgZz9a3KVicWR7vcz8rnzA==}
 
+  dateformat@4.6.3:
+    resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
+
   debug@3.2.7:
     resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
     peerDependencies:
@@ -1927,6 +1943,9 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
 
   entities@6.0.1:
     resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
@@ -2122,6 +2141,9 @@ packages:
   fast-content-type-parse@3.0.0:
     resolution: {integrity: sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==}
 
+  fast-copy@4.0.3:
+    resolution: {integrity: sha512-58apWr0GUiDFM8+3afrO6eYwJBn9ZAhDOzG3L+/9llab/haCARS2UIfffmOurYLwbgDRs8n0rfr6qAAPEAuAQw==}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -2134,6 +2156,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
@@ -2333,6 +2358,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  help-me@5.0.0:
+    resolution: {integrity: sha512-7xgomUX6ADmcYzFik0HzAxh/73YlKR9bmFzf51CZwR+b6YtzU2m0u49hQCqV6SvlqIqsaxovfwdvbnsw3b/zpg==}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -2548,6 +2576,10 @@ packages:
 
   jose@6.2.2:
     resolution: {integrity: sha512-d7kPDd34KO/YnzaDOlikGpOurfF0ByC2sEV4cANCtdqLlTfBlw2p14O/5d/zv40gJPbIQxfES3nSx1/oYNyuZQ==}
+
+  joycon@3.1.1:
+    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
+    engines: {node: '>=10'}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -2858,6 +2890,10 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -2979,6 +3015,20 @@ packages:
     resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
     engines: {node: '>=0.10.0'}
 
+  pino-abstract-transport@3.0.0:
+    resolution: {integrity: sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==}
+
+  pino-pretty@13.1.3:
+    resolution: {integrity: sha512-ttXRkkOz6WWC95KeY9+xxWL6AtImwbyMHrL1mSwqwW9u+vLp/WIElvHvCSDg0xO/Dzrggz1zv3rN5ovTRVowKg==}
+    hasBin: true
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@10.3.1:
+    resolution: {integrity: sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==}
+    hasBin: true
+
   pirates@4.0.7:
     resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
     engines: {node: '>= 6'}
@@ -3086,8 +3136,14 @@ packages:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
 
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
   prop-types@15.8.1:
     resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -3099,6 +3155,9 @@ packages:
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
 
   react-dom@18.3.1:
     resolution: {integrity: sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==}
@@ -3121,6 +3180,10 @@ packages:
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
 
   rechoir@0.8.0:
     resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
@@ -3202,12 +3265,19 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -3269,6 +3339,9 @@ packages:
   slash@3.0.0:
     resolution: {integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==}
     engines: {node: '>=8'}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -3364,6 +3437,10 @@ packages:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
 
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
+
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -3419,6 +3496,10 @@ packages:
 
   thenify@3.3.1:
     resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@4.0.0:
+    resolution: {integrity: sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==}
+    engines: {node: '>=20'}
 
   tildify@2.0.0:
     resolution: {integrity: sha512-Cc+OraorugtXNfs50hU9KS369rFXCfgGLpfCfvlc+Ud5u6VWmUQsOAa9HbTvheQdYnrdJqqv1e5oIqXppMYnSw==}
@@ -4439,6 +4520,8 @@ snapshots:
 
   '@panva/hkdf@1.2.1': {}
 
+  '@pinojs/redact@0.4.0': {}
+
   '@pkgjs/parseargs@0.11.0':
     optional: true
 
@@ -5072,6 +5155,8 @@ snapshots:
 
   async-function@1.0.0: {}
 
+  atomic-sleep@1.0.0: {}
+
   autoprefixer@10.4.27(postcss@8.5.8):
     dependencies:
       browserslist: 4.28.2
@@ -5268,6 +5353,8 @@ snapshots:
 
   dataloader@2.2.3: {}
 
+  dateformat@4.6.3: {}
+
   debug@3.2.7:
     dependencies:
       ms: 2.1.3
@@ -5345,6 +5432,10 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
 
   entities@6.0.1: {}
 
@@ -5725,6 +5816,8 @@ snapshots:
 
   fast-content-type-parse@3.0.0: {}
 
+  fast-copy@4.0.3: {}
+
   fast-deep-equal@3.1.3: {}
 
   fast-glob@3.3.3:
@@ -5738,6 +5831,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fastq@1.20.1:
     dependencies:
@@ -5985,6 +6080,8 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  help-me@5.0.0: {}
+
   html-encoding-sniffer@6.0.0:
     dependencies:
       '@exodus/bytes': 1.15.0
@@ -6205,6 +6302,8 @@ snapshots:
   jju@1.4.0: {}
 
   jose@6.2.2: {}
+
+  joycon@3.1.1: {}
 
   js-tokens@4.0.0: {}
 
@@ -6501,6 +6600,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  on-exit-leak-free@2.1.2: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -6632,6 +6733,42 @@ snapshots:
 
   pify@2.3.0: {}
 
+  pino-abstract-transport@3.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-pretty@13.1.3:
+    dependencies:
+      colorette: 2.0.20
+      dateformat: 4.6.3
+      fast-copy: 4.0.3
+      fast-safe-stringify: 2.1.1
+      help-me: 5.0.0
+      joycon: 3.1.1
+      minimist: 1.2.8
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pump: 3.0.4
+      secure-json-parse: 4.1.0
+      sonic-boom: 4.2.1
+      strip-json-comments: 5.0.3
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@10.3.1:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 3.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 4.0.0
+
   pirates@4.0.7: {}
 
   pony-cause@2.1.11: {}
@@ -6712,11 +6849,18 @@ snapshots:
       ansi-styles: 5.2.0
       react-is: 17.0.2
 
+  process-warning@5.0.0: {}
+
   prop-types@15.8.1:
     dependencies:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
 
   punycode@2.3.1: {}
 
@@ -6725,6 +6869,8 @@ snapshots:
       side-channel: 1.1.0
 
   queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
 
   react-dom@18.3.1(react@18.3.1):
     dependencies:
@@ -6747,6 +6893,8 @@ snapshots:
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.2
+
+  real-require@0.2.0: {}
 
   rechoir@0.8.0:
     dependencies:
@@ -6866,6 +7014,8 @@ snapshots:
       es-errors: 1.3.0
       is-regex: 1.2.1
 
+  safe-stable-stringify@2.5.0: {}
+
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
@@ -6873,6 +7023,8 @@ snapshots:
   scheduler@0.23.2:
     dependencies:
       loose-envify: 1.4.0
+
+  secure-json-parse@4.1.0: {}
 
   semver@6.3.1: {}
 
@@ -6943,6 +7095,10 @@ snapshots:
   signal-exit@4.1.0: {}
 
   slash@3.0.0: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
 
   source-map-js@1.2.1: {}
 
@@ -7052,6 +7208,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
+  strip-json-comments@5.0.3: {}
+
   styled-jsx@5.1.1(react@18.3.1):
     dependencies:
       client-only: 0.0.1
@@ -7124,6 +7282,10 @@ snapshots:
   thenify@3.3.1:
     dependencies:
       any-promise: 1.3.0
+
+  thread-stream@4.0.0:
+    dependencies:
+      real-require: 0.2.0
 
   tildify@2.0.0: {}
 

--- a/src/app/admin/assignments/[id]/entregas-table.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.tsx
@@ -20,19 +20,19 @@ export type EntregaRow = {
   nombreCompleto: string;
 };
 
-export function filterEntregas(entregas: EntregaRow[], q: string): EntregaRow[] {
-  const query = q.toLowerCase().trim();
+export function filterEntregas(entregas: EntregaRow[], rawQuery: string): EntregaRow[] {
+  const query = rawQuery.toLowerCase().trim();
   if (!query) return entregas;
   return entregas.filter(
-    (e) =>
-      e.githubUsernames.some((u) => u.toLowerCase().includes(query)) ||
-      (e.repoName ?? "").toLowerCase().includes(query)
+    (entrega) =>
+      entrega.githubUsernames.some((username) => username.toLowerCase().includes(query)) ||
+      (entrega.repoName ?? "").toLowerCase().includes(query)
   );
 }
 
 export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
-  const [q, setQ] = useState("");
-  const filtradas = filterEntregas(entregas, q);
+  const [query, setQuery] = useState("");
+  const filtradas = filterEntregas(entregas, query);
 
   return (
     <div>
@@ -43,8 +43,8 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
         <input
           type="search"
           autoComplete="new-password"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
           placeholder="Buscar por usuario o repo..."
           className="border border-gray-300 rounded-md px-3 py-1 text-sm w-full sm:w-64 focus:outline-none focus:ring-2 focus:ring-pdep-400"
         />
@@ -52,8 +52,8 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
 
       {filtradas.length === 0 ? (
         <div className="p-8 text-center text-gray-500">
-          {q
-            ? `No se encontraron entregas para "${q}".`
+          {query
+            ? `No se encontraron entregas para "${query}".`
             : "No hay entregas todavía."}
         </div>
       ) : (
@@ -65,24 +65,24 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
             <DataHeaderCell>Fecha</DataHeaderCell>
           </DataHeader>
           <DataBody>
-            {filtradas.map((e) => (
-              <DataRow key={e.id}>
+            {filtradas.map((entrega) => (
+              <DataRow key={entrega.id}>
                 <DataCell label="Nombre completo" heading>
-                  {e.nombreCompleto}
+                  {entrega.nombreCompleto}
                 </DataCell>
                 <DataCell label="Usuario(s)">
                   <span className="font-mono text-xs break-all">
-                    {e.githubUsernames.join(", ")}
+                    {entrega.githubUsernames.join(", ")}
                   </span>
                 </DataCell>
                 <DataCell label="Repositorio">
-                  {e.repoDeleted ? (
+                  {entrega.repoDeleted ? (
                     <span className="text-red-400 text-xs">
                       Repositorio borrado
                     </span>
-                  ) : e.repoUrl ? (
+                  ) : entrega.repoUrl ? (
                     <a
-                      href={e.repoUrl}
+                      href={entrega.repoUrl}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="inline-flex items-center gap-1.5 text-sm bg-green-50 text-green-700 border border-green-200 px-3 py-1.5 rounded-lg font-medium hover:bg-green-100 transition-colors"
@@ -107,7 +107,7 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
                   )}
                 </DataCell>
                 <DataCell label="Fecha">
-                  <span className="text-gray-500 text-xs">{e.createdAt}</span>
+                  <span className="text-gray-500 text-xs">{entrega.createdAt}</span>
                 </DataCell>
               </DataRow>
             ))}

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -38,20 +38,20 @@ export default async function AssignmentDetailPage({
   const pendientes = Math.max(0, total - aceptadas);
 
   const alumnosPorUsername = new Map<string, Alumno>(
-    alumnos.map((a) => [a.githubUsername.toLowerCase(), a])
+    alumnos.map((alumno) => [alumno.githubUsername.toLowerCase(), alumno])
   );
 
-  const entregaRows = entregas.map((e) => ({
-    id: e.id,
-    githubUsernames: e.githubUsernames,
-    repoName: e.repoName,
-    repoUrl: e.repoUrl,
-    repoDeleted: e.repoDeleted,
-    createdAt: new Date(e.createdAt).toLocaleDateString("es-AR"),
-    nombreCompleto: e.githubUsernames
-      .map((u) => {
-        const a = alumnosPorUsername.get(u.toLowerCase());
-        return a ? `${a.apellido}, ${a.nombre}` : "—";
+  const entregaRows = entregas.map((entrega) => ({
+    id: entrega.id,
+    githubUsernames: entrega.githubUsernames,
+    repoName: entrega.repoName,
+    repoUrl: entrega.repoUrl,
+    repoDeleted: entrega.repoDeleted,
+    createdAt: new Date(entrega.createdAt).toLocaleDateString("es-AR"),
+    nombreCompleto: entrega.githubUsernames
+      .map((username) => {
+        const alumno = alumnosPorUsername.get(username.toLowerCase());
+        return alumno ? `${alumno.apellido}, ${alumno.nombre}` : "—";
       })
       .join(" / "),
   }));
@@ -72,7 +72,7 @@ export default async function AssignmentDetailPage({
         <div className="flex items-center gap-3">
           <DeleteReposButton
             assignmentId={assignment.id}
-            activeRepoCount={entregas.filter((e) => e.repoName && !e.repoDeleted).length}
+            activeRepoCount={entregas.filter((entrega) => entrega.repoName && !entrega.repoDeleted).length}
           />
           <Link
             href={`/admin/assignments/${assignment.id}/edit`}

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -21,16 +21,19 @@ export default async function AssignmentDetailPage({
   const assignment = await getAssignment(params.id);
   if (!assignment) redirect("/admin/assignments");
 
-  const [entregas, alumnos, gruposRef] = await Promise.all([
+  // `getAlumnos` se dispara una sola vez: Individual reutiliza la misma
+  // promise vía el thunk para calcular su total, y el map de nombres también
+  // consume el resultado. Grupal ignora el thunk y pide los grupos.
+  const alumnosPromise = getAlumnos();
+  const [entregas, alumnos, total] = await Promise.all([
     getEntregas(params.id),
-    getAlumnos(),
-    assignment.tipo === "grupal"
-      ? getGruposDeAssignment(params.id)
-      : Promise.resolve([]),
+    alumnosPromise,
+    assignment.totalEsperado({
+      getAlumnosDelCurso: () => alumnosPromise,
+      getGruposDeAssignment,
+    }),
   ]);
 
-  const total =
-    assignment.tipo === "individual" ? alumnos.length : gruposRef.length;
   const aceptadas = entregas.length;
   const pendientes = Math.max(0, total - aceptadas);
 
@@ -117,7 +120,7 @@ export default async function AssignmentDetailPage({
         <div className="bg-white border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-3xl font-bold text-gray-600">{total}</div>
           <div className="text-sm text-gray-500 mt-1">
-            {assignment.tipo === "individual" ? "Alumnos" : "Grupos"} totales
+            {assignment.etiquetaTotales()} totales
           </div>
         </div>
       </div>

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -57,55 +57,55 @@ export default async function AdminAssignmentsPage() {
             <DataHeaderCell>Acciones</DataHeaderCell>
           </DataHeader>
           <DataBody>
-            {sorted.map((a) => (
-              <DataRow key={a.id}>
+            {sorted.map((assignment) => (
+              <DataRow key={assignment.id}>
                 <DataCell label="Título" heading>
-                  {a.titulo}
+                  {assignment.titulo}
                 </DataCell>
                 <DataCell label="Paradigma">
                   <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">
-                    {a.paradigma}
+                    {assignment.paradigma}
                   </span>
                 </DataCell>
                 <DataCell label="Tipo">
-                  <span className="text-gray-500">{a.tipo}</span>
+                  <span className="text-gray-500">{assignment.tipo}</span>
                 </DataCell>
                 <DataCell label="Template">
                   <span className="font-mono text-xs text-gray-500 break-all">
-                    {a.templateRepo}
+                    {assignment.templateRepo}
                   </span>
                 </DataCell>
                 <DataCell label="Entregas">
                   <span className="font-mono">
-                    {entregasCounts.get(a.id) ?? 0}
+                    {entregasCounts.get(assignment.id) ?? 0}
                   </span>
                 </DataCell>
                 <DataCell label="Deadline">
                   <span className="text-gray-500">
-                    {a.deadline
-                      ? new Date(a.deadline).toLocaleDateString("es-AR")
+                    {assignment.deadline
+                      ? new Date(assignment.deadline).toLocaleDateString("es-AR")
                       : "—"}
                   </span>
                 </DataCell>
                 <DataCell label="">
                   <div className="flex items-center gap-3 flex-wrap">
                     <Link
-                      href={`/admin/assignments/${a.id}`}
+                      href={`/admin/assignments/${assignment.id}`}
                       className="text-gray-500 hover:text-gray-700 text-xs font-medium"
                     >
                       Ver
                     </Link>
                     <Link
-                      href={`/admin/assignments/${a.id}/edit`}
+                      href={`/admin/assignments/${assignment.id}/edit`}
                       className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
                     >
                       Editar
                     </Link>
                     <DeleteReposButton
-                      assignmentId={a.id}
-                      activeRepoCount={activeRepoCounts.get(a.id) ?? 0}
+                      assignmentId={assignment.id}
+                      activeRepoCount={activeRepoCounts.get(assignment.id) ?? 0}
                     />
-                    <DeleteAssignmentButton id={a.id} titulo={a.titulo} />
+                    <DeleteAssignmentButton id={assignment.id} titulo={assignment.titulo} />
                   </div>
                 </DataCell>
               </DataRow>

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -1,6 +1,11 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
-import { IndividualAssignment, Entrega } from "@/domain/entities";
+import {
+  IndividualAssignment,
+  GrupalAssignment,
+  Entrega,
+  type Assignment,
+} from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -49,13 +54,17 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
   };
 }
 
-function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const a = new IndividualAssignment();
+type AssignmentOverrides = Partial<IndividualAssignment & GrupalAssignment>;
+
+function makeAssignment(overrides?: AssignmentOverrides): Assignment {
+  const a: Assignment =
+    overrides?.tipo === "grupal"
+      ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
+      : new IndividualAssignment();
   a.id = "a1";
   a.titulo = "Kata Funcional";
   a.descripcion = "";
   a.templateRepo = "kata-template";
-  a.tipo = "individual";
   a.paradigma = "funcional";
   a.slug = "kata-funcional";
   a.createdAt = new Date("2026-01-01");

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -179,7 +179,7 @@ describe("POST /api/assignments/[id]/accept", () => {
       return {
         id,
         nombre: "Los Lambdas",
-        alumnos: { getItems: () => githubUsernames.map((u) => ({ githubUsername: u })) },
+        alumnos: { getItems: () => githubUsernames.map((username) => ({ githubUsername: username })) },
       };
     }
 

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -5,6 +5,7 @@ import { GrupoNoAsignadoError, type ParticipantesResueltos } from "@/domain/enti
 import { crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
 import { checkRateLimit } from "@/lib/rate-limit";
+import { internalServerError } from "@/lib/api-errors";
 
 export async function POST(
   _req: Request,
@@ -90,8 +91,10 @@ export async function POST(
 
     return NextResponse.json(entrega);
   } catch (error) {
-    console.error("Error aceptando assignment:", error);
-    const message = error instanceof Error ? error.message : "Error interno";
-    return NextResponse.json({ error: message }, { status: 500 });
+    return internalServerError(
+      "POST /api/assignments/[id]/accept",
+      error,
+      { assignmentId: params.id }
+    );
   }
 }

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { getAssignment, getEntregaDeUsuario, createEntrega, getGrupoDeAlumnoEnAssignment } from "@/lib/repositories";
-import { GrupoNoAsignadoError } from "@/domain/entities";
+import { GrupoNoAsignadoError, type ParticipantesResueltos } from "@/domain/entities";
 import { crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -36,20 +36,19 @@ export async function POST(
     }
 
     // ── Determinar quiénes van al repo ───────────────────────
-    let usernames: string[];
-    let grupoId: string | undefined;
-
+    let participantes: ParticipantesResueltos;
     try {
-      ({ usernames, grupoId } = await assignment.resolverParticipantesPara(
+      participantes = await assignment.resolverParticipantesPara(
         user,
         getGrupoDeAlumnoEnAssignment
-      ));
-    } catch (e) {
-      if (e instanceof GrupoNoAsignadoError) {
-        return NextResponse.json({ error: e.message }, { status: 400 });
+      );
+    } catch (error) {
+      if (error instanceof GrupoNoAsignadoError) {
+        return NextResponse.json({ error: error.message }, { status: 400 });
       }
-      throw e;
+      throw error;
     }
+    const { usernames, grupoId } = participantes;
 
     // ── Extraer nombre del template (sin org) ────────────────
     const templateRepo = assignment.templateRepo.includes("/")
@@ -90,9 +89,9 @@ export async function POST(
     });
 
     return NextResponse.json(entrega);
-  } catch (e) {
-    console.error("Error aceptando assignment:", e);
-    const message = e instanceof Error ? e.message : "Error interno";
+  } catch (error) {
+    console.error("Error aceptando assignment:", error);
+    const message = error instanceof Error ? error.message : "Error interno";
     return NextResponse.json({ error: message }, { status: 500 });
   }
 }

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { getAssignment, getEntregaDeUsuario, createEntrega, getGrupoDeAlumnoEnAssignment } from "@/lib/repositories";
+import { GrupoNoAsignadoError } from "@/domain/entities";
 import { crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
 import { checkRateLimit } from "@/lib/rate-limit";
@@ -38,21 +39,16 @@ export async function POST(
     let usernames: string[];
     let grupoId: string | undefined;
 
-    if (assignment.tipo === "grupal") {
-      const grupo = await getGrupoDeAlumnoEnAssignment(assignment.id, user.githubUsername);
-      if (!grupo) {
-        return NextResponse.json(
-          {
-            error:
-              "No tenés grupo asignado para este TP. Contactá a tu docente.",
-          },
-          { status: 400 }
-        );
+    try {
+      ({ usernames, grupoId } = await assignment.resolverParticipantesPara(
+        user,
+        getGrupoDeAlumnoEnAssignment
+      ));
+    } catch (e) {
+      if (e instanceof GrupoNoAsignadoError) {
+        return NextResponse.json({ error: e.message }, { status: 400 });
       }
-      usernames = grupo.alumnos.getItems().map((a) => a.githubUsername);
-      grupoId = grupo.id;
-    } else {
-      usernames = [user.githubUsername];
+      throw e;
     }
 
     // ── Extraer nombre del template (sin org) ────────────────

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
+import { internalServerError } from "@/lib/api-errors";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -63,7 +64,6 @@ export async function PATCH(req: Request) {
 
     return NextResponse.json({ ok: true });
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "Error interno";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    return internalServerError("PATCH /api/perfil", e);
   }
 }

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -175,7 +175,9 @@ describe("POST /api/registro", () => {
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(500);
     const json = await res.json();
-    expect(json.error).toBe("boom");
+    // El mensaje del error interno no debe filtrarse al cliente.
+    expect(json.error).toBe("Error interno del servidor");
+    expect(json.error).not.toContain("boom");
   });
 
   // ── Suscripción al Google Group ────────────────────────────
@@ -224,18 +226,19 @@ describe("POST /api/registro", () => {
     });
 
     it("enmascara el email en el log de error para no exponer PII", async () => {
-      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const { logger } = await import("@/lib/logger");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
       mockAgregarMiembroAGrupo.mockResolvedValue({
         status: "error",
         error: "Sin permisos",
       });
       await POST(makeRequest(validBody));
-      const loggedLines = errorSpy.mock.calls.flat().join(" ");
+      const loggedPayload = JSON.stringify(errorSpy.mock.calls);
       // El email completo no debe aparecer, pero sí el dominio y un
       // identificador útil para el admin (githubUsername).
-      expect(loggedLines).not.toContain("juan@gmail.com");
-      expect(loggedLines).toContain("@gmail.com");
-      expect(loggedLines).toContain("juangarcia");
+      expect(loggedPayload).not.toContain("juan@gmail.com");
+      expect(loggedPayload).toContain("@gmail.com");
+      expect(loggedPayload).toContain("juangarcia");
       errorSpy.mockRestore();
     });
 

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -9,13 +9,15 @@ import { logger } from "@/lib/logger";
 // Enmascara la parte local del email para no escupir PII a los logs,
 // preservando dominio y primeras 2 letras para que un admin pueda
 // reconocer al alumno (combinado con el githubUsername del log).
-function maskEmail(email: string): string {
-  const at = email.indexOf("@");
-  if (at <= 0) return "***";
-  const user = email.slice(0, at);
-  const domain = email.slice(at);
-  const visible = user.slice(0, 2);
-  return `${visible}${"*".repeat(Math.max(user.length - 2, 1))}${domain}`;
+function maskEmail(correo: string): string {
+  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
+}
+
+// Enmascara cualquier email embebido en un texto libre (p. ej. el
+// `message` de un error de googleapis, que suele citar el email del
+// miembro que se intentó agregar).
+function maskEmailsEnTexto(texto: string): string {
+  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
 }
 
 export async function POST(req: Request) {
@@ -103,7 +105,7 @@ export async function POST(req: Request) {
         {
           githubUsername: body.githubUsername,
           maskedEmail: maskEmail(body.email),
-          err: groupSubscription.error,
+          err: maskEmailsEnTexto(groupSubscription.error),
         },
         "Error al suscribir al Google Group"
       );

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -3,6 +3,8 @@ import { requireUser } from "@/lib/session";
 import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
 import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
+import { internalServerError } from "@/lib/api-errors";
+import { logger } from "@/lib/logger";
 
 // Enmascara la parte local del email para no escupir PII a los logs,
 // preservando dominio y primeras 2 letras para que un admin pueda
@@ -97,14 +99,18 @@ export async function POST(req: Request) {
     // muestre si corresponde y logueamos el detalle server-side.
     const groupSubscription = await agregarMiembroAGrupo(body.email);
     if (groupSubscription.status === "error") {
-      console.error(
-        `Error al suscribir al Google Group: github=${body.githubUsername} email=${maskEmail(body.email)} — ${groupSubscription.error}`
+      logger.error(
+        {
+          githubUsername: body.githubUsername,
+          maskedEmail: maskEmail(body.email),
+          err: groupSubscription.error,
+        },
+        "Error al suscribir al Google Group"
       );
     }
 
     return NextResponse.json({ ok: true, groupSubscription: groupSubscription.status });
   } catch (e) {
-    const msg = e instanceof Error ? e.message : "Error interno";
-    return NextResponse.json({ error: msg }, { status: 500 });
+    return internalServerError("POST /api/registro", e);
   }
 }

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -21,9 +21,9 @@ describe("IndividualAssignment", () => {
   });
 
   it("totalEsperado cuenta todos los alumnos del curso", async () => {
-    const a = new IndividualAssignment();
+    const individual = new IndividualAssignment();
     const alumnos = [fakeAlumno("ana"), fakeAlumno("bob"), fakeAlumno("cora")];
-    const total = await a.totalEsperado({
+    const total = await individual.totalEsperado({
       getAlumnosDelCurso: async () => alumnos,
       getGruposDeAssignment: vi.fn(),
     });
@@ -31,9 +31,9 @@ describe("IndividualAssignment", () => {
   });
 
   it("totalEsperado no consulta grupos (no le aplican al individual)", async () => {
-    const a = new IndividualAssignment();
+    const individual = new IndividualAssignment();
     const getGrupos = vi.fn();
-    await a.totalEsperado({
+    await individual.totalEsperado({
       getAlumnosDelCurso: async () => [],
       getGruposDeAssignment: getGrupos,
     });
@@ -41,38 +41,38 @@ describe("IndividualAssignment", () => {
   });
 
   it("resolverParticipantesPara devuelve solo al usuario que acepta", async () => {
-    const a = new IndividualAssignment();
-    const r = await a.resolverParticipantesPara(
+    const individual = new IndividualAssignment();
+    const participantes = await individual.resolverParticipantesPara(
       { githubUsername: "ana" },
       vi.fn()
     );
-    expect(r.usernames).toEqual(["ana"]);
-    expect(r.grupoId).toBeUndefined();
+    expect(participantes.usernames).toEqual(["ana"]);
+    expect(participantes.grupoId).toBeUndefined();
   });
 
   it("resolverParticipantesPara ignora la lambda de buscar grupo", async () => {
-    const a = new IndividualAssignment();
+    const individual = new IndividualAssignment();
     const buscar = vi.fn();
-    await a.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
+    await individual.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
     expect(buscar).not.toHaveBeenCalled();
   });
 });
 
 describe("GrupalAssignment", () => {
-  function make(): GrupalAssignment {
-    const g = new GrupalAssignment();
-    g.id = "a1";
-    g.maxIntegrantes = 4;
-    return g;
+  function nuevoGrupal(): GrupalAssignment {
+    const grupal = new GrupalAssignment();
+    grupal.id = "a1";
+    grupal.maxIntegrantes = 4;
+    return grupal;
   }
 
   it("la etiqueta de totales es 'Grupos'", () => {
-    expect(make().etiquetaTotales()).toBe("Grupos");
+    expect(nuevoGrupal().etiquetaTotales()).toBe("Grupos");
   });
 
   it("totalEsperado cuenta los grupos del assignment", async () => {
-    const a = make();
-    const total = await a.totalEsperado({
+    const grupal = nuevoGrupal();
+    const total = await grupal.totalEsperado({
       getAlumnosDelCurso: vi.fn(),
       getGruposDeAssignment: async (id) => {
         expect(id).toBe("a1");
@@ -83,9 +83,9 @@ describe("GrupalAssignment", () => {
   });
 
   it("totalEsperado no consulta alumnos del curso (no aplica al grupal)", async () => {
-    const a = make();
+    const grupal = nuevoGrupal();
     const getAlumnos = vi.fn();
-    await a.totalEsperado({
+    await grupal.totalEsperado({
       getAlumnosDelCurso: getAlumnos,
       getGruposDeAssignment: async () => [],
     });
@@ -93,32 +93,32 @@ describe("GrupalAssignment", () => {
   });
 
   it("resolverParticipantesPara devuelve los usernames del grupo y su id", async () => {
-    const a = make();
+    const grupal = nuevoGrupal();
     const buscar = vi.fn().mockResolvedValue(
       fakeGrupo("los-lambdas", ["ana", "bob"])
     );
-    const r = await a.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
-    expect(r).toEqual({ usernames: ["ana", "bob"], grupoId: "los-lambdas" });
+    const participantes = await grupal.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
+    expect(participantes).toEqual({ usernames: ["ana", "bob"], grupoId: "los-lambdas" });
     expect(buscar).toHaveBeenCalledWith("a1", "ana");
   });
 
   it("resolverParticipantesPara lanza GrupoNoAsignadoError si el alumno no tiene grupo", async () => {
-    const a = make();
+    const grupal = nuevoGrupal();
     const buscar = vi.fn().mockResolvedValue(null);
     await expect(
-      a.resolverParticipantesPara({ githubUsername: "forastero" }, buscar)
+      grupal.resolverParticipantesPara({ githubUsername: "forastero" }, buscar)
     ).rejects.toBeInstanceOf(GrupoNoAsignadoError);
   });
 
   it("el error incluye el assignmentId y el githubUsername para diagnóstico", async () => {
-    const a = make();
+    const grupal = nuevoGrupal();
     const buscar = vi.fn().mockResolvedValue(null);
     try {
-      await a.resolverParticipantesPara({ githubUsername: "forastero" }, buscar);
+      await grupal.resolverParticipantesPara({ githubUsername: "forastero" }, buscar);
       expect.fail("debería haber lanzado GrupoNoAsignadoError");
-    } catch (e) {
-      expect(e).toBeInstanceOf(GrupoNoAsignadoError);
-      const err = e as GrupoNoAsignadoError;
+    } catch (error) {
+      expect(error).toBeInstanceOf(GrupoNoAsignadoError);
+      const err = error as GrupoNoAsignadoError;
       expect(err.assignmentId).toBe("a1");
       expect(err.githubUsername).toBe("forastero");
     }

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect, vi } from "vitest";
+import { IndividualAssignment } from "./IndividualAssignment";
+import { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
+import type { Alumno } from "./Alumno";
+import type { Grupo } from "./Grupo";
+
+function fakeAlumno(github: string): Alumno {
+  return { githubUsername: github } as Alumno;
+}
+
+function fakeGrupo(id: string, usernames: string[]): Grupo {
+  return {
+    id,
+    alumnos: { getItems: () => usernames.map(fakeAlumno) },
+  } as unknown as Grupo;
+}
+
+describe("IndividualAssignment", () => {
+  it("la etiqueta de totales es 'Alumnos'", () => {
+    expect(new IndividualAssignment().etiquetaTotales()).toBe("Alumnos");
+  });
+
+  it("totalEsperado cuenta todos los alumnos del curso", async () => {
+    const a = new IndividualAssignment();
+    const alumnos = [fakeAlumno("ana"), fakeAlumno("bob"), fakeAlumno("cora")];
+    const total = await a.totalEsperado({
+      getAlumnosDelCurso: async () => alumnos,
+      getGruposDeAssignment: vi.fn(),
+    });
+    expect(total).toBe(3);
+  });
+
+  it("totalEsperado no consulta grupos (no le aplican al individual)", async () => {
+    const a = new IndividualAssignment();
+    const getGrupos = vi.fn();
+    await a.totalEsperado({
+      getAlumnosDelCurso: async () => [],
+      getGruposDeAssignment: getGrupos,
+    });
+    expect(getGrupos).not.toHaveBeenCalled();
+  });
+
+  it("resolverParticipantesPara devuelve solo al usuario que acepta", async () => {
+    const a = new IndividualAssignment();
+    const r = await a.resolverParticipantesPara(
+      { githubUsername: "ana" },
+      vi.fn()
+    );
+    expect(r.usernames).toEqual(["ana"]);
+    expect(r.grupoId).toBeUndefined();
+  });
+
+  it("resolverParticipantesPara ignora la lambda de buscar grupo", async () => {
+    const a = new IndividualAssignment();
+    const buscar = vi.fn();
+    await a.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
+    expect(buscar).not.toHaveBeenCalled();
+  });
+});
+
+describe("GrupalAssignment", () => {
+  function make(): GrupalAssignment {
+    const g = new GrupalAssignment();
+    g.id = "a1";
+    g.maxIntegrantes = 4;
+    return g;
+  }
+
+  it("la etiqueta de totales es 'Grupos'", () => {
+    expect(make().etiquetaTotales()).toBe("Grupos");
+  });
+
+  it("totalEsperado cuenta los grupos del assignment", async () => {
+    const a = make();
+    const total = await a.totalEsperado({
+      getAlumnosDelCurso: vi.fn(),
+      getGruposDeAssignment: async (id) => {
+        expect(id).toBe("a1");
+        return [fakeGrupo("g1", []), fakeGrupo("g2", [])];
+      },
+    });
+    expect(total).toBe(2);
+  });
+
+  it("totalEsperado no consulta alumnos del curso (no aplica al grupal)", async () => {
+    const a = make();
+    const getAlumnos = vi.fn();
+    await a.totalEsperado({
+      getAlumnosDelCurso: getAlumnos,
+      getGruposDeAssignment: async () => [],
+    });
+    expect(getAlumnos).not.toHaveBeenCalled();
+  });
+
+  it("resolverParticipantesPara devuelve los usernames del grupo y su id", async () => {
+    const a = make();
+    const buscar = vi.fn().mockResolvedValue(
+      fakeGrupo("los-lambdas", ["ana", "bob"])
+    );
+    const r = await a.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
+    expect(r).toEqual({ usernames: ["ana", "bob"], grupoId: "los-lambdas" });
+    expect(buscar).toHaveBeenCalledWith("a1", "ana");
+  });
+
+  it("resolverParticipantesPara lanza GrupoNoAsignadoError si el alumno no tiene grupo", async () => {
+    const a = make();
+    const buscar = vi.fn().mockResolvedValue(null);
+    await expect(
+      a.resolverParticipantesPara({ githubUsername: "forastero" }, buscar)
+    ).rejects.toBeInstanceOf(GrupoNoAsignadoError);
+  });
+
+  it("el error incluye el assignmentId y el githubUsername para diagnóstico", async () => {
+    const a = make();
+    const buscar = vi.fn().mockResolvedValue(null);
+    try {
+      await a.resolverParticipantesPara({ githubUsername: "forastero" }, buscar);
+      expect.fail("debería haber lanzado GrupoNoAsignadoError");
+    } catch (e) {
+      expect(e).toBeInstanceOf(GrupoNoAsignadoError);
+      const err = e as GrupoNoAsignadoError;
+      expect(err.assignmentId).toBe("a1");
+      expect(err.githubUsername).toBe("forastero");
+    }
+  });
+});

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -7,7 +7,33 @@ import {
 } from "@mikro-orm/core";
 import { randomUUID } from "crypto";
 import { Comision } from "./Comision";
+import type { Alumno } from "./Alumno";
+import type { Grupo } from "./Grupo";
 import type { Paradigma, TipoAssignment } from "@/types";
+
+// Dependencias de lectura que las subclases pueden usar desde sus métodos
+// polimórficos — se pasan como parámetro para que las entidades no importen
+// `@/lib/repositories` (mantiene el dominio testeable sin mocks globales).
+//
+// `getAlumnosDelCurso` es un thunk, no la lista ya cargada: el caller puede
+// querer arrancar la query en paralelo con otras y pasarle la misma promise
+// para que Individual la reutilice sin disparar un segundo fetch.
+export interface TotalEsperadoCtx {
+  getAlumnosDelCurso: () => Promise<Alumno[]>;
+  getGruposDeAssignment: (assignmentId: string) => Promise<Grupo[]>;
+}
+
+// Lambda con la firma mínima que necesita `GrupalAssignment.resolverParticipantesPara`.
+// Individual la ignora. Declararla como tipo evita acoplar la entidad al repo.
+export type BuscarGrupoDelAlumno = (
+  assignmentId: string,
+  githubUsername: string
+) => Promise<Grupo | null>;
+
+export interface ParticipantesResueltos {
+  usernames: string[];
+  grupoId?: string;
+}
 
 // Single Table Inheritance: todos los assignments en una sola tabla,
 // discriminados por la columna `tipo`
@@ -42,4 +68,24 @@ export abstract class Assignment {
 
   @ManyToOne(() => Comision, { nullable: true })
   comision?: Comision;
+
+  /** Etiqueta para el contador "totales" del admin (ej: "Alumnos" / "Grupos"). */
+  abstract etiquetaTotales(): string;
+
+  /**
+   * Cardinalidad del total esperado para el contador del admin. Individual
+   * usa el padrón del curso; Grupal usa los grupos del assignment.
+   */
+  abstract totalEsperado(ctx: TotalEsperadoCtx): Promise<number>;
+
+  /**
+   * Resuelve a qué github users darles acceso al repo cuando un alumno acepta
+   * el assignment. La lambda `buscarGrupoDelAlumno` sólo la usa la variante
+   * grupal — individual la ignora. Lanza `GrupoNoAsignadoError` si el alumno
+   * no tiene grupo en un assignment grupal.
+   */
+  abstract resolverParticipantesPara(
+    user: { githubUsername: string },
+    buscarGrupoDelAlumno: BuscarGrupoDelAlumno
+  ): Promise<ParticipantesResueltos>;
 }

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -18,14 +18,14 @@ import type { Paradigma, TipoAssignment } from "@/types";
 // `getAlumnosDelCurso` es un thunk, no la lista ya cargada: el caller puede
 // querer arrancar la query en paralelo con otras y pasarle la misma promise
 // para que Individual la reutilice sin disparar un segundo fetch.
-export interface TotalEsperadoCtx {
+export interface FuentesDeConteo {
   getAlumnosDelCurso: () => Promise<Alumno[]>;
   getGruposDeAssignment: (assignmentId: string) => Promise<Grupo[]>;
 }
 
 // Lambda con la firma mínima que necesita `GrupalAssignment.resolverParticipantesPara`.
 // Individual la ignora. Declararla como tipo evita acoplar la entidad al repo.
-export type BuscarGrupoDelAlumno = (
+export type BuscadorDeGrupoDelAlumno = (
   assignmentId: string,
   githubUsername: string
 ) => Promise<Grupo | null>;
@@ -76,7 +76,7 @@ export abstract class Assignment {
    * Cardinalidad del total esperado para el contador del admin. Individual
    * usa el padrón del curso; Grupal usa los grupos del assignment.
    */
-  abstract totalEsperado(ctx: TotalEsperadoCtx): Promise<number>;
+  abstract totalEsperado(fuentes: FuentesDeConteo): Promise<number>;
 
   /**
    * Resuelve a qué github users darles acceso al repo cuando un alumno acepta
@@ -86,6 +86,6 @@ export abstract class Assignment {
    */
   abstract resolverParticipantesPara(
     user: { githubUsername: string },
-    buscarGrupoDelAlumno: BuscarGrupoDelAlumno
+    buscarGrupoDelAlumno: BuscadorDeGrupoDelAlumno
   ): Promise<ParticipantesResueltos>;
 }

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -1,9 +1,9 @@
 import { Collection, Entity, OneToMany, Property } from "@mikro-orm/core";
 import {
   Assignment,
-  type BuscarGrupoDelAlumno,
+  type BuscadorDeGrupoDelAlumno,
   type ParticipantesResueltos,
-  type TotalEsperadoCtx,
+  type FuentesDeConteo,
 } from "./Assignment";
 import type { Grupo } from "./Grupo";
 
@@ -32,20 +32,20 @@ export class GrupalAssignment extends Assignment {
     return "Grupos";
   }
 
-  async totalEsperado(ctx: TotalEsperadoCtx): Promise<number> {
-    return (await ctx.getGruposDeAssignment(this.id)).length;
+  async totalEsperado(fuentes: FuentesDeConteo): Promise<number> {
+    return (await fuentes.getGruposDeAssignment(this.id)).length;
   }
 
   async resolverParticipantesPara(
     user: { githubUsername: string },
-    buscarGrupoDelAlumno: BuscarGrupoDelAlumno
+    buscarGrupoDelAlumno: BuscadorDeGrupoDelAlumno
   ): Promise<ParticipantesResueltos> {
     const grupo = await buscarGrupoDelAlumno(this.id, user.githubUsername);
     if (!grupo) {
       throw new GrupoNoAsignadoError(this.id, user.githubUsername);
     }
     return {
-      usernames: grupo.alumnos.getItems().map((a) => a.githubUsername),
+      usernames: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
       grupoId: grupo.id,
     };
   }

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -1,6 +1,24 @@
 import { Collection, Entity, OneToMany, Property } from "@mikro-orm/core";
-import { Assignment } from "./Assignment";
+import {
+  Assignment,
+  type BuscarGrupoDelAlumno,
+  type ParticipantesResueltos,
+  type TotalEsperadoCtx,
+} from "./Assignment";
 import type { Grupo } from "./Grupo";
+
+// Lanzado cuando un alumno intenta aceptar un TP grupal y no figura en
+// ningún grupo del assignment. El handler de accept lo traduce a 400 con
+// un mensaje amigable — análogo al `LegajoConflictError` de registro.
+export class GrupoNoAsignadoError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly githubUsername: string
+  ) {
+    super("No tenés grupo asignado para este TP. Contactá a tu docente.");
+    this.name = "GrupoNoAsignadoError";
+  }
+}
 
 @Entity({ discriminatorValue: "grupal" })
 export class GrupalAssignment extends Assignment {
@@ -9,4 +27,26 @@ export class GrupalAssignment extends Assignment {
 
   @OneToMany("Grupo", "assignment")
   grupos = new Collection<Grupo>(this);
+
+  etiquetaTotales(): string {
+    return "Grupos";
+  }
+
+  async totalEsperado(ctx: TotalEsperadoCtx): Promise<number> {
+    return (await ctx.getGruposDeAssignment(this.id)).length;
+  }
+
+  async resolverParticipantesPara(
+    user: { githubUsername: string },
+    buscarGrupoDelAlumno: BuscarGrupoDelAlumno
+  ): Promise<ParticipantesResueltos> {
+    const grupo = await buscarGrupoDelAlumno(this.id, user.githubUsername);
+    if (!grupo) {
+      throw new GrupoNoAsignadoError(this.id, user.githubUsername);
+    }
+    return {
+      usernames: grupo.alumnos.getItems().map((a) => a.githubUsername),
+      grupoId: grupo.id,
+    };
+  }
 }

--- a/src/domain/entities/IndividualAssignment.ts
+++ b/src/domain/entities/IndividualAssignment.ts
@@ -3,7 +3,7 @@ import { Alumno } from "./Alumno";
 import {
   Assignment,
   type ParticipantesResueltos,
-  type TotalEsperadoCtx,
+  type FuentesDeConteo,
 } from "./Assignment";
 
 @Entity({ discriminatorValue: "individual" })
@@ -16,8 +16,8 @@ export class IndividualAssignment extends Assignment {
     return "Alumnos";
   }
 
-  async totalEsperado(ctx: TotalEsperadoCtx): Promise<number> {
-    return (await ctx.getAlumnosDelCurso()).length;
+  async totalEsperado(fuentes: FuentesDeConteo): Promise<number> {
+    return (await fuentes.getAlumnosDelCurso()).length;
   }
 
   async resolverParticipantesPara(user: {

--- a/src/domain/entities/IndividualAssignment.ts
+++ b/src/domain/entities/IndividualAssignment.ts
@@ -1,10 +1,28 @@
 import { Collection, Entity, ManyToMany } from "@mikro-orm/core";
 import { Alumno } from "./Alumno";
-import { Assignment } from "./Assignment";
+import {
+  Assignment,
+  type ParticipantesResueltos,
+  type TotalEsperadoCtx,
+} from "./Assignment";
 
 @Entity({ discriminatorValue: "individual" })
 export class IndividualAssignment extends Assignment {
   // Alumnos asignados a este TP individual (quiénes deben entregar)
   @ManyToMany(() => Alumno)
   alumnos = new Collection<Alumno>(this);
+
+  etiquetaTotales(): string {
+    return "Alumnos";
+  }
+
+  async totalEsperado(ctx: TotalEsperadoCtx): Promise<number> {
+    return (await ctx.getAlumnosDelCurso()).length;
+  }
+
+  async resolverParticipantesPara(user: {
+    githubUsername: string;
+  }): Promise<ParticipantesResueltos> {
+    return { usernames: [user.githubUsername] };
+  }
 }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -2,9 +2,9 @@ export { Alumno } from "./Alumno";
 export { Comision } from "./Comision";
 export { Assignment } from "./Assignment";
 export type {
-  TotalEsperadoCtx,
+  FuentesDeConteo,
   ParticipantesResueltos,
-  BuscarGrupoDelAlumno,
+  BuscadorDeGrupoDelAlumno,
 } from "./Assignment";
 export { IndividualAssignment } from "./IndividualAssignment";
 export { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,7 +1,12 @@
 export { Alumno } from "./Alumno";
 export { Comision } from "./Comision";
 export { Assignment } from "./Assignment";
+export type {
+  TotalEsperadoCtx,
+  ParticipantesResueltos,
+  BuscarGrupoDelAlumno,
+} from "./Assignment";
 export { IndividualAssignment } from "./IndividualAssignment";
-export { GrupalAssignment } from "./GrupalAssignment";
+export { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
 export { Grupo } from "./Grupo";
 export { Entrega } from "./Entrega";

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+import { logger } from "./logger";
+
+// Loggea el error completo server-side y devuelve siempre un 500 con mensaje
+// genérico — evita filtrar detalles internos (stack traces, esquemas de DB,
+// mensajes de librerías de terceros) al cliente.
+//
+// El `context` es opcional: sirve para adjuntar IDs útiles para debugging
+// (githubUsername, assignmentId, etc.) que quedan en el log server-side
+// pero NO llegan al cliente.
+//
+// TODO(PR 2): extender este helper para persistir el error también en la
+// tabla `error_log` (con dedup por fingerprint) y exponerlo en una pantalla
+// admin con badge de no leídos. Ver issue en el README.
+export function internalServerError(
+  route: string,
+  error: unknown,
+  context?: Record<string, unknown>
+): NextResponse {
+  logger.error({ err: error, route, ...context }, "handler error");
+  return NextResponse.json(
+    { error: "Error interno del servidor" },
+    { status: 500 }
+  );
+}

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -17,7 +17,7 @@ export function internalServerError(
   error: unknown,
   context?: Record<string, unknown>
 ): NextResponse {
-  logger.error({ err: error, route, ...context }, "handler error");
+  logger.error({ ...context, err: error, route }, "handler error");
   return NextResponse.json(
     { error: "Error interno del servidor" },
     { status: 500 }

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,35 @@
+import pino from "pino";
+
+// En dev usamos `pino-pretty` (legible en la terminal). En prod no podemos
+// usar transports: Vercel corre en serverless y los transports spawnean un
+// worker thread que no sobrevive. Solo escupimos JSON a stdout y la
+// plataforma lo captura. En test tampoco queremos pretty-print (los tests
+// mockean el logger y no necesitan spawnear un worker).
+const isDev = process.env.NODE_ENV === "development";
+
+export const logger = pino({
+  level: process.env.LOG_LEVEL ?? "info",
+  // `redact` enmascara campos sensibles aunque alguien los pase por accidente
+  // en el context del log. Ante la duda, agregar acá antes de logguear el valor.
+  redact: {
+    paths: [
+      "email",
+      "*.email",
+      "password",
+      "*.password",
+      "token",
+      "*.token",
+      "authorization",
+      "*.authorization",
+      "cookie",
+      "*.cookie",
+    ],
+    censor: "[REDACTED]",
+  },
+  ...(isDev && {
+    transport: {
+      target: "pino-pretty",
+      options: { colorize: true, translateTime: "HH:MM:ss.l" },
+    },
+  }),
+});


### PR DESCRIPTION
## Summary

`IndividualAssignment` y `GrupalAssignment` responden a tres mensajes en vez de que los consumidores discriminen con \`assignment.tipo === "..."\`:

| Método | Individual | Grupal |
|---|---|---|
| \`etiquetaTotales()\` | \`"Alumnos"\` | \`"Grupos"\` |
| \`totalEsperado(ctx)\` | padrón del curso | grupos del assignment |
| \`resolverParticipantesPara(user, buscarGrupoDelAlumno)\` | \`[user.github]\` | miembros del grupo |

Las dependencias de IO se **inyectan como parámetros**, como discutimos: los métodos no importan \`@/lib/repositories\`, el dominio queda testeable sin mocks globales.

### Detalle interesante

`totalEsperado` recibe un **thunk** (\`getAlumnosDelCurso: () => Promise<Alumno[]>\`) en vez de la lista ya cargada. El admin page lanza \`getAlumnos()\` una sola vez y pasa la misma promise al método — así Individual la **reutiliza** para contar sin disparar un segundo fetch. Grupal ignora el thunk y pide los grupos por su cuenta. El test \`siempre consulta alumnos (para nombres y conteo individual)\` del admin page ahora pasa con \`toHaveBeenCalledOnce()\`.

### Error tipado

Nuevo \`GrupoNoAsignadoError\` (lanzado por \`GrupalAssignment.resolverParticipantesPara\` cuando el alumno no tiene grupo) que el handler de accept traduce a 400 — análogo al patrón de \`LegajoConflictError\` de Fase 4.

### Archivos tocados

- \`src/domain/entities/Assignment.ts\` — métodos abstract + tipos \`TotalEsperadoCtx\`, \`ParticipantesResueltos\`, \`BuscarGrupoDelAlumno\`
- \`src/domain/entities/IndividualAssignment.ts\` / \`GrupalAssignment.ts\` — implementación polimórfica
- \`src/app/admin/assignments/[id]/page.tsx\` — reemplaza 3 IFs por llamadas polimórficas
- \`src/app/api/assignments/[id]/accept/route.ts\` — reemplaza el IF grupal por \`resolverParticipantesPara\` + catch de \`GrupoNoAsignadoError\`
- \`src/domain/entities/Assignment.test.ts\` (nuevo) — 11 tests de unidad sobre el comportamiento polimórfico
- \`src/app/api/assignments/[id]/accept/route.test.ts\` — helper \`makeAssignment\` instancia la subclase correcta según \`tipo\`

## Test plan

- [x] \`pnpm test:run\` — 528/528 (11 tests nuevos en \`Assignment.test.ts\`).
- [x] \`pnpm tsc --noEmit\` — cero errores en archivos productivos.
- [ ] Probar en local: detalle de TP individual y grupal muestran la etiqueta y el total correcto; aceptar un TP grupal sin grupo asignado devuelve 400 con el mensaje amigable.

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Revisión del modelo de asignaciones: totales y etiquetas ahora se resuelven según tipo (individual vs grupal), y la UI muestra la etiqueta de totales correspondiente.

* **Bug Fixes**
  * Manejo claro cuando no hay grupo asignado al aceptar una asignación; responde adecuadamente al cliente.

* **Tests**
  * Nuevos tests que verifican comportamientos para asignaciones individuales y grupales y la gestión de grupos no asignados.

* **Documentation**
  * Checklist del README actualizado: “Observabilidad” y “Fase 1” marcadas como completadas.

* **Seguridad / Operaciones**
  * Respuestas de error internas estandarizadas y registro mejorado con datos sensibles enmascarados.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->