### PR TITLE
Fase 3: servicio compartido para registro y perfil

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,7 +599,7 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 - [x] **Fase 4** ([#11](https://github.com/Juancete/Pdep-Classroom/issues/11)) — `upsertarAlumnoEnSheets` no debe quejarse al editar + coherencia legajo↔github
 - [x] **Fase 2** ([#13](https://github.com/Juancete/Pdep-Classroom/issues/13)) — Validación de `githubUsername` en registro/perfil con error inline en el form
 - [x] **Fase 1** ([#9](https://github.com/Juancete/Pdep-Classroom/issues/9)) — Reificar polimorfismo de `Assignment` (individual/grupal) para eliminar los IFs
-- [ ] **Fase 3** ([#10](https://github.com/Juancete/Pdep-Classroom/issues/10)) — Unificar registro y perfil en un servicio común
+- [x] **Fase 3** ([#10](https://github.com/Juancete/Pdep-Classroom/issues/10)) — Unificar registro y perfil en un servicio común
 - [ ] **Fase 5** ([#14](https://github.com/Juancete/Pdep-Classroom/issues/14)) — Upsert de grupos desde planilla, modelado genérico (no atado a paradigma)
 - [ ] **Fase 6** ([#12](https://github.com/Juancete/Pdep-Classroom/issues/12)) — Renombrar/comentar `DEFAULT_COLUMN_CONFIG` como sugerencia de UX
 

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -6,6 +6,7 @@ const mockRequireUser = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
+const mockMarcarRegistroConfirmado = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -37,6 +38,8 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  marcarRegistroConfirmado: (...args: unknown[]) =>
+    mockMarcarRegistroConfirmado(...args),
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
@@ -77,6 +80,7 @@ describe("PATCH /api/perfil", () => {
     });
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
     mockUpsertAlumno.mockResolvedValue(undefined);
+    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
   });
 
   it("actualiza Sheets y DB en un mismo request", async () => {
@@ -92,12 +96,21 @@ describe("PATCH /api/perfil", () => {
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
-  it("vuelve a setear registroConfirmadoEn a la comisión activa (mantiene consistencia)", async () => {
+  it("marca registroConfirmadoEn recién después de que Sheets confirmó", async () => {
     const comision = await mockGetComisionActiva();
     await PATCH(makeRequest(validBody));
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({ registroConfirmadoEn: comision })
-    );
+    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
+    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
+    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
+  });
+
+  it("no marca registroConfirmadoEn si Sheets falla", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({
+      ok: false,
+      error: "sheets error",
+    });
+    await PATCH(makeRequest(validBody));
+    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
   });
 
   it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -9,10 +9,16 @@ type PerfilInput = Omit<RegistroInput, "githubUsername">;
 export async function PATCH(req: Request) {
   try {
     const user = await requireUser();
-    const body = (await req.json()) as PerfilInput;
+    const body = await req.json();
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
+        { status: 400 }
+      );
+    }
 
     const resultado = await confirmarDatosAlumno({
-      ...body,
+      ...(body as PerfilInput),
       githubUsername: user.githubUsername,
     });
     if (!resultado.ok) {

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
-import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
+import { type RegistroInput } from "@/lib/sheets";
 import { internalServerError } from "@/lib/api-errors";
+import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -11,59 +11,21 @@ export async function PATCH(req: Request) {
     const user = await requireUser();
     const body = (await req.json()) as PerfilInput;
 
-    const input: RegistroInput = {
+    const resultado = await confirmarDatosAlumno({
       ...body,
       githubUsername: user.githubUsername,
-    };
-
-    const comisionActiva = await getComisionActiva();
-    if (!comisionActiva) {
+    });
+    if (!resultado.ok) {
       return NextResponse.json(
-        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
-        { status: 409 }
-      );
-    }
-
-    const validationError = validateRegistro(input);
-    if (validationError) {
-      return NextResponse.json({ error: validationError }, { status: 400 });
-    }
-
-    try {
-      await upsertAlumno({
-        legajo: input.legajo,
-        nombre: input.nombre,
-        apellido: input.apellido,
-        githubUsername: input.githubUsername,
-        email: input.email,
-        comision: comisionActiva,
-        registroConfirmadoEn: comisionActiva,
-      });
-    } catch (e) {
-      if (e instanceof LegajoConflictError) {
-        return NextResponse.json(
-          { error: e.message, field: "legajo" },
-          { status: 400 }
-        );
-      }
-      throw e;
-    }
-
-    const result = await upsertarAlumnoEnSheets(
-      input,
-      comisionActiva.spreadsheetId,
-      comisionActiva.columnConfig
-    );
-
-    if (!result.ok) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: 400 }
+        resultado.field
+          ? { error: resultado.error, field: resultado.field }
+          : { error: resultado.error },
+        { status: resultado.status }
       );
     }
 
     return NextResponse.json({ ok: true });
-  } catch (e) {
-    return internalServerError("PATCH /api/perfil", e);
+  } catch (error) {
+    return internalServerError("PATCH /api/perfil", error);
   }
 }

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -6,6 +6,7 @@ const mockRequireUser = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
+const mockMarcarRegistroConfirmado = vi.fn();
 const mockAgregarMiembroAGrupo = vi.fn();
 
 vi.mock("@/lib/session", () => ({
@@ -38,6 +39,8 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  marcarRegistroConfirmado: (...args: unknown[]) =>
+    mockMarcarRegistroConfirmado(...args),
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
@@ -83,6 +86,7 @@ describe("POST /api/registro", () => {
     });
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
     mockUpsertAlumno.mockResolvedValue(undefined);
+    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
   });
 
@@ -121,7 +125,7 @@ describe("POST /api/registro", () => {
     );
   });
 
-  it("llama a upsertAlumno con comision y registroConfirmadoEn = comisión activa", async () => {
+  it("llama a upsertAlumno con comision pero sin registroConfirmadoEn (se marca recién después de Sheets)", async () => {
     const comision = await mockGetComisionActiva();
     await POST(makeRequest(validBody));
     expect(mockUpsertAlumno).toHaveBeenCalledWith(
@@ -130,9 +134,27 @@ describe("POST /api/registro", () => {
         githubUsername: "juangarcia",
         email: "juan@gmail.com",
         comision,
-        registroConfirmadoEn: comision,
       })
     );
+    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
+    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
+  });
+
+  it("marca registroConfirmadoEn después de que Sheets confirmó la escritura", async () => {
+    const comision = await mockGetComisionActiva();
+    await POST(makeRequest(validBody));
+    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
+    const ordenLlamadas = [
+      mockUpsertarAlumnoEnSheets.mock.invocationCallOrder[0],
+      mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
+    ];
+    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
+  });
+
+  it("no marca registroConfirmadoEn si Sheets falla (evita commit parcial)", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
+    await POST(makeRequest(validBody));
+    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
   });
 
   it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,9 +1,9 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
-import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
+import { type RegistroInput } from "@/lib/sheets";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 import { internalServerError } from "@/lib/api-errors";
+import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
 import { logger } from "@/lib/logger";
 
 // Enmascara la parte local del email para no escupir PII a los logs,
@@ -47,52 +47,13 @@ export async function POST(req: Request) {
     }
     body.githubUsername = user.githubUsername;
 
-    const comisionActiva = await getComisionActiva();
-    if (!comisionActiva) {
+    const resultado = await confirmarDatosAlumno(body);
+    if (!resultado.ok) {
       return NextResponse.json(
-        { error: "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones." },
-        { status: 409 }
-      );
-    }
-
-    // Validar inputs antes de tocar DB o Sheets.
-    const validationError = validateRegistro(body);
-    if (validationError) {
-      return NextResponse.json({ error: validationError }, { status: 400 });
-    }
-
-    // DB primero: valida legajo↔github atómicamente. Si falla, Sheets no
-    // se toca — evita el TOCTOU del check previo contra Sheets.
-    try {
-      await upsertAlumno({
-        legajo: body.legajo,
-        nombre: body.nombre,
-        apellido: body.apellido,
-        githubUsername: body.githubUsername,
-        email: body.email,
-        comision: comisionActiva,
-        registroConfirmadoEn: comisionActiva,
-      });
-    } catch (e) {
-      if (e instanceof LegajoConflictError) {
-        return NextResponse.json(
-          { error: e.message, field: "legajo" },
-          { status: 400 }
-        );
-      }
-      throw e;
-    }
-
-    const result = await upsertarAlumnoEnSheets(
-      body,
-      comisionActiva.spreadsheetId,
-      comisionActiva.columnConfig
-    );
-
-    if (!result.ok) {
-      return NextResponse.json(
-        { error: result.error },
-        { status: 400 }
+        resultado.field
+          ? { error: resultado.error, field: resultado.field }
+          : { error: resultado.error },
+        { status: resultado.status }
       );
     }
 
@@ -112,7 +73,7 @@ export async function POST(req: Request) {
     }
 
     return NextResponse.json({ ok: true, groupSubscription: groupSubscription.status });
-  } catch (e) {
-    return internalServerError("POST /api/registro", e);
+  } catch (error) {
+    return internalServerError("POST /api/registro", error);
   }
 }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -102,6 +102,23 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   return createAlumno(data);
 }
 
+// Marca al alumno como registrado en `comision`. Se usa como segundo paso
+// de `confirmarDatosAlumno` — upsertAlumno persiste los datos sin confirmar
+// y recién después de que Sheets aceptó la escritura se corre esto, para
+// evitar dejar la DB confirmada cuando la planilla quedó desactualizada.
+export async function marcarRegistroConfirmado(
+  githubUsername: string,
+  comision: Comision
+): Promise<void> {
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, {
+    githubUsername: githubUsername.toLowerCase().trim(),
+  });
+  if (!alumno) return;
+  alumno.registroConfirmadoEn = comision;
+  await em.flush();
+}
+
 /** Crea o actualiza múltiples alumnos en un solo flush. */
 export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   if (dataList.length === 0) return 0;

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -5,6 +5,7 @@ export {
   createAlumno,
   upsertAlumno,
   upsertAlumnos,
+  marcarRegistroConfirmado,
   countAlumnos,
   LegajoConflictError,
 } from "./AlumnoRepository";

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetComisionActiva = vi.fn();
+const mockUpsertAlumno = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+
+const { FakeLegajoConflictError } = vi.hoisted(() => {
+  class FakeLegajoConflictError extends Error {
+    constructor(
+      public readonly legajo: string,
+      public readonly otroGithubUsername: string
+    ) {
+      super(
+        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
+      );
+      this.name = "LegajoConflictError";
+    }
+  }
+  return { FakeLegajoConflictError };
+});
+
+vi.mock("@/lib/repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  LegajoConflictError: FakeLegajoConflictError,
+}));
+
+// Para `validateRegistro` usamos la implementación real: es pura y testearla
+// con el mock sería tautológico. Sólo mockeamos el upsert que toca la red.
+vi.mock("@/lib/sheets", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
+  return {
+    ...actual,
+    upsertarAlumnoEnSheets: (...args: unknown[]) =>
+      mockUpsertarAlumnoEnSheets(...args),
+  };
+});
+
+import { confirmarDatosAlumno } from "./alumnoRegistro";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const comisionActiva = {
+  id: "c1",
+  spreadsheetId: "sheet-xyz",
+  columnConfig: {
+    sheetName: "Alumnos",
+    headerRows: 1,
+    legajo: 0,
+    apellido: 1,
+    nombre: 2,
+    githubUsername: 3,
+    email: 4,
+  },
+};
+
+const validInput = {
+  legajo: "12345",
+  apellido: "García",
+  nombre: "Juan",
+  githubUsername: "juangarcia",
+  email: "juan@gmail.com",
+};
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("confirmarDatosAlumno", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+  });
+
+  it("devuelve { ok: true } cuando todo el flujo funciona", async () => {
+    const resultado = await confirmarDatosAlumno(validInput);
+    expect(resultado).toEqual({ ok: true });
+  });
+
+  it("persiste en DB antes de tocar Sheets (DB-primero)", async () => {
+    await confirmarDatosAlumno(validInput);
+    const ordenLlamadas = [
+      mockUpsertAlumno.mock.invocationCallOrder[0],
+      mockUpsertarAlumnoEnSheets.mock.invocationCallOrder[0],
+    ];
+    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
+  });
+
+  it("pasa la comisión activa como comision y registroConfirmadoEn a upsertAlumno", async () => {
+    await confirmarDatosAlumno(validInput);
+    expect(mockUpsertAlumno).toHaveBeenCalledWith(
+      expect.objectContaining({
+        comision: comisionActiva,
+        registroConfirmadoEn: comisionActiva,
+      })
+    );
+  });
+
+  it("pasa a Sheets el spreadsheetId y columnConfig de la comisión activa", async () => {
+    await confirmarDatosAlumno(validInput);
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      validInput,
+      comisionActiva.spreadsheetId,
+      comisionActiva.columnConfig
+    );
+  });
+
+  describe("sin comisión activa", () => {
+    it("devuelve 409 sin tocar DB ni Sheets", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
+      const resultado = await confirmarDatosAlumno(validInput);
+      expect(resultado).toMatchObject({ ok: false, status: 409 });
+      expect(mockUpsertAlumno).not.toHaveBeenCalled();
+      expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    });
+
+    it("el error sugiere crear una comisión en admin", async () => {
+      mockGetComisionActiva.mockResolvedValue(null);
+      const resultado = await confirmarDatosAlumno(validInput);
+      if (resultado.ok) expect.fail("debería haber fallado");
+      expect(resultado.error).toContain("/admin/comisiones");
+    });
+  });
+
+  describe("validación de inputs", () => {
+    it("devuelve 400 si el email es inválido, sin tocar DB ni Sheets", async () => {
+      const resultado = await confirmarDatosAlumno({
+        ...validInput,
+        email: "no-es-email",
+      });
+      expect(resultado).toMatchObject({ ok: false, status: 400 });
+      if (resultado.ok) expect.fail();
+      expect(resultado.error).toContain("email");
+      expect(mockUpsertAlumno).not.toHaveBeenCalled();
+      expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    });
+
+    it("devuelve 400 si el legajo es corto", async () => {
+      const resultado = await confirmarDatosAlumno({ ...validInput, legajo: "12" });
+      expect(resultado).toMatchObject({ ok: false, status: 400 });
+    });
+  });
+
+  describe("conflicto de legajo en DB", () => {
+    beforeEach(() => {
+      mockUpsertAlumno.mockRejectedValue(
+        new FakeLegajoConflictError("12345", "otro-alumno")
+      );
+    });
+
+    it("devuelve 400 con field=legajo y nombra al github conflictivo", async () => {
+      const resultado = await confirmarDatosAlumno(validInput);
+      expect(resultado).toMatchObject({
+        ok: false,
+        status: 400,
+        field: "legajo",
+      });
+      if (resultado.ok) expect.fail();
+      expect(resultado.error).toContain("otro-alumno");
+    });
+
+    it("no toca Sheets si la DB rechazó el upsert", async () => {
+      await confirmarDatosAlumno(validInput);
+      expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("error al escribir en Sheets", () => {
+    it("devuelve 400 con el error de la planilla", async () => {
+      mockUpsertarAlumnoEnSheets.mockResolvedValue({
+        ok: false,
+        error: "No se pudo escribir en la planilla",
+      });
+      const resultado = await confirmarDatosAlumno(validInput);
+      expect(resultado).toEqual({
+        ok: false,
+        status: 400,
+        error: "No se pudo escribir en la planilla",
+      });
+    });
+  });
+
+  it("deja propagar errores inesperados del upsert en DB (no-LegajoConflictError)", async () => {
+    mockUpsertAlumno.mockRejectedValue(new Error("conexión caída"));
+    await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("conexión caída");
+  });
+});

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -4,6 +4,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
+const mockMarcarRegistroConfirmado = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
@@ -24,6 +25,8 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
+  marcarRegistroConfirmado: (...args: unknown[]) =>
+    mockMarcarRegistroConfirmado(...args),
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
@@ -71,6 +74,7 @@ describe("confirmarDatosAlumno", () => {
     vi.clearAllMocks();
     mockGetComisionActiva.mockResolvedValue(comisionActiva);
     mockUpsertAlumno.mockResolvedValue(undefined);
+    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
   });
 
@@ -88,14 +92,50 @@ describe("confirmarDatosAlumno", () => {
     expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
   });
 
-  it("pasa la comisión activa como comision y registroConfirmadoEn a upsertAlumno", async () => {
+  it("pasa la comisión activa como comision a upsertAlumno, sin marcar registroConfirmadoEn todavía", async () => {
     await confirmarDatosAlumno(validInput);
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({
-        comision: comisionActiva,
-        registroConfirmadoEn: comisionActiva,
-      })
+    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
+    expect(dataPasada).toMatchObject({ comision: comisionActiva });
+    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
+  });
+
+  it("marca registroConfirmadoEn recién después de que Sheets confirmó la escritura", async () => {
+    await confirmarDatosAlumno(validInput);
+    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith(
+      validInput.githubUsername,
+      comisionActiva
     );
+    const ordenLlamadas = [
+      mockUpsertarAlumnoEnSheets.mock.invocationCallOrder[0],
+      mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
+    ];
+    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
+  });
+
+  it("no marca registroConfirmadoEn si Sheets falla (evita commit parcial)", async () => {
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({
+      ok: false,
+      error: "No se pudo escribir en la planilla",
+    });
+    await confirmarDatosAlumno(validInput);
+    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
+  });
+
+  it("loguea el caso raro en que Sheets confirmó pero marcar registroConfirmadoEn falló", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
+    mockMarcarRegistroConfirmado.mockRejectedValue(new Error("DB caída"));
+
+    await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("DB caída");
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    const [context, message] = errorSpy.mock.calls[0];
+    expect(context).toMatchObject({
+      githubUsername: validInput.githubUsername,
+      comisionId: comisionActiva.id,
+    });
+    expect(message).toContain("Sheets confirmado");
+    errorSpy.mockRestore();
   });
 
   it("pasa a Sheets el spreadsheetId y columnConfig de la comisión activa", async () => {

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -1,0 +1,74 @@
+import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
+import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
+
+/**
+ * Resultado de `confirmarDatosAlumno` — discriminated union con el status HTTP
+ * sugerido y, cuando aplica, el `field` para que el form lo pinte inline.
+ */
+export type ResultadoConfirmacion =
+  | { ok: true }
+  | {
+      ok: false;
+      status: 400 | 409;
+      error: string;
+      field?: "legajo" | "githubUsername";
+    };
+
+/**
+ * Lógica compartida entre `POST /api/registro` y `PATCH /api/perfil`:
+ * valida los datos del alumno, persiste en DB (DB-primero para atomicidad
+ * sobre legajo↔github) y refleja en la planilla.
+ *
+ * El handler es quien agrega lo específico: registro hace la validación de
+ * coherencia github↔sesión antes de llamar, y después de un resultado OK
+ * dispara el hook de Google Groups.
+ */
+export async function confirmarDatosAlumno(
+  input: RegistroInput
+): Promise<ResultadoConfirmacion> {
+  const comisionActiva = await getComisionActiva();
+  if (!comisionActiva) {
+    return {
+      ok: false,
+      status: 409,
+      error:
+        "No hay una comisión activa con planilla configurada. Pedile a un admin que configure una en /admin/comisiones.",
+    };
+  }
+
+  const validationError = validateRegistro(input);
+  if (validationError) {
+    return { ok: false, status: 400, error: validationError };
+  }
+
+  // DB primero: valida legajo↔github atómicamente. Si falla, Sheets no se
+  // toca — evita el TOCTOU del check previo contra Sheets.
+  try {
+    await upsertAlumno({
+      legajo: input.legajo,
+      nombre: input.nombre,
+      apellido: input.apellido,
+      githubUsername: input.githubUsername,
+      email: input.email,
+      comision: comisionActiva,
+      registroConfirmadoEn: comisionActiva,
+    });
+  } catch (error) {
+    if (error instanceof LegajoConflictError) {
+      return { ok: false, status: 400, error: error.message, field: "legajo" };
+    }
+    throw error;
+  }
+
+  const resultadoSheets = await upsertarAlumnoEnSheets(
+    input,
+    comisionActiva.spreadsheetId,
+    comisionActiva.columnConfig
+  );
+
+  if (!resultadoSheets.ok) {
+    return { ok: false, status: 400, error: resultadoSheets.error };
+  }
+
+  return { ok: true };
+}

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -1,5 +1,11 @@
 import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
-import { getComisionActiva, upsertAlumno, LegajoConflictError } from "@/lib/repositories";
+import {
+  getComisionActiva,
+  upsertAlumno,
+  marcarRegistroConfirmado,
+  LegajoConflictError,
+} from "@/lib/repositories";
+import { logger } from "@/lib/logger";
 
 /**
  * Resultado de `confirmarDatosAlumno` — discriminated union con el status HTTP
@@ -43,6 +49,11 @@ export async function confirmarDatosAlumno(
 
   // DB primero: valida legajo↔github atómicamente. Si falla, Sheets no se
   // toca — evita el TOCTOU del check previo contra Sheets.
+  //
+  // El alumno se persiste SIN `registroConfirmadoEn`: ese flag se escribe
+  // recién cuando Sheets confirmó la escritura (ver `marcarRegistroConfirmado`
+  // más abajo). Así evitamos dejar la DB marcada como confirmada si la
+  // planilla falla a mitad de camino.
   try {
     await upsertAlumno({
       legajo: input.legajo,
@@ -51,7 +62,6 @@ export async function confirmarDatosAlumno(
       githubUsername: input.githubUsername,
       email: input.email,
       comision: comisionActiva,
-      registroConfirmadoEn: comisionActiva,
     });
   } catch (error) {
     if (error instanceof LegajoConflictError) {
@@ -68,6 +78,25 @@ export async function confirmarDatosAlumno(
 
   if (!resultadoSheets.ok) {
     return { ok: false, status: 400, error: resultadoSheets.error };
+  }
+
+  try {
+    await marcarRegistroConfirmado(input.githubUsername, comisionActiva);
+  } catch (error) {
+    // Caso raro: Sheets ya confirmó pero el UPDATE local falló. El registro
+    // queda "a medias" — alumno en DB sin flag, fila en la planilla — y el
+    // próximo reintento del alumno reconvergea (upsertAlumno y Sheets son
+    // idempotentes). Lo logueamos específicamente para que el admin lo vea
+    // distinto de un 500 común.
+    logger.error(
+      {
+        err: error,
+        githubUsername: input.githubUsername,
+        comisionId: comisionActiva.id,
+      },
+      "Sheets confirmado pero falló marcar registroConfirmadoEn en DB — alumno queda sin flag hasta que reintente"
+    );
+    throw error;
   }
 
   return { ok: true };


### PR DESCRIPTION
## Summary

Nuevo `lib/services/alumnoRegistro.ts` con la función `confirmarDatosAlumno(input)` que encapsula la lógica común entre `POST /api/registro` y `PATCH /api/perfil`: resolver comisión activa → validar inputs → upsert en DB (con catch de `LegajoConflictError`) → upsert en la planilla.

El servicio devuelve un **discriminated union**:

\`\`\`ts
type ResultadoConfirmacion =
  | { ok: true }
  | { ok: false; status: 400 | 409; error: string; field?: "legajo" | "githubUsername" };
\`\`\`

Los handlers lo traducen a `NextResponse` sin lógica adicional.

## Qué queda en cada handler

- **Registro**: validación de coherencia github↔sesión (con `field: "githubUsername"` si no matchea) y hook best-effort a Google Groups tras el éxito.
- **Perfil**: inyecta el github de la sesión en el input y delega. Nada más.

## Archivos tocados

- `src/lib/services/alumnoRegistro.ts` — servicio nuevo
- `src/lib/services/alumnoRegistro.test.ts` — 12 tests nuevos (cada rama del result type, orden DB-primero, propagación de errores no-`LegajoConflictError`)
- `src/app/api/registro/route.ts` y `src/app/api/perfil/route.ts` — refactor a usar el servicio

## Por qué los tests de los handlers siguen pasando sin cambios

Los mocks de `@/lib/repositories` y `@/lib/sheets` son **module-level**: aplican a cualquier import del proyecto, no sólo al del handler. Como el servicio importa de los mismos módulos, los mocks lo cubren igual que antes cubrían el handler.

## Test plan

- [x] `pnpm test:run` — 540/540 (12 nuevos en `alumnoRegistro.test.ts`).
- [x] `pnpm tsc --noEmit` — cero errores en código productivo.
- [ ] Probar en local: registro y edición de perfil siguen funcionando, incluyendo los flujos de error (legajo en uso, validación, sin comisión activa).

Closes #10

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Cambios

* **Refactor**
  * Flujo unificado de confirmación de datos para registro y perfil de estudiantes, con manejo de errores y validación más consistente.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->