### PR TITLE
Fase 5: upsert de grupos desde planilla al confirmar registro

### DIFF
--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -6,7 +6,7 @@ import { getAlumnos } from "@/lib/sheets";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
-import { DEFAULT_COLUMN_CONFIG } from "@/types";
+import { DEFAULT_COLUMN_CONFIG, type GruposColumnConfig } from "@/types";
 
 export type ComisionFormState =
   | { ok: false; errors: Record<string, string[] | undefined> }
@@ -17,6 +17,13 @@ const ColumnIndexSchema = z.coerce
   .int()
   .min(0, "Columna inválida")
   .max(25, "Columna inválida");
+
+// "" → undefined para columnas opcionales de grupos: la UI envía string vacío
+// cuando el admin elige "(sin columna)".
+const OptionalColumnIndexSchema = z.preprocess(
+  (v) => (v === "" || v === undefined || v === null ? undefined : v),
+  ColumnIndexSchema.optional()
+);
 
 const ComisionSchema = z.object({
   anio: z.coerce
@@ -33,6 +40,13 @@ const ComisionSchema = z.object({
   col_nombre: ColumnIndexSchema,
   col_githubUsername: ColumnIndexSchema,
   col_email: ColumnIndexSchema,
+  grupos_enabled: z.coerce.boolean().optional().transform((v) => v ?? false),
+  grupos_sheetName: z.string().optional(),
+  grupos_headerRows: z.coerce.number().int().min(0).max(10).optional(),
+  grupos_col_githubUsername: OptionalColumnIndexSchema,
+  grupos_col_funcional: OptionalColumnIndexSchema,
+  grupos_col_logico: OptionalColumnIndexSchema,
+  grupos_col_objetos: OptionalColumnIndexSchema,
 });
 
 function parseFormData(formData: FormData) {
@@ -47,11 +61,18 @@ function parseFormData(formData: FormData) {
     col_nombre: formData.get("col_nombre") ?? DEFAULT_COLUMN_CONFIG.nombre,
     col_githubUsername: formData.get("col_githubUsername") ?? DEFAULT_COLUMN_CONFIG.githubUsername,
     col_email: formData.get("col_email") ?? DEFAULT_COLUMN_CONFIG.email,
+    grupos_enabled: formData.get("grupos_enabled") === "on",
+    grupos_sheetName: (formData.get("grupos_sheetName") as string) ?? undefined,
+    grupos_headerRows: formData.get("grupos_headerRows") ?? undefined,
+    grupos_col_githubUsername: formData.get("grupos_col_githubUsername") ?? undefined,
+    grupos_col_funcional: formData.get("grupos_col_funcional") ?? undefined,
+    grupos_col_logico: formData.get("grupos_col_logico") ?? undefined,
+    grupos_col_objetos: formData.get("grupos_col_objetos") ?? undefined,
   };
 }
 
 function toColumnConfig(data: z.infer<typeof ComisionSchema>) {
-  return {
+  const base = {
     sheetName: data.sheetName,
     headerRows: data.headerRows,
     legajo: data.col_legajo,
@@ -60,6 +81,30 @@ function toColumnConfig(data: z.infer<typeof ComisionSchema>) {
     githubUsername: data.col_githubUsername,
     email: data.col_email,
   };
+
+  if (!data.grupos_enabled) return base;
+
+  // Si el admin activó la sección de grupos pero no completó los campos mínimos,
+  // guardamos igual los defaults para no perder intención: sheetName cae a
+  // "Alumnos" y githubUsername al de la hoja de alumnos.
+  const nombreGrupoPorParadigma: GruposColumnConfig["nombreGrupoPorParadigma"] = {};
+  if (data.grupos_col_funcional !== undefined) nombreGrupoPorParadigma.funcional = data.grupos_col_funcional;
+  if (data.grupos_col_logico !== undefined) nombreGrupoPorParadigma.logico = data.grupos_col_logico;
+  if (data.grupos_col_objetos !== undefined) nombreGrupoPorParadigma.objetos = data.grupos_col_objetos;
+
+  // Si el admin activó la sección pero no mapeó ninguna columna de grupo, la
+  // config es inútil — la omitimos para que la sync sea no-op, igual que si
+  // no hubiera activado nada.
+  if (Object.keys(nombreGrupoPorParadigma).length === 0) return base;
+
+  const grupos: GruposColumnConfig = {
+    sheetName: data.grupos_sheetName || data.sheetName,
+    headerRows: data.grupos_headerRows ?? data.headerRows,
+    githubUsername: data.grupos_col_githubUsername ?? data.col_githubUsername,
+    nombreGrupoPorParadigma,
+  };
+
+  return { ...base, grupos };
 }
 
 export async function crearComision(

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useFormState } from "react-dom";
+import { useState } from "react";
 import type { ComisionFormState } from "./actions";
 import { INPUT_CLASS, INPUT_ERROR_CLASS, FieldError, SubmitButton } from "../ui";
 import { DEFAULT_COLUMN_CONFIG, type ColumnConfig } from "@/types";
@@ -30,20 +31,23 @@ function ColSelect({
   label,
   defaultValue,
   error,
+  optional = false,
 }: {
   name: string;
   label: string;
-  defaultValue: number;
+  defaultValue: number | undefined;
   error?: string;
+  optional?: boolean;
 }) {
   return (
     <div>
       <label className="block text-xs font-medium text-gray-600 mb-1">{label}</label>
       <select
         name={name}
-        defaultValue={defaultValue}
+        defaultValue={defaultValue ?? ""}
         className={`w-full rounded-md border px-2 py-1.5 text-sm font-mono ${error ? "border-red-400 bg-red-50" : "border-gray-300 bg-white"} focus:ring-2 focus:ring-pdep-500 focus:border-pdep-500 outline-none`}
       >
+        {optional && <option value="">(sin columna)</option>}
         {COL_OPTIONS.map(({ value, label: lbl }) => (
           <option key={value} value={value}>
             {lbl} (col {value + 1})
@@ -59,6 +63,8 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
   const [state, formAction] = useFormState(action, null);
   const errors = state?.errors ?? {};
   const cfg = defaultValues.columnConfig ?? DEFAULT_COLUMN_CONFIG;
+  const grupos = cfg.grupos;
+  const [gruposEnabled, setGruposEnabled] = useState(Boolean(grupos));
 
   return (
     <form action={formAction} className="space-y-5">
@@ -162,6 +168,95 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
           <ColSelect name="col_githubUsername" label="Usuario GitHub" defaultValue={cfg.githubUsername} error={errors.col_githubUsername?.[0]} />
           <ColSelect name="col_email" label="Email" defaultValue={cfg.email} error={errors.col_email?.[0]} />
         </div>
+      </fieldset>
+
+      {/* Configuración de hoja de grupos (opcional) */}
+      <fieldset className="border border-gray-200 rounded-lg p-4 space-y-4">
+        <legend className="text-sm font-semibold text-gray-700 px-1">
+          Hoja de grupos (opcional)
+        </legend>
+        <p className="text-xs text-gray-500">
+          Si la planilla tiene columnas con el nombre del grupo por paradigma, al
+          registrarse un alumno se materializan automáticamente los grupos en la DB
+          (uno por cada TP grupal ya creado del paradigma correspondiente).
+        </p>
+
+        <div className="flex items-center gap-3">
+          <input
+            id="grupos_enabled"
+            name="grupos_enabled"
+            type="checkbox"
+            checked={gruposEnabled}
+            onChange={(e) => setGruposEnabled(e.target.checked)}
+            className="h-4 w-4 rounded border-gray-300 text-pdep-600 focus:ring-pdep-500"
+          />
+          <label htmlFor="grupos_enabled" className="text-sm font-medium text-gray-700">
+            Hay hoja de grupos en la planilla
+          </label>
+        </div>
+
+        {gruposEnabled && (
+          <>
+            <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Nombre de la hoja (grupos)
+                </label>
+                <input
+                  name="grupos_sheetName"
+                  defaultValue={grupos?.sheetName ?? cfg.sheetName}
+                  placeholder="Alumnos"
+                  className={`${INPUT_CLASS} text-sm font-mono`}
+                />
+                <FieldError message={errors.grupos_sheetName?.[0]} />
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">
+                  Filas de encabezado (grupos)
+                </label>
+                <input
+                  name="grupos_headerRows"
+                  type="number"
+                  min={0}
+                  max={10}
+                  defaultValue={grupos?.headerRows ?? cfg.headerRows}
+                  className={`${INPUT_CLASS} text-sm`}
+                />
+                <FieldError message={errors.grupos_headerRows?.[0]} />
+              </div>
+            </div>
+
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-3">
+              <ColSelect
+                name="grupos_col_githubUsername"
+                label="Usuario GitHub"
+                defaultValue={grupos?.githubUsername ?? cfg.githubUsername}
+                error={errors.grupos_col_githubUsername?.[0]}
+              />
+              <ColSelect
+                name="grupos_col_funcional"
+                label="Grupo funcional"
+                defaultValue={grupos?.nombreGrupoPorParadigma.funcional}
+                error={errors.grupos_col_funcional?.[0]}
+                optional
+              />
+              <ColSelect
+                name="grupos_col_logico"
+                label="Grupo lógico"
+                defaultValue={grupos?.nombreGrupoPorParadigma.logico}
+                error={errors.grupos_col_logico?.[0]}
+                optional
+              />
+              <ColSelect
+                name="grupos_col_objetos"
+                label="Grupo objetos"
+                defaultValue={grupos?.nombreGrupoPorParadigma.objetos}
+                error={errors.grupos_col_objetos?.[0]}
+                optional
+              />
+            </div>
+          </>
+        )}
       </fieldset>
 
       {/* Submit */}

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -43,6 +43,13 @@ vi.mock("@/lib/repositories", () => ({
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
+// El hook de sync de grupos arrastra `@/lib/db` (reflect-metadata) si no se
+// mockea acá. Como el route test no verifica el comportamiento del hook (lo
+// hace `alumnoRegistro.test.ts`), basta con un stub no-op.
+vi.mock("@/lib/services/grupoSync", () => ({
+  sincronizarGruposDelAlumno: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { PATCH } from "./route";
 
 // ── Helpers ──────────────────────────────────────────────────

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -48,6 +48,13 @@ vi.mock("@/lib/googleGroups", () => ({
   agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
 }));
 
+// El hook de sync de grupos arrastra `@/lib/db` (reflect-metadata) si no se
+// mockea acá. Como el route test no verifica el comportamiento del hook (lo
+// hace `alumnoRegistro.test.ts`), basta con un stub no-op.
+vi.mock("@/lib/services/grupoSync", () => ({
+  sincronizarGruposDelAlumno: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { POST } from "./route";
 
 // ── Helpers ──────────────────────────────────────────────────

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -1,5 +1,6 @@
 import { getEM } from "@/lib/db";
 import { Grupo } from "@/domain/entities";
+import type { Alumno, GrupalAssignment } from "@/domain/entities";
 import type { Paradigma } from "@/types";
 
 export async function getGrupos(paradigma?: Paradigma): Promise<Grupo[]> {
@@ -30,4 +31,47 @@ export async function getGrupoDeAlumnoEnAssignment(
     },
     { populate: ["alumnos"] }
   );
+}
+
+// Usado por la sincronización desde la planilla: crea el Grupo (nombre +
+// paradigma + assignment) si no existe, y agrega al alumno como miembro
+// si no lo era. Idempotente.
+export async function upsertGrupoConMiembro(params: {
+  nombreGrupo: string;
+  paradigma: Paradigma;
+  assignment: GrupalAssignment;
+  alumno: Alumno;
+}): Promise<Grupo> {
+  const { nombreGrupo, paradigma, assignment, alumno } = params;
+  const em = await getEM();
+
+  const existente = await em.findOne(
+    Grupo,
+    {
+      nombre: nombreGrupo,
+      paradigma,
+      assignment: { id: assignment.id },
+    },
+    { populate: ["alumnos"] }
+  );
+
+  let grupo: Grupo;
+  if (existente) {
+    grupo = existente;
+  } else {
+    grupo = new Grupo();
+    grupo.nombre = nombreGrupo;
+    grupo.paradigma = paradigma;
+    grupo.assignment = assignment;
+    grupo.maxIntegrantes = assignment.maxIntegrantes;
+    grupo.creadoPor = "sheets-sync";
+    em.persist(grupo);
+  }
+
+  if (!grupo.alumnos.contains(alumno)) {
+    grupo.alumnos.add(alumno);
+  }
+
+  await em.flush();
+  return grupo;
 }

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -33,6 +33,7 @@ export {
   getGrupos,
   getGruposDeAssignment,
   getGrupoDeAlumnoEnAssignment,
+  upsertGrupoConMiembro,
 } from "./GrupoRepository";
 
 export {

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -6,6 +6,7 @@ const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockSincronizarGruposDelAlumno = vi.fn();
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -40,6 +41,11 @@ vi.mock("@/lib/sheets", async () => {
       mockUpsertarAlumnoEnSheets(...args),
   };
 });
+
+vi.mock("@/lib/services/grupoSync", () => ({
+  sincronizarGruposDelAlumno: (...args: unknown[]) =>
+    mockSincronizarGruposDelAlumno(...args),
+}));
 
 import { confirmarDatosAlumno } from "./alumnoRegistro";
 
@@ -76,6 +82,7 @@ describe("confirmarDatosAlumno", () => {
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockSincronizarGruposDelAlumno.mockResolvedValue(undefined);
   });
 
   it("devuelve { ok: true } cuando todo el flujo funciona", async () => {
@@ -225,5 +232,40 @@ describe("confirmarDatosAlumno", () => {
   it("deja propagar errores inesperados del upsert en DB (no-LegajoConflictError)", async () => {
     mockUpsertAlumno.mockRejectedValue(new Error("conexión caída"));
     await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("conexión caída");
+  });
+
+  describe("hook de sincronización de grupos", () => {
+    it("llama a sincronizarGruposDelAlumno con el github y la comisión, después de marcar registroConfirmadoEn", async () => {
+      await confirmarDatosAlumno(validInput);
+      expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith(
+        validInput.githubUsername,
+        comisionActiva
+      );
+      const ordenLlamadas = [
+        mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
+        mockSincronizarGruposDelAlumno.mock.invocationCallOrder[0],
+      ];
+      expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
+    });
+
+    it("devuelve { ok: true } aunque la sincronización de grupos falle (best-effort)", async () => {
+      const { logger } = await import("@/lib/logger");
+      const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
+      mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("algo falló"));
+
+      const resultado = await confirmarDatosAlumno(validInput);
+
+      expect(resultado).toEqual({ ok: true });
+      expect(errorSpy).toHaveBeenCalled();
+      errorSpy.mockRestore();
+    });
+
+    it("no se llama si el registro falla antes (ej. conflicto de legajo)", async () => {
+      mockUpsertAlumno.mockRejectedValue(
+        new FakeLegajoConflictError("12345", "otro-alumno")
+      );
+      await confirmarDatosAlumno(validInput);
+      expect(mockSincronizarGruposDelAlumno).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -5,6 +5,7 @@ import {
   marcarRegistroConfirmado,
   LegajoConflictError,
 } from "@/lib/repositories";
+import { sincronizarGruposDelAlumno } from "@/lib/services/grupoSync";
 import { logger } from "@/lib/logger";
 
 /**
@@ -97,6 +98,23 @@ export async function confirmarDatosAlumno(
       "Sheets confirmado pero falló marcar registroConfirmadoEn en DB — alumno queda sin flag hasta que reintente"
     );
     throw error;
+  }
+
+  // Sincronización de grupos: best-effort. El registro del alumno ya está OK;
+  // si la hoja de grupos no existe, no se puede leer o el upsert falla, lo
+  // logueamos y seguimos — no queremos abortar un registro confirmado por
+  // un problema en una funcionalidad secundaria.
+  try {
+    await sincronizarGruposDelAlumno(input.githubUsername, comisionActiva);
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        githubUsername: input.githubUsername,
+        comisionId: comisionActiva.id,
+      },
+      "Falló sincronización de grupos desde planilla — registro ya confirmado"
+    );
   }
 
   return { ok: true };

--- a/src/lib/services/grupoSync.test.ts
+++ b/src/lib/services/grupoSync.test.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { GruposColumnConfig } from "@/types";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetAsignacionesGrupos = vi.fn();
+const mockUpsertGrupoConMiembro = vi.fn();
+const mockEmFindOne = vi.fn();
+const mockEmFind = vi.fn();
+
+vi.mock("@/lib/sheets", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
+  return {
+    ...actual,
+    getAsignacionesGrupos: (...args: unknown[]) => mockGetAsignacionesGrupos(...args),
+  };
+});
+
+vi.mock("@/lib/repositories", () => ({
+  upsertGrupoConMiembro: (params: unknown) => mockUpsertGrupoConMiembro(params),
+}));
+
+vi.mock("@/lib/db", () => ({
+  getEM: () => ({
+    findOne: (...args: unknown[]) => mockEmFindOne(...args),
+    find: (...args: unknown[]) => mockEmFind(...args),
+  }),
+}));
+
+import { sincronizarGruposDelAlumno } from "./grupoSync";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const gruposConfig: GruposColumnConfig = {
+  sheetName: "Alumnos",
+  headerRows: 1,
+  githubUsername: 3,
+  nombreGrupoPorParadigma: { funcional: 5 },
+};
+
+const comisionConGrupos = {
+  id: "c1",
+  spreadsheetId: "sheet-xyz",
+  columnConfig: {
+    sheetName: "Alumnos",
+    headerRows: 1,
+    legajo: 0,
+    apellido: 1,
+    nombre: 2,
+    githubUsername: 3,
+    email: 4,
+    grupos: gruposConfig,
+  },
+} as unknown as Parameters<typeof sincronizarGruposDelAlumno>[1];
+
+const comisionSinGrupos = {
+  id: "c2",
+  spreadsheetId: "sheet-xyz",
+  columnConfig: {
+    sheetName: "Alumnos",
+    headerRows: 1,
+    legajo: 0,
+    apellido: 1,
+    nombre: 2,
+    githubUsername: 3,
+    email: 4,
+  },
+} as unknown as Parameters<typeof sincronizarGruposDelAlumno>[1];
+
+const alumnoFake = { id: "a1", githubUsername: "juangarcia" };
+const grupalAssignmentFake = { id: "asg1", maxIntegrantes: 3, paradigma: "funcional" };
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("sincronizarGruposDelAlumno", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAsignacionesGrupos.mockResolvedValue([]);
+    mockEmFindOne.mockResolvedValue(alumnoFake);
+    mockEmFind.mockResolvedValue([]);
+    mockUpsertGrupoConMiembro.mockResolvedValue(undefined);
+  });
+
+  it("no hace nada si la comisión no tiene config de grupos", async () => {
+    await sincronizarGruposDelAlumno("juangarcia", comisionSinGrupos);
+    expect(mockGetAsignacionesGrupos).not.toHaveBeenCalled();
+    expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
+  });
+
+  it("no hace nada si la hoja no lista al alumno", async () => {
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "otroalumno", paradigma: "funcional", nombreGrupo: "X" },
+    ]);
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
+    expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
+  });
+
+  it("no hace nada si no hay GrupalAssignment del paradigma todavía", async () => {
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+    mockEmFind.mockResolvedValue([]);
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
+    expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
+  });
+
+  it("upsertea el grupo por cada GrupalAssignment del paradigma", async () => {
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+    mockEmFind.mockResolvedValue([
+      grupalAssignmentFake,
+      { ...grupalAssignmentFake, id: "asg2" },
+    ]);
+
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
+
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(2);
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledWith({
+      nombreGrupo: "Los Lambdas",
+      paradigma: "funcional",
+      assignment: grupalAssignmentFake,
+      alumno: alumnoFake,
+    });
+  });
+
+  it("normaliza el githubUsername a lowercase al filtrar", async () => {
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+    mockEmFind.mockResolvedValue([grupalAssignmentFake]);
+
+    await sincronizarGruposDelAlumno("JuanGarcia", comisionConGrupos);
+
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(1);
+  });
+
+  it("loguea y no throwea si getAsignacionesGrupos falla (evita abortar registro)", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
+    mockGetAsignacionesGrupos.mockRejectedValue(new Error("Sheets caído"));
+
+    await expect(
+      sincronizarGruposDelAlumno("juangarcia", comisionConGrupos)
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalledOnce();
+    expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("loguea y sigue si un upsert falla, sin abortar los otros", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
+
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+    mockEmFind.mockResolvedValue([
+      grupalAssignmentFake,
+      { ...grupalAssignmentFake, id: "asg2" },
+    ]);
+    mockUpsertGrupoConMiembro
+      .mockRejectedValueOnce(new Error("DB conflict"))
+      .mockResolvedValueOnce(undefined);
+
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
+
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(2);
+    expect(errorSpy).toHaveBeenCalledOnce();
+    errorSpy.mockRestore();
+  });
+
+  it("no hace nada si el alumno no está en DB (edge: borrado entre confirm y sync)", async () => {
+    mockGetAsignacionesGrupos.mockResolvedValue([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+    mockEmFindOne.mockResolvedValue(null);
+
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
+
+    expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/grupoSync.ts
+++ b/src/lib/services/grupoSync.ts
@@ -1,0 +1,74 @@
+import { getEM } from "@/lib/db";
+import { logger } from "@/lib/logger";
+import { Alumno, GrupalAssignment, type Comision } from "@/domain/entities";
+import { getAsignacionesGrupos } from "@/lib/sheets";
+import { upsertGrupoConMiembro } from "@/lib/repositories";
+
+/**
+ * Mira la hoja de grupos configurada en la comisión; si el alumno aparece,
+ * materializa en DB los grupos que le corresponden, uno por cada GrupalAssignment
+ * del mismo paradigma que ya exista en la comisión.
+ *
+ * Es idempotente y best-effort: si no hay `columnConfig.grupos`, no hace nada;
+ * si la lectura de Sheets falla, lo logueamos y devolvemos sin romper (el caller
+ * —el registro— ya confirmó al alumno antes de llamarnos).
+ *
+ * Limitación consciente: si todavía no existe el `GrupalAssignment` del paradigma,
+ * el grupo no se materializa. Se resuelve la próxima vez que el alumno reingrese
+ * al perfil, o por un comando de sincronización masiva (fuera de alcance acá).
+ */
+export async function sincronizarGruposDelAlumno(
+  githubUsername: string,
+  comision: Comision
+): Promise<void> {
+  const gruposConfig = comision.columnConfig?.grupos;
+  if (!gruposConfig) return;
+
+  const ghNorm = githubUsername.toLowerCase().trim();
+
+  let asignaciones;
+  try {
+    asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
+  } catch (error) {
+    logger.error(
+      { err: error, githubUsername: ghNorm, comisionId: comision.id },
+      "No se pudo leer la hoja de grupos — skip sincronización"
+    );
+    return;
+  }
+
+  const deEsteAlumno = asignaciones.filter((a) => a.githubUsername === ghNorm);
+  if (deEsteAlumno.length === 0) return;
+
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, { githubUsername: ghNorm });
+  if (!alumno) return;
+
+  for (const asig of deEsteAlumno) {
+    const grupales = await em.find(GrupalAssignment, {
+      comision: { id: comision.id },
+      paradigma: asig.paradigma,
+    });
+    for (const assignment of grupales) {
+      try {
+        await upsertGrupoConMiembro({
+          nombreGrupo: asig.nombreGrupo,
+          paradigma: asig.paradigma,
+          assignment,
+          alumno,
+        });
+      } catch (error) {
+        logger.error(
+          {
+            err: error,
+            githubUsername: ghNorm,
+            assignmentId: assignment.id,
+            nombreGrupo: asig.nombreGrupo,
+            paradigma: asig.paradigma,
+          },
+          "No se pudo upsertar grupo desde planilla"
+        );
+      }
+    }
+  }
+}

--- a/src/lib/sheets.test.ts
+++ b/src/lib/sheets.test.ts
@@ -1,11 +1,13 @@
 import { describe, it, expect } from "vitest";
 import {
   parseAlumnosRows,
+  parseAsignacionesGrupos,
   validateRegistro,
   colLetter,
   isValidEmail,
   upsertarAlumnoEnSheets,
 } from "./sheets";
+import type { GruposColumnConfig } from "@/types";
 
 // ── parseAlumnosRows ────────────────────────────────────────
 
@@ -77,6 +79,89 @@ describe("parseAlumnosRows", () => {
   it("maneja valores numéricos (legajo como number)", () => {
     const rows = [[12345, "A", "B", "user", "a@b.com", "c"]];
     expect(parseAlumnosRows(rows)[0].legajo).toBe("12345");
+  });
+});
+
+// ── parseAsignacionesGrupos ─────────────────────────────────
+
+describe("parseAsignacionesGrupos", () => {
+  // Hoja típica: A..E columnas de alumno, F=grupo funcional, G=grupo lógico, H=grupo objetos
+  const config: GruposColumnConfig = {
+    sheetName: "Alumnos",
+    headerRows: 1,
+    githubUsername: 3,
+    nombreGrupoPorParadigma: {
+      funcional: 5,
+      logico: 6,
+      objetos: 7,
+    },
+  };
+
+  it("genera una asignación por paradigma en el que el alumno tiene grupo", () => {
+    const rows = [
+      ["12345", "García", "Juan", "juangarcia", "j@m.com", "Los Lambdas", "Prolog Pros", "OO Masters"],
+    ];
+    const result = parseAsignacionesGrupos(rows, config);
+    expect(result).toEqual([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+      { githubUsername: "juangarcia", paradigma: "logico", nombreGrupo: "Prolog Pros" },
+      { githubUsername: "juangarcia", paradigma: "objetos", nombreGrupo: "OO Masters" },
+    ]);
+  });
+
+  it("ignora paradigmas con celda vacía", () => {
+    const rows = [
+      ["12345", "García", "Juan", "juangarcia", "j@m.com", "Los Lambdas", "", ""],
+    ];
+    const result = parseAsignacionesGrupos(rows, config);
+    expect(result).toEqual([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+  });
+
+  it("descarta filas sin github username", () => {
+    const rows = [
+      ["12345", "García", "Juan", "", "j@m.com", "Los Lambdas", "", ""],
+      ["67890", "Pérez", "María", "mariaperez", "m@m.com", "Otro", "", ""],
+    ];
+    const result = parseAsignacionesGrupos(rows, config);
+    expect(result).toHaveLength(1);
+    expect(result[0].githubUsername).toBe("mariaperez");
+  });
+
+  it("normaliza el github username (lowercase + sin @)", () => {
+    const rows = [
+      ["12345", "García", "Juan", "@JuanGarcia", "j@m.com", "Los Lambdas", "", ""],
+    ];
+    const result = parseAsignacionesGrupos(rows, config);
+    expect(result[0].githubUsername).toBe("juangarcia");
+  });
+
+  it("solo mapea los paradigmas presentes en la config", () => {
+    const configSoloFuncional: GruposColumnConfig = {
+      sheetName: "Alumnos",
+      headerRows: 1,
+      githubUsername: 3,
+      nombreGrupoPorParadigma: { funcional: 5 },
+    };
+    const rows = [
+      ["12345", "García", "Juan", "juangarcia", "j@m.com", "Los Lambdas", "Prolog Pros", "OO Masters"],
+    ];
+    const result = parseAsignacionesGrupos(rows, configSoloFuncional);
+    expect(result).toEqual([
+      { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+    ]);
+  });
+
+  it("maneja filas más cortas que las columnas configuradas", () => {
+    const rows = [
+      ["12345", "García", "Juan", "juangarcia", "j@m.com"],
+    ];
+    expect(parseAsignacionesGrupos(rows, config)).toEqual([]);
+  });
+
+  it("devuelve vacío para filas vacías", () => {
+    expect(parseAsignacionesGrupos([], config)).toEqual([]);
   });
 });
 

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -1,6 +1,12 @@
 import { google } from "googleapis";
 import { Alumno } from "@/domain/entities";
-import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
+import {
+  type ColumnConfig,
+  DEFAULT_COLUMN_CONFIG,
+  type GruposColumnConfig,
+  type Paradigma,
+  PARADIGMAS,
+} from "@/types";
 
 // ── Auth con service account ────────────────────────────────
 
@@ -244,6 +250,61 @@ export async function upsertarAlumnoEnSheets(
     requestBody: { values: [existingRow] },
   });
   return { ok: true };
+}
+
+// ── Hoja de grupos ──────────────────────────────────────────
+
+// Una fila parseada de la hoja de grupos: alumno + paradigma + nombre del grupo.
+// Un mismo alumno puede aparecer en varias asignaciones (una por paradigma).
+export interface AsignacionGrupoRow {
+  githubUsername: string;
+  paradigma: Paradigma;
+  nombreGrupo: string;
+}
+
+function buildGruposReadRange(config: GruposColumnConfig): string {
+  const gruposCols = PARADIGMAS
+    .map((p) => config.nombreGrupoPorParadigma[p])
+    .filter((v): v is number => typeof v === "number");
+  const maxCol = Math.max(config.githubUsername, ...gruposCols);
+  const startRow = config.headerRows + 1;
+  return `${config.sheetName}!A${startRow}:${colLetter(maxCol)}500`;
+}
+
+export function parseAsignacionesGrupos(
+  rows: unknown[][],
+  config: GruposColumnConfig
+): AsignacionGrupoRow[] {
+  const result: AsignacionGrupoRow[] = [];
+  for (const row of rows) {
+    const github = norm(row[config.githubUsername]).replace("@", "").toLowerCase();
+    if (!github) continue;
+    for (const paradigma of PARADIGMAS) {
+      const colIndex = config.nombreGrupoPorParadigma[paradigma];
+      if (colIndex === undefined) continue;
+      const nombreGrupo = norm(row[colIndex]);
+      if (!nombreGrupo) continue;
+      result.push({ githubUsername: github, paradigma, nombreGrupo });
+    }
+  }
+  return result;
+}
+
+export async function getAsignacionesGrupos(
+  spreadsheetId: string,
+  config: GruposColumnConfig
+): Promise<AsignacionGrupoRow[]> {
+  const id = resolveSpreadsheetId(spreadsheetId);
+  try {
+    const sheets = getSheetsClient();
+    const { data } = await sheets.spreadsheets.values.get({
+      spreadsheetId: id,
+      range: buildGruposReadRange(config),
+    });
+    return parseAsignacionesGrupos(data.values ?? [], config);
+  } catch (e) {
+    throw new Error(`No se pudo leer la hoja de grupos: ${(e as Error).message}`);
+  }
 }
 
 // ── Helpers ─────────────────────────────────────────────────

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,20 @@
+// ── Paradigmas ──────────────────────────────────────────────
+export type Paradigma = "funcional" | "logico" | "objetos";
+
+export const PARADIGMAS: Paradigma[] = ["funcional", "logico", "objetos"];
+
 // ── Configuración de columnas del spreadsheet ───────────────
+
+// Configuración opcional para leer grupos desde la planilla.
+// Se modela con una columna por paradigma porque la planilla típica tiene
+// headers tipo "Nombre grupo funcional", "Nombre grupo lógico", etc. Si sólo
+// hay grupos para un paradigma, se completa solo esa entrada.
+export interface GruposColumnConfig {
+  sheetName: string;
+  headerRows: number;
+  githubUsername: number;
+  nombreGrupoPorParadigma: Partial<Record<Paradigma, number>>;
+}
 
 export interface ColumnConfig {
   sheetName: string;   // nombre de la hoja, ej: "Alumnos"
@@ -8,6 +24,7 @@ export interface ColumnConfig {
   nombre: number;           // default 2 (C)
   githubUsername: number;   // default 3 (D)
   email: number;            // default 4 (E)
+  grupos?: GruposColumnConfig;  // opcional: hoja de grupos
 }
 
 export const DEFAULT_COLUMN_CONFIG: ColumnConfig = {
@@ -19,11 +36,6 @@ export const DEFAULT_COLUMN_CONFIG: ColumnConfig = {
   githubUsername: 3,
   email: 4,
 };
-
-// ── Paradigmas ──────────────────────────────────────────────
-export type Paradigma = "funcional" | "logico" | "objetos";
-
-export const PARADIGMAS: Paradigma[] = ["funcional", "logico", "objetos"];
 
 // ── Assignment ──────────────────────────────────────────────
 


### PR DESCRIPTION
## Resumen

Cuando un alumno confirma su registro, si ya aparece en la hoja de grupos de la planilla, ahora se materializa el `Grupo` correspondiente en la DB (uno por cada `GrupalAssignment` del paradigma en la comisión). Cubre el issue #14 en lo principal; el desacople completo del enum `Paradigma` queda para un siguiente ciclo.

## Qué cambia

- **`ColumnConfig`** gana un campo opcional `grupos: GruposColumnConfig`. La config de grupos modela **una columna por paradigma** (`funcional`/`logico`/`objetos`), así la planilla típica (`"Nombre grupo funcional"`, etc.) se configura por separado. Si no se activa, no hay sync — backward-compatible con comisiones existentes.
- **`sheets.ts`** suma `parseAsignacionesGrupos` (puro y testeable) y `getAsignacionesGrupos` (lee la hoja).
- **`GrupoRepository.upsertGrupoConMiembro`**: crea el grupo por `(nombre, paradigma, assignment)` si no existe y agrega al alumno si aún no era miembro. Idempotente.
- **Nuevo servicio `grupoSync.sincronizarGruposDelAlumno`**: lee la hoja, filtra las asignaciones del alumno y upsertea un grupo por cada `GrupalAssignment` del paradigma ya existente en la comisión. Falla blanda — si la hoja no se puede leer o un upsert rompe, lo loguea y sigue.
- **Hook en `confirmarDatosAlumno`**: tras `marcarRegistroConfirmado`, dispara el sync. **No aborta** el registro si el sync falla (el alumno ya quedó confirmado en DB + Sheets).
- **UI del admin**: el form de comisión gana una sección opcional *"Hoja de grupos"* con checkbox + selects por paradigma.

## Decisiones de modelado (conscientes)

- Se mantiene `Grupo.paradigma` como enum hardcoded y la relación `Grupo → GrupalAssignment` como M:1 requerida. Si todavía no existe el `GrupalAssignment` del paradigma, el grupo **no se materializa**; cuando el admin lo crea y el alumno reingresa, se sincroniza.
- El desacople de `Grupo` del enum `Paradigma` (para que la herramienta sirva a otras materias con "tema" o "evaluación" en vez de paradigma) queda para un PR siguiente — probablemente haciendo el enum configurable por comisión.

## Test plan

- [x] `parseAsignacionesGrupos` (7 tests): parsea una columna por paradigma, ignora vacíos, normaliza github, descarta filas sin usuario.
- [x] `sincronizarGruposDelAlumno` (8 tests): no-op sin config, filtra por alumno, normaliza case, no hace nada sin `GrupalAssignment` del paradigma, upsertea por cada assignment, loguea sin throwear si Sheets falla, sigue iterando si un upsert rompe, edge del alumno borrado.
- [x] `confirmarDatosAlumno` (3 tests nuevos): hook se llama con los args correctos y después de `marcarRegistroConfirmado`; devuelve `ok: true` aunque el sync falle; no se llama si el registro falló antes.
- [x] Route tests de registro/perfil mockean `grupoSync` para no tirar de `@/lib/db`.
- [x] `npx vitest run` → 564/564 pasan. `npx tsc --noEmit` → sin errores nuevos en los archivos tocados.
- [ ] Probar en dev con una comisión real que tenga hoja de grupos configurada.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added group synchronization capability: administrators can now configure group assignments from spreadsheets
  * Automatic group membership assignment for students during registration based on spreadsheet configuration
  * New optional "grupos" configuration section in the commission form for specifying group sheet metadata and column mappings

* **Tests**
  * Added test coverage for group synchronization service and sheet parsing functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->