### PR TITLE
Estado persistente de sync de grupos: no tragar errores, remediación admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -593,6 +593,7 @@ Reutilizamos la service account que ya está en `GOOGLE_SERVICE_ACCOUNT_KEY` —
 - [ ] Export de estado de entregas a Google Sheets (cerrar el loop con la planilla)
 - [x] Suscribir a los alumnos al grupo de Google Groups automáticamente
 - [ ] Observabilidad ([#18](https://github.com/Juancete/Pdep-Classroom/issues/18)) — tabla `error_log` + pantalla `/admin/errores` + badge en el header con no leídos (PR 2 del refactor de logging, hoy los 500 solo logguean por pino a Vercel)
+- [ ] Vista admin detallada de alumnos con `gruposSyncFallidoEn` pendiente ([#21](https://github.com/Juancete/Pdep-Classroom/issues/21)) — listar quiénes son, desde cuándo, y permitir reintento por alumno. Hoy hay un badge + botón "Resincronizar grupos" masivo en `/admin/comisiones/[id]/edit`, pero no se ve el detalle individual.
 
 ## Refactor en curso
 

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,93 +22,13 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
+        "anio": {
+          "name": "anio",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -116,15 +36,47 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "integer"
         },
-        "registro_confirmado_en_id": {
-          "name": "registro_confirmado_en_id",
-          "type": "uuid",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,
@@ -132,74 +84,26 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "json"
         }
       },
-      "name": "alumno",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_github_username_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_legajo_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
+          "keyName": "comision_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "alumno_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "columnNames": [
-            "comision_id"
-          ],
-          "constraintName": "alumno_comision_id_foreign",
-          "localTableName": "public.alumno",
-          "referencedTableName": "public.comision",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        },
-        "alumno_registro_confirmado_en_id_foreign": {
-          "columnNames": [
-            "registro_confirmado_en_id"
-          ],
-          "constraintName": "alumno_registro_confirmado_en_id_foreign",
-          "localTableName": "public.alumno",
-          "referencedTableName": "public.comision",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -340,7 +244,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz(6)",
+          "type": "timestamptz",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -372,15 +276,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int4",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": 32,
-          "scale": 0,
+          "precision": null,
+          "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -392,43 +296,254 @@
       "indexes": [
         {
           "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "assignment_pkey",
-          "unique": true,
-          "primary": true
-        },
-        {
-          "columnNames": [
             "tipo"
           ],
           "composite": false,
-          "constraint": false,
           "keyName": "assignment_tipo_index",
-          "unique": false,
-          "primary": false
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "assignment_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "constraintName": "assignment_comision_id_foreign",
           "columnNames": [
             "comision_id"
           ],
-          "constraintName": "assignment_comision_id_foreign",
           "localTableName": "public.assignment",
-          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "grupos_sync_fallido_en": {
+          "name": "grupos_sync_fallido_en",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "alumno",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "keyName": "alumno_legajo_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "keyName": "alumno_github_username_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "keyName": "alumno_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "constraintName": "alumno_comision_id_foreign",
+          "columnNames": [
+            "comision_id"
+          ],
+          "localTableName": "public.alumno",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "localTableName": "public.alumno",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -469,48 +584,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "assignment_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
-          "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "assignment_alumnos_assignment_id_foreign": {
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "columnNames": [
             "assignment_id"
           ],
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.assignment",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "assignment_alumnos_alumno_id_foreign": {
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.assignment_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -530,24 +644,8 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -562,9 +660,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "bool",
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -573,14 +671,18 @@
           "length": null,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -592,27 +694,72 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
-      "name": "comision",
+      "name": "grupo",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "comision_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "constraintName": "grupo_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -639,6 +786,22 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -712,41 +875,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz(6)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
         "repo_deleted": {
           "name": "repo_deleted",
-          "type": "bool",
+          "type": "boolean",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -759,202 +890,81 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "boolean"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "entrega_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
+        "entrega_assignment_id_foreign": {
+          "constraintName": "entrega_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
         "entrega_alumno_id_foreign": {
+          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
-          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        },
-        "entrega_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "entrega_assignment_id_foreign",
-          "localTableName": "public.entrega",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
+          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "creado_por": {
-          "name": "creado_por",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        }
-      },
-      "name": "grupo",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "grupo_pkey",
-          "unique": true,
-          "primary": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "grupo_assignment_id_foreign",
-          "localTableName": "public.grupo",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -995,48 +1005,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "grupo_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
-          "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "grupo_alumnos_grupo_id_foreign": {
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.grupo",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "grupo_alumnos_alumno_id_foreign": {
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.grupo_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260423180258_add_grupos_sync_fallido_en_to_alumno.ts
+++ b/migrations/Migration20260423180258_add_grupos_sync_fallido_en_to_alumno.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260423180258_add_grupos_sync_fallido_en_to_alumno extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "alumno" add column "grupos_sync_fallido_en" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" drop column "grupos_sync_fallido_en";`);
+  }
+
+}

--- a/src/app/admin/comisiones/[id]/edit/page.test.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.test.tsx
@@ -9,6 +9,7 @@ const mockGetComision = vi.fn();
 const mockCountAlumnos = vi.fn();
 const mockGetAlumnos = vi.fn();
 const mockRedirect = vi.fn();
+const mockGetAlumnosConGruposSyncPendiente = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -17,6 +18,8 @@ vi.mock("@/lib/session", () => ({
 vi.mock("@/lib/repositories", () => ({
   getComision: (id: string) => mockGetComision(id),
   countAlumnos: () => mockCountAlumnos(),
+  getAlumnosConGruposSyncPendiente: (...args: unknown[]) =>
+    mockGetAlumnosConGruposSyncPendiente(...args),
 }));
 
 vi.mock("@/lib/sheets", () => ({
@@ -34,11 +37,21 @@ vi.mock("next/navigation", () => ({
 vi.mock("../../actions", () => ({
   actualizarComision: vi.fn(),
   sincronizarAlumnos: vi.fn().mockResolvedValue({ status: "idle" }),
+  sincronizarGruposDeLaComision: vi.fn().mockResolvedValue({ status: "idle" }),
 }));
 
 vi.mock("../../sync-button", () => ({
   SyncButton: ({ comisionId }: { comisionId: string }) =>
     React.createElement("button", { "data-testid": "sync-button", "data-comision-id": comisionId }, "Sincronizar"),
+}));
+
+vi.mock("../../sync-grupos-button", () => ({
+  SyncGruposButton: ({ comisionId }: { comisionId: string }) =>
+    React.createElement(
+      "button",
+      { "data-testid": "sync-grupos-button", "data-comision-id": comisionId },
+      "Resincronizar grupos"
+    ),
 }));
 
 vi.mock("../../comision-form", () => ({
@@ -85,6 +98,7 @@ describe("Edit Comision page", () => {
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetAlumnos.mockResolvedValue([]);
     mockCountAlumnos.mockResolvedValue(0);
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
   });
 
   it("siempre llama a requireAdmin", async () => {
@@ -199,6 +213,44 @@ describe("Edit Comision page", () => {
         comision.spreadsheetId,
         comision.columnConfig
       );
+    });
+  });
+
+  describe("badge de alumnos con grupos pendientes", () => {
+    it("muestra el badge + SyncGruposButton cuando hay alumnos con flag prendido", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+        { githubUsername: "ana" },
+        { githubUsername: "bruno" },
+      ]);
+
+      const html = renderToStaticMarkup(
+        await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
+      );
+      expect(html).toContain("Grupos pendientes");
+      expect(html).toContain("2");
+      expect(html).toContain('data-testid="sync-grupos-button"');
+    });
+
+    it("no muestra el badge si no hay alumnos pendientes", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+
+      const html = renderToStaticMarkup(
+        await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
+      );
+      expect(html).not.toContain("Grupos pendientes");
+      expect(html).not.toContain('data-testid="sync-grupos-button"');
+    });
+
+    it("no rompe la página si la query de pendientes falla", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGruposSyncPendiente.mockRejectedValue(new Error("DB down"));
+
+      const html = renderToStaticMarkup(
+        await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
+      );
+      expect(html).not.toContain("Grupos pendientes");
     });
   });
 });

--- a/src/app/admin/comisiones/[id]/edit/page.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.tsx
@@ -1,10 +1,15 @@
 import { requireAdmin } from "@/lib/session";
-import { getComision, countAlumnos } from "@/lib/repositories";
+import {
+  getComision,
+  countAlumnos,
+  getAlumnosConGruposSyncPendiente,
+} from "@/lib/repositories";
 import { getAlumnos } from "@/lib/sheets";
 import { redirect } from "next/navigation";
 import { ComisionForm } from "../../comision-form";
 import { actualizarComision } from "../../actions";
 import { SyncButton } from "../../sync-button";
+import { SyncGruposButton } from "../../sync-grupos-button";
 
 export default async function EditComisionPage({
   params,
@@ -17,19 +22,21 @@ export default async function EditComisionPage({
   if (!comision) redirect("/admin/comisiones");
 
   // Comparar counts en paralelo; si alguno falla no rompemos la página
-  const [countSheet, countDB] = await Promise.all([
+  const [countSheet, countDB, pendientesGrupos] = await Promise.all([
     getAlumnos(comision.spreadsheetId, comision.columnConfig)
       .then((a) => a.length)
       .catch(() => null),
     countAlumnos().catch(() => null),
+    getAlumnosConGruposSyncPendiente(comision.id).catch(() => [] as unknown[]),
   ]);
 
   const desynced =
     countSheet !== null && countDB !== null && countSheet !== countDB;
+  const cantPendientesGrupos = pendientesGrupos.length;
 
   return (
     <div className="max-w-xl">
-      <div className="flex items-center gap-3 mb-6">
+      <div className="flex flex-wrap items-center gap-3 mb-6">
         <h1 className="text-2xl font-bold">Editar Comisión {comision.anio}</h1>
         {desynced && (
           <>
@@ -41,6 +48,18 @@ export default async function EditComisionPage({
               Desincronizado · {countSheet} en planilla / {countDB} en DB
             </span>
             <SyncButton comisionId={comision.id} />
+          </>
+        )}
+        {cantPendientesGrupos > 0 && (
+          <>
+            <span
+              title="Alumnos cuyo último intento de sincronizar grupos desde la planilla falló"
+              className="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 text-red-700 border border-red-200 px-2.5 py-1 rounded-full"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+              Grupos pendientes · {cantPendientesGrupos}
+            </span>
+            <SyncGruposButton comisionId={comision.id} />
           </>
         )}
       </div>

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -9,6 +9,8 @@ const mockGetComision = vi.fn();
 const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnos = vi.fn();
+const mockGetAlumnosConGruposSyncPendiente = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -34,7 +36,14 @@ vi.mock("@/lib/repositories", () => ({
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
   upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
+  getAlumnosConGruposSyncPendiente: (...args: unknown[]) =>
+    mockGetAlumnosConGruposSyncPendiente(...args),
   LegajoConflictError: FakeLegajoConflictError,
+}));
+
+vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
 }));
 
 vi.mock("@/lib/sheets", () => ({
@@ -49,7 +58,12 @@ vi.mock("next/cache", () => ({
   revalidatePath: vi.fn(),
 }));
 
-import { crearComision, actualizarComision, sincronizarAlumnos } from "./actions";
+import {
+  crearComision,
+  actualizarComision,
+  sincronizarAlumnos,
+  sincronizarGruposDeLaComision,
+} from "./actions";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -264,5 +278,74 @@ describe("sincronizarAlumnos", () => {
       status: "error",
       message: "El legajo 111 ya está registrado con el usuario @otra-persona. Verificá que sea el tuyo.",
     });
+  });
+});
+
+// ── sincronizarGruposDeLaComision ────────────────────────────
+
+describe("sincronizarGruposDeLaComision", () => {
+  const comision = { id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {} };
+
+  function makeFd(): FormData {
+    const fd = new FormData();
+    fd.append("comisionId", "c1");
+    return fd;
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(undefined);
+    mockGetComision.mockResolvedValue(comision);
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+    mockIntentarSincronizarGrupos.mockResolvedValue(false);
+  });
+
+  it("devuelve error si la comisión no existe", async () => {
+    mockGetComision.mockResolvedValue(null);
+    const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+    expect(result).toEqual({ status: "error", message: "Comisión no encontrada" });
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+
+  it("devuelve ok con 0 sincronizados cuando no hay alumnos pendientes", async () => {
+    const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+    expect(result).toEqual({ status: "ok", sincronizados: 0, aunConError: 0 });
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+
+  it("reintenta la sync para cada alumno pendiente de la comisión", async () => {
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+      { githubUsername: "ana" },
+      { githubUsername: "bruno" },
+    ]);
+
+    await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledTimes(2);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("ana", comision);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("bruno", comision);
+  });
+
+  it("cuenta cuántos se resolvieron y cuántos siguen con error", async () => {
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+      { githubUsername: "ana" },
+      { githubUsername: "bruno" },
+      { githubUsername: "cintia" },
+    ]);
+    mockIntentarSincronizarGrupos
+      .mockResolvedValueOnce(false) // ana: ok
+      .mockResolvedValueOnce(true) // bruno: sigue fallando
+      .mockResolvedValueOnce(false); // cintia: ok
+
+    const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+
+    expect(result).toEqual({ status: "ok", sincronizados: 2, aunConError: 1 });
+  });
+
+  it("requiere admin antes de ejecutar", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("forbidden"));
+    await expect(
+      sincronizarGruposDeLaComision({ status: "idle" }, makeFd())
+    ).rejects.toThrow("forbidden");
   });
 });

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -9,6 +9,7 @@ const mockGetComision = vi.fn();
 const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnos = vi.fn();
+const mockGetAsignacionesGrupos = vi.fn();
 const mockGetAlumnosConGruposSyncPendiente = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
 
@@ -48,6 +49,7 @@ vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
 
 vi.mock("@/lib/sheets", () => ({
   getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
+  getAsignacionesGrupos: (...args: unknown[]) => mockGetAsignacionesGrupos(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -284,7 +286,20 @@ describe("sincronizarAlumnos", () => {
 // ── sincronizarGruposDeLaComision ────────────────────────────
 
 describe("sincronizarGruposDeLaComision", () => {
-  const comision = { id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {} };
+  const gruposConfig = {
+    sheetName: "Alumnos",
+    headerRows: 1,
+    githubUsername: 3,
+    nombreGrupoPorParadigma: { funcional: 5 },
+  };
+  const comision = {
+    id: "c1",
+    spreadsheetId: "sheet-xyz",
+    columnConfig: { grupos: gruposConfig },
+  };
+  const asignacionesFake = [
+    { githubUsername: "ana", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
+  ];
 
   function makeFd(): FormData {
     const fd = new FormData();
@@ -297,7 +312,8 @@ describe("sincronizarGruposDeLaComision", () => {
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetComision.mockResolvedValue(comision);
     mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
-    mockIntentarSincronizarGrupos.mockResolvedValue(false);
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+    mockGetAsignacionesGrupos.mockResolvedValue(asignacionesFake);
   });
 
   it("devuelve error si la comisión no existe", async () => {
@@ -311,19 +327,52 @@ describe("sincronizarGruposDeLaComision", () => {
     const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
     expect(result).toEqual({ status: "ok", sincronizados: 0, aunConError: 0 });
     expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    // Sin pendientes no hace falta leer la hoja.
+    expect(mockGetAsignacionesGrupos).not.toHaveBeenCalled();
   });
 
-  it("reintenta la sync para cada alumno pendiente de la comisión", async () => {
+  it("lee la hoja de grupos una sola vez y reutiliza el resultado en cada alumno", async () => {
     mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
       { githubUsername: "ana" },
       { githubUsername: "bruno" },
+      { githubUsername: "cintia" },
     ]);
 
     await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
 
-    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledTimes(2);
-    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("ana", comision);
-    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("bruno", comision);
+    expect(mockGetAsignacionesGrupos).toHaveBeenCalledTimes(1);
+    expect(mockGetAsignacionesGrupos).toHaveBeenCalledWith("sheet-xyz", gruposConfig);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledTimes(3);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("ana", comision, asignacionesFake);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("bruno", comision, asignacionesFake);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("cintia", comision, asignacionesFake);
+  });
+
+  it("devuelve error y no sincroniza nada si la lectura única de la hoja falla", async () => {
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([{ githubUsername: "ana" }]);
+    mockGetAsignacionesGrupos.mockRejectedValue(new Error("No se pudo leer la hoja de grupos: rate limited"));
+
+    const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+
+    expect(result).toEqual({
+      status: "error",
+      message: "No se pudo leer la hoja de grupos: rate limited",
+    });
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+
+  it("no lee la hoja si la comisión no tiene config de grupos (no-op que limpia flags)", async () => {
+    mockGetComision.mockResolvedValue({ id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {} });
+    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([{ githubUsername: "ana" }]);
+
+    await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+
+    expect(mockGetAsignacionesGrupos).not.toHaveBeenCalled();
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+      "ana",
+      expect.objectContaining({ id: "c1" }),
+      undefined
+    );
   });
 
   it("cuenta cuántos se resolvieron y cuántos siguen con error", async () => {
@@ -333,9 +382,9 @@ describe("sincronizarGruposDeLaComision", () => {
       { githubUsername: "cintia" },
     ]);
     mockIntentarSincronizarGrupos
-      .mockResolvedValueOnce(false) // ana: ok
-      .mockResolvedValueOnce(true) // bruno: sigue fallando
-      .mockResolvedValueOnce(false); // cintia: ok
+      .mockResolvedValueOnce(undefined) // ana: ok
+      .mockRejectedValueOnce(new Error("sigue fallando")) // bruno
+      .mockResolvedValueOnce(undefined); // cintia: ok
 
     const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
 

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -1,8 +1,16 @@
 "use server";
 
 import { requireAdmin } from "@/lib/session";
-import { createComision, updateComision, getComision, upsertAlumnos, LegajoConflictError } from "@/lib/repositories";
+import {
+  createComision,
+  updateComision,
+  getComision,
+  upsertAlumnos,
+  LegajoConflictError,
+  getAlumnosConGruposSyncPendiente,
+} from "@/lib/repositories";
 import { getAlumnos } from "@/lib/sheets";
+import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
@@ -178,4 +186,37 @@ export async function sincronizarAlumnos(
 
   revalidatePath("/admin/comisiones");
   return { status: "ok", sincronizados };
+}
+
+export type SyncGruposState =
+  | { status: "idle" }
+  | { status: "ok"; sincronizados: number; aunConError: number }
+  | { status: "error"; message: string };
+
+// Reintenta `sincronizarGruposDelAlumno` para todos los alumnos de la comisión
+// con el flag `gruposSyncFallidoEn` prendido. El wrapper `intentarSincronizarGrupos`
+// se encarga del logging y de limpiar/mantener el flag por alumno; esta action
+// solo agrega un resumen para que el admin lo vea.
+export async function sincronizarGruposDeLaComision(
+  _prevState: SyncGruposState,
+  formData: FormData
+): Promise<SyncGruposState> {
+  await requireAdmin();
+
+  const id = formData.get("comisionId") as string;
+  const comision = await getComision(id);
+  if (!comision) return { status: "error", message: "Comisión no encontrada" };
+
+  const pendientes = await getAlumnosConGruposSyncPendiente(id);
+  let sincronizados = 0;
+  let aunConError = 0;
+  for (const alumno of pendientes) {
+    const fallo = await intentarSincronizarGrupos(alumno.githubUsername, comision);
+    if (fallo) aunConError++;
+    else sincronizados++;
+  }
+
+  revalidatePath("/admin/comisiones");
+  revalidatePath(`/admin/comisiones/${id}/edit`);
+  return { status: "ok", sincronizados, aunConError };
 }

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -9,7 +9,7 @@ import {
   LegajoConflictError,
   getAlumnosConGruposSyncPendiente,
 } from "@/lib/repositories";
-import { getAlumnos } from "@/lib/sheets";
+import { getAlumnos, getAsignacionesGrupos, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
@@ -208,12 +208,31 @@ export async function sincronizarGruposDeLaComision(
   if (!comision) return { status: "error", message: "Comisión no encontrada" };
 
   const pendientes = await getAlumnosConGruposSyncPendiente(id);
+
+  // Lectura única de la hoja de grupos: con un solo pendiente el costo es el
+  // mismo que antes, pero con N evitamos N lecturas a Sheets (cada alumno
+  // releía la hoja entera). Si la lectura falla reportamos el error global y
+  // no tocamos los flags — ya estaban en fallido y un retry masivo sobre una
+  // hoja inaccesible no aporta información nueva.
+  let asignaciones: AsignacionGrupoRow[] | undefined;
+  const gruposConfig = comision.columnConfig?.grupos;
+  if (gruposConfig && pendientes.length > 0) {
+    try {
+      asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
+    } catch (e) {
+      return { status: "error", message: (e as Error).message };
+    }
+  }
+
   let sincronizados = 0;
   let aunConError = 0;
   for (const alumno of pendientes) {
-    const fallo = await intentarSincronizarGrupos(alumno.githubUsername, comision);
-    if (fallo) aunConError++;
-    else sincronizados++;
+    try {
+      await intentarSincronizarGrupos(alumno.githubUsername, comision, asignaciones);
+      sincronizados++;
+    } catch {
+      aunConError++;
+    }
   }
 
   revalidatePath("/admin/comisiones");

--- a/src/app/admin/comisiones/sync-grupos-button.test.tsx
+++ b/src/app/admin/comisiones/sync-grupos-button.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen } from "@testing-library/react";
+
+// ── Mocks ─────────────────────────────────────────────────────
+
+const mockUseFormState = vi.fn();
+const mockUseFormStatus = vi.fn();
+
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return {
+    ...actual,
+    useFormState: (...args: unknown[]) => mockUseFormState(...args),
+    useFormStatus: () => mockUseFormStatus(),
+  };
+});
+
+vi.mock("./actions", () => ({
+  sincronizarGruposDeLaComision: vi.fn(),
+}));
+
+import { SyncGruposButton } from "./sync-grupos-button";
+
+// ── Helpers ───────────────────────────────────────────────────
+
+const noop = vi.fn();
+
+function idleState() {
+  mockUseFormState.mockReturnValue([{ status: "idle" }, noop]);
+}
+
+// ── Tests ─────────────────────────────────────────────────────
+
+describe("SyncGruposButton", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    idleState();
+    mockUseFormStatus.mockReturnValue({ pending: false });
+  });
+
+  describe("estado idle", () => {
+    it("renderiza el botón 'Resincronizar grupos'", () => {
+      render(<SyncGruposButton comisionId="c1" />);
+      expect(
+        screen.getByRole("button", { name: "Resincronizar grupos" })
+      ).toBeInTheDocument();
+    });
+
+    it("incluye el comisionId como campo oculto", () => {
+      const { container } = render(<SyncGruposButton comisionId="abc123" />);
+      const hidden = container.querySelector<HTMLInputElement>('[name="comisionId"]');
+      expect(hidden?.value).toBe("abc123");
+    });
+
+    it("no muestra mensajes de estado", () => {
+      render(<SyncGruposButton comisionId="c1" />);
+      expect(screen.queryByText(/resueltos/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("estado ok", () => {
+    it("muestra cuántos quedaron resueltos", () => {
+      mockUseFormState.mockReturnValue([
+        { status: "ok", sincronizados: 5, aunConError: 0 },
+        noop,
+      ]);
+      render(<SyncGruposButton comisionId="c1" />);
+      expect(screen.getByText(/5 resueltos/)).toBeInTheDocument();
+      expect(screen.queryByText(/aún con error/)).not.toBeInTheDocument();
+    });
+
+    it("muestra cuántos quedaron con error además de los resueltos", () => {
+      mockUseFormState.mockReturnValue([
+        { status: "ok", sincronizados: 3, aunConError: 2 },
+        noop,
+      ]);
+      render(<SyncGruposButton comisionId="c1" />);
+      expect(screen.getByText(/3 resueltos/)).toBeInTheDocument();
+      expect(screen.getByText(/2 aún con error/)).toBeInTheDocument();
+    });
+  });
+
+  describe("estado error", () => {
+    it("muestra el mensaje de error", () => {
+      mockUseFormState.mockReturnValue([
+        { status: "error", message: "Comisión no encontrada" },
+        noop,
+      ]);
+      render(<SyncGruposButton comisionId="c1" />);
+      expect(screen.getByText("Comisión no encontrada")).toBeInTheDocument();
+    });
+  });
+
+  describe("estado pending", () => {
+    it("muestra 'Sincronizando…' y desactiva el botón", () => {
+      mockUseFormStatus.mockReturnValue({ pending: true });
+      render(<SyncGruposButton comisionId="c1" />);
+      const btn = screen.getByRole("button", { name: "Sincronizando…" });
+      expect(btn).toBeInTheDocument();
+      expect(btn).toBeDisabled();
+    });
+  });
+});

--- a/src/app/admin/comisiones/sync-grupos-button.tsx
+++ b/src/app/admin/comisiones/sync-grupos-button.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+import { useFormState, useFormStatus } from "react-dom";
+import { sincronizarGruposDeLaComision, type SyncGruposState } from "./actions";
+
+function SyncSubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex items-center gap-1.5 text-xs font-medium bg-amber-500 hover:bg-amber-600 text-white px-2.5 py-1 rounded-full transition-colors disabled:opacity-60"
+    >
+      {pending ? "Sincronizando…" : "Resincronizar grupos"}
+    </button>
+  );
+}
+
+export function SyncGruposButton({ comisionId }: { comisionId: string }) {
+  const [state, action] = useFormState<SyncGruposState, FormData>(
+    sincronizarGruposDeLaComision,
+    { status: "idle" }
+  );
+
+  return (
+    <form action={action} className="flex items-center gap-2">
+      <input type="hidden" name="comisionId" value={comisionId} />
+      <SyncSubmitButton />
+      {state.status === "ok" && (
+        <span className="text-xs font-medium text-green-700">
+          {state.sincronizados} resueltos
+          {state.aunConError > 0 && (
+            <span className="text-red-600"> · {state.aunConError} aún con error</span>
+          )}
+        </span>
+      )}
+      {state.status === "error" && (
+        <span className="text-xs text-red-600">{state.message}</span>
+      )}
+    </form>
+  );
+}

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -89,7 +89,7 @@ describe("PATCH /api/perfil", () => {
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
-    mockIntentarSincronizarGrupos.mockResolvedValue(false);
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
   it("actualiza Sheets y DB en un mismo request", async () => {
@@ -173,15 +173,15 @@ describe("PATCH /api/perfil", () => {
       );
     });
 
-    it("no incluye gruposSync en el body cuando el wrapper devuelve false (ok)", async () => {
+    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
       const res = await PATCH(makeRequest(validBody));
       const json = await res.json();
       expect(res.status).toBe(200);
       expect(json.gruposSync).toBeUndefined();
     });
 
-    it("responde 200 con gruposSync='error' cuando el wrapper devuelve true (falló)", async () => {
-      mockIntentarSincronizarGrupos.mockResolvedValue(true);
+    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
+      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
 
       const res = await PATCH(makeRequest(validBody));
       const json = await res.json();

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -7,6 +7,7 @@ const mockUpsertarAlumnoEnSheets = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -43,11 +44,11 @@ vi.mock("@/lib/repositories", () => ({
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
-// El hook de sync de grupos arrastra `@/lib/db` (reflect-metadata) si no se
-// mockea acá. Como el route test no verifica el comportamiento del hook (lo
-// hace `alumnoRegistro.test.ts`), basta con un stub no-op.
-vi.mock("@/lib/services/grupoSync", () => ({
-  sincronizarGruposDelAlumno: vi.fn().mockResolvedValue(undefined),
+// El handler llama al wrapper `intentarSincronizarGrupos`, que encapsula
+// log + flag persistente + retorno booleano para el handler.
+vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
 }));
 
 import { PATCH } from "./route";
@@ -88,6 +89,7 @@ describe("PATCH /api/perfil", () => {
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
+    mockIntentarSincronizarGrupos.mockResolvedValue(false);
   });
 
   it("actualiza Sheets y DB en un mismo request", async () => {
@@ -159,5 +161,40 @@ describe("PATCH /api/perfil", () => {
     mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
     const res = await PATCH(makeRequest(validBody));
     expect(res.status).toBe(500);
+  });
+
+  describe("sincronización de grupos desde planilla", () => {
+    it("llama a intentarSincronizarGrupos con el github de la sesión y la comisión activa", async () => {
+      const comision = await mockGetComisionActiva();
+      await PATCH(makeRequest(validBody));
+      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+        "juangarcia",
+        comision
+      );
+    });
+
+    it("no incluye gruposSync en el body cuando el wrapper devuelve false (ok)", async () => {
+      const res = await PATCH(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.gruposSync).toBeUndefined();
+    });
+
+    it("responde 200 con gruposSync='error' cuando el wrapper devuelve true (falló)", async () => {
+      mockIntentarSincronizarGrupos.mockResolvedValue(true);
+
+      const res = await PATCH(makeRequest(validBody));
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.gruposSync).toBe("error");
+      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
+    });
+
+    it("no intenta sincronizar si la confirmación del perfil falla antes", async () => {
+      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
+      await PATCH(makeRequest(validBody));
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -31,10 +31,15 @@ export async function PATCH(req: Request) {
       );
     }
 
-    const gruposSyncFallida = await intentarSincronizarGrupos(
-      user.githubUsername,
-      resultado.comision
-    );
+    // Los datos del alumno ya se actualizaron. Si el sync falla, el wrapper
+    // marca el flag en DB para disparar el retry automático en /perfil —
+    // degradamos la respuesta a `gruposSync: "error"` para el warning inmediato.
+    let gruposSyncFallida = false;
+    try {
+      await intentarSincronizarGrupos(user.githubUsername, resultado.comision);
+    } catch {
+      gruposSyncFallida = true;
+    }
 
     return NextResponse.json({
       ok: true,

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -3,6 +3,7 @@ import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { internalServerError } from "@/lib/api-errors";
 import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
+import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -30,7 +31,15 @@ export async function PATCH(req: Request) {
       );
     }
 
-    return NextResponse.json({ ok: true });
+    const gruposSyncFallida = await intentarSincronizarGrupos(
+      user.githubUsername,
+      resultado.comision
+    );
+
+    return NextResponse.json({
+      ok: true,
+      ...(gruposSyncFallida && { gruposSync: "error" }),
+    });
   } catch (error) {
     return internalServerError("PATCH /api/perfil", error);
   }

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -8,6 +8,7 @@ const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
 const mockAgregarMiembroAGrupo = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -48,11 +49,12 @@ vi.mock("@/lib/googleGroups", () => ({
   agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
 }));
 
-// El hook de sync de grupos arrastra `@/lib/db` (reflect-metadata) si no se
-// mockea acá. Como el route test no verifica el comportamiento del hook (lo
-// hace `alumnoRegistro.test.ts`), basta con un stub no-op.
-vi.mock("@/lib/services/grupoSync", () => ({
-  sincronizarGruposDelAlumno: vi.fn().mockResolvedValue(undefined),
+// El handler llama al wrapper `intentarSincronizarGrupos`, que es quien se
+// encarga del logging, el flag persistente y el retorno booleano que el
+// handler usa para decidir si mete `gruposSync: "error"` en el body.
+vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
 }));
 
 import { POST } from "./route";
@@ -95,6 +97,7 @@ describe("POST /api/registro", () => {
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGrupos.mockResolvedValue(false);
   });
 
   it("usa el githubUsername del usuario autenticado cuando coincide con el body", async () => {
@@ -281,6 +284,44 @@ describe("POST /api/registro", () => {
       mockGetComisionActiva.mockResolvedValue(null);
       await POST(makeRequest(validBody));
       expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Sincronización de grupos desde planilla ────────────────
+
+  describe("sincronización de grupos desde planilla", () => {
+    it("llama a intentarSincronizarGrupos con el github y la comisión activa tras un registro exitoso", async () => {
+      const comision = await mockGetComisionActiva();
+      await POST(makeRequest(validBody));
+      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+        "juangarcia",
+        comision
+      );
+    });
+
+    it("no incluye gruposSync en el body cuando el wrapper devuelve false (ok)", async () => {
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+      expect(res.status).toBe(200);
+      expect(json.gruposSync).toBeUndefined();
+    });
+
+    it("responde 200 con gruposSync='error' cuando el wrapper devuelve true (falló)", async () => {
+      mockIntentarSincronizarGrupos.mockResolvedValue(true);
+
+      const res = await POST(makeRequest(validBody));
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json.gruposSync).toBe("error");
+      // El alta no se deshace por un fallo en el hook accesorio
+      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
+    });
+
+    it("no intenta sincronizar si el registro no se confirmó (ej. Sheets falló)", async () => {
+      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
+      await POST(makeRequest(validBody));
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -50,8 +50,8 @@ vi.mock("@/lib/googleGroups", () => ({
 }));
 
 // El handler llama al wrapper `intentarSincronizarGrupos`, que es quien se
-// encarga del logging, el flag persistente y el retorno booleano que el
-// handler usa para decidir si mete `gruposSync: "error"` en el body.
+// encarga del logging y de persistir el flag. Si throwea, el handler lo
+// captura y degrada la respuesta a `gruposSync: "error"`.
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
   intentarSincronizarGrupos: (...args: unknown[]) =>
     mockIntentarSincronizarGrupos(...args),
@@ -97,7 +97,7 @@ describe("POST /api/registro", () => {
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-    mockIntentarSincronizarGrupos.mockResolvedValue(false);
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
   it("usa el githubUsername del usuario autenticado cuando coincide con el body", async () => {
@@ -299,15 +299,15 @@ describe("POST /api/registro", () => {
       );
     });
 
-    it("no incluye gruposSync en el body cuando el wrapper devuelve false (ok)", async () => {
+    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
       const res = await POST(makeRequest(validBody));
       const json = await res.json();
       expect(res.status).toBe(200);
       expect(json.gruposSync).toBeUndefined();
     });
 
-    it("responde 200 con gruposSync='error' cuando el wrapper devuelve true (falló)", async () => {
-      mockIntentarSincronizarGrupos.mockResolvedValue(true);
+    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
+      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
 
       const res = await POST(makeRequest(validBody));
       const json = await res.json();

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -4,6 +4,7 @@ import { type RegistroInput } from "@/lib/sheets";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 import { internalServerError } from "@/lib/api-errors";
 import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
+import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import { logger } from "@/lib/logger";
 
 // Enmascara la parte local del email para no escupir PII a los logs,
@@ -57,9 +58,9 @@ export async function POST(req: Request) {
       );
     }
 
-    // El alta ya quedó persistida — una falla al suscribir al grupo no
-    // debe romper el registro. Informamos el resultado para que la UI lo
-    // muestre si corresponde y logueamos el detalle server-side.
+    // Hooks accesorios: el alta ya está persistida. Cada uno puede fallar sin
+    // abortar el registro; la respuesta incluye un status por hook para que el
+    // form muestre el warning correspondiente.
     const groupSubscription = await agregarMiembroAGrupo(body.email);
     if (groupSubscription.status === "error") {
       logger.error(
@@ -72,7 +73,16 @@ export async function POST(req: Request) {
       );
     }
 
-    return NextResponse.json({ ok: true, groupSubscription: groupSubscription.status });
+    const gruposSyncFallida = await intentarSincronizarGrupos(
+      body.githubUsername,
+      resultado.comision
+    );
+
+    return NextResponse.json({
+      ok: true,
+      groupSubscription: groupSubscription.status,
+      ...(gruposSyncFallida && { gruposSync: "error" }),
+    });
   } catch (error) {
     return internalServerError("POST /api/registro", error);
   }

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -73,10 +73,16 @@ export async function POST(req: Request) {
       );
     }
 
-    const gruposSyncFallida = await intentarSincronizarGrupos(
-      body.githubUsername,
-      resultado.comision
-    );
+    // Hook accesorio: el alta ya está persistida. Si el sync falla, el wrapper
+    // marca el flag en DB para disparar el retry automático en /perfil — solo
+    // degradamos la respuesta a `gruposSync: "error"` para que el form muestre
+    // el warning inmediato.
+    let gruposSyncFallida = false;
+    try {
+      await intentarSincronizarGrupos(body.githubUsername, resultado.comision);
+    } catch {
+      gruposSyncFallida = true;
+    }
 
     return NextResponse.json({
       ok: true,

--- a/src/app/components/AlumnoForm.test.tsx
+++ b/src/app/components/AlumnoForm.test.tsx
@@ -6,6 +6,11 @@ vi.mock("next-auth/react", () => ({
   signOut: (...args: unknown[]) => mockSignOut(...args),
 }));
 
+const mockRouterRefresh = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
 const DEFAULT_VALUES = {
   githubUsername: "juangarcia",
   legajo: "12345",
@@ -120,6 +125,13 @@ describe("AlumnoForm", () => {
       await waitFor(() => expect(screen.getByText("¡Datos actualizados!")).toBeInTheDocument());
       expect(screen.queryByRole("button")).not.toBeInTheDocument();
     });
+
+    it("llama a router.refresh() post-submit OK para re-renderizar el banner global", async () => {
+      mockRouterRefresh.mockClear();
+      renderForm();
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => expect(mockRouterRefresh).toHaveBeenCalled());
+    });
   });
 
   describe("warning de suscripción al grupo", () => {
@@ -173,6 +185,45 @@ describe("AlumnoForm", () => {
       fireEvent.submit(screen.getByRole("button").closest("form")!);
       await waitFor(() => screen.getByText("Listo"));
       expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("warning de sincronización de grupos", () => {
+    function mockOkConBody(body: Record<string, unknown>) {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(JSON.stringify({ ok: true, ...body }), { status: 200 })
+      );
+    }
+
+    const SYNC_WARNING_PATTERN = /no pudimos asignarte al grupo de tp/i;
+
+    it("muestra el warning cuando gruposSync === 'error'", async () => {
+      mockOkConBody({ gruposSync: "error" });
+      renderForm();
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() =>
+        expect(screen.getByRole("alert")).toHaveTextContent(SYNC_WARNING_PATTERN)
+      );
+    });
+
+    it("no muestra el warning cuando el body no trae gruposSync", async () => {
+      mockOkConBody({});
+      renderForm({ successMessage: "Listo" });
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => screen.getByText("Listo"));
+      expect(screen.queryByText(SYNC_WARNING_PATTERN)).not.toBeInTheDocument();
+    });
+
+    it("muestra ambos warnings cuando fallan Google Group y sync de grupos", async () => {
+      mockOkConBody({ groupSubscription: "error", gruposSync: "error" });
+      renderForm();
+      fireEvent.submit(screen.getByRole("button").closest("form")!);
+      await waitFor(() => {
+        const alerts = screen.getAllByRole("alert");
+        expect(alerts).toHaveLength(2);
+      });
+      expect(screen.getByText(/no pudimos suscribirte al grupo/i)).toBeInTheDocument();
+      expect(screen.getByText(SYNC_WARNING_PATTERN)).toBeInTheDocument();
     });
   });
 

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useApiCall } from "@/app/hooks/useApiCall";
 
@@ -38,9 +39,11 @@ export function AlumnoForm({
   submitLabel,
   successMessage,
 }: Props) {
+  const router = useRouter();
   const { loading, error, call } = useApiCall();
   const [success, setSuccess] = useState(false);
   const [groupWarning, setGroupWarning] = useState(false);
+  const [gruposSyncWarning, setGruposSyncWarning] = useState(false);
   const [fieldError, setFieldError] = useState<{ message: string; field: string } | null>(null);
 
   async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
@@ -68,12 +71,18 @@ export function AlumnoForm({
         throw new Error(json.error ?? "Error al guardar");
       }
       const hasGroupWarning = json.groupSubscription === "error";
+      const hasGruposSyncWarning = json.gruposSync === "error";
       setGroupWarning(hasGroupWarning);
+      setGruposSyncWarning(hasGruposSyncWarning);
       setSuccess(true);
-      // Damos más tiempo antes de redirigir si hay que mostrar el warning
+      // Revalidamos el árbol server para que el banner global
+      // `SyncPendingBanner` refleje el estado actualizado del flag
+      // (lo limpiamos si la sync funcionó, lo prendemos si falló).
+      router.refresh();
+      // Damos más tiempo antes de redirigir si hay que mostrar un warning
       // para que el alumno alcance a leerlo.
       if (onSuccessRedirect) {
-        const delay = hasGroupWarning ? 5000 : 1500;
+        const delay = hasGroupWarning || hasGruposSyncWarning ? 5000 : 1500;
         setTimeout(() => { window.location.href = onSuccessRedirect; }, delay);
       }
     });
@@ -91,6 +100,14 @@ export function AlumnoForm({
             className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-sm text-amber-800"
           >
             No pudimos suscribirte al grupo del curso. Avisale a un docente para que te agregue manualmente.
+          </div>
+        )}
+        {gruposSyncWarning && (
+          <div
+            role="alert"
+            className="bg-amber-50 border border-amber-200 rounded-lg px-3 py-2 text-sm text-amber-800"
+          >
+            Tus datos quedaron guardados, pero no pudimos asignarte al grupo de TP. Guardá de nuevo para reintentar; si persiste, avisale a un docente.
           </div>
         )}
       </div>

--- a/src/app/components/SyncPendingBanner.test.tsx
+++ b/src/app/components/SyncPendingBanner.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { Alumno } from "@/domain/entities";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetCurrentUser = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+}));
+
+import { SyncPendingBanner } from "./SyncPendingBanner";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
+  return {
+    id: "uuid-1",
+    legajo: "12345",
+    nombre: "Juan",
+    apellido: "Garcia",
+    githubUsername: "juangarcia",
+    email: "juan@example.com",
+    ...overrides,
+  } as Alumno;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("SyncPendingBanner", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("no renderiza nada si no hay usuario logueado", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const el = await SyncPendingBanner();
+    expect(el).toBeNull();
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+  });
+
+  it("no renderiza nada si el usuario es admin (no aplica)", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: true,
+    });
+    const el = await SyncPendingBanner();
+    expect(el).toBeNull();
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+  });
+
+  it("no renderiza nada si el alumno no existe en DB", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    const el = await SyncPendingBanner();
+    expect(el).toBeNull();
+  });
+
+  it("no renderiza nada si el alumno no tiene el flag prendido", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    const el = await SyncPendingBanner();
+    expect(el).toBeNull();
+  });
+
+  it("renderiza el banner cuando el alumno tiene el flag prendido", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
+    );
+
+    const el = await SyncPendingBanner();
+    const html = renderToStaticMarkup(el as React.ReactElement);
+
+    expect(html).toContain("No pudimos asignarte a tu grupo de TP");
+    expect(html).toContain('href="/perfil"');
+    expect(html).toContain("Reintentar");
+  });
+});

--- a/src/app/components/SyncPendingBanner.tsx
+++ b/src/app/components/SyncPendingBanner.tsx
@@ -1,0 +1,36 @@
+import Link from "next/link";
+import { getCurrentUser } from "@/lib/session";
+import { getAlumnoByGithub } from "@/lib/repositories";
+
+/**
+ * Banner global que avisa al alumno que su sincronización con los grupos de
+ * la planilla quedó en error. Es persistente: mientras `gruposSyncFallidoEn`
+ * siga prendido en la DB, se muestra en todas las páginas logueadas.
+ *
+ * El flag se limpia solo cuando un reintento de sync funciona (ya sea al
+ * entrar a `/perfil` o al guardar desde el form); cuando eso pasa, este
+ * banner desaparece en el próximo render.
+ */
+export async function SyncPendingBanner() {
+  const user = await getCurrentUser();
+  if (!user || user.isAdmin) return null;
+
+  const alumno = await getAlumnoByGithub(user.githubUsername);
+  if (!alumno?.gruposSyncFallidoEn) return null;
+
+  return (
+    <div
+      role="alert"
+      className="bg-amber-50 border-b border-amber-200 text-amber-900 text-sm"
+    >
+      <div className="max-w-5xl mx-auto px-4 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
+        <span>
+          No pudimos asignarte a tu grupo de TP desde la planilla.
+        </span>
+        <Link href="/perfil" className="underline font-medium hover:text-amber-950">
+          Reintentar desde tu perfil
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import "./globals.css";
 import { Nav } from "./nav";
+import { SyncPendingBanner } from "./components/SyncPendingBanner";
 
 export const metadata: Metadata = {
   title: "PdeP Classroom",
@@ -21,6 +22,7 @@ export default function RootLayout({
     <html lang="es">
       <body className="font-sans">
         <Nav />
+        <SyncPendingBanner />
         <main className="max-w-5xl mx-auto px-4 py-6 sm:py-8">{children}</main>
       </body>
     </html>

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -7,6 +7,8 @@ import type { Alumno } from "@/domain/entities";
 
 const mockAuth = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
+const mockGetComisionActiva = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -17,6 +19,12 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+  getComisionActiva: () => mockGetComisionActiva(),
+}));
+
+vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -95,6 +103,8 @@ describe("Perfil page", () => {
     beforeEach(() => {
       mockAuth.mockResolvedValue(makeSession("juangarcia"));
       mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+      mockGetComisionActiva.mockResolvedValue({ id: "c1" });
+      mockIntentarSincronizarGrupos.mockResolvedValue(false);
     });
 
     it("muestra el título Mi perfil", async () => {
@@ -120,6 +130,40 @@ describe("Perfil page", () => {
     it("consulta getAlumnoByGithub de la DB con el username de la sesión", async () => {
       await PerfilPage();
       expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("juangarcia");
+    });
+  });
+
+  describe("reintento de sincronización de grupos al montar", () => {
+    beforeEach(() => {
+      mockAuth.mockResolvedValue(makeSession("juangarcia"));
+      mockGetComisionActiva.mockResolvedValue({ id: "c1" });
+      mockIntentarSincronizarGrupos.mockResolvedValue(false);
+    });
+
+    it("no reintenta la sync si el alumno no tiene el flag prendido", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+      await PerfilPage();
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    });
+
+    it("reintenta la sync al montar si el alumno tiene el flag prendido", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
+      );
+      await PerfilPage();
+      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+        "juangarcia",
+        { id: "c1" }
+      );
+    });
+
+    it("no reintenta si tiene el flag pero no hay comisión activa (evita el crash)", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
+      );
+      mockGetComisionActiva.mockResolvedValue(null);
+      await PerfilPage();
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -137,7 +137,7 @@ describe("Perfil page", () => {
     beforeEach(() => {
       mockAuth.mockResolvedValue(makeSession("juangarcia"));
       mockGetComisionActiva.mockResolvedValue({ id: "c1" });
-      mockIntentarSincronizarGrupos.mockResolvedValue(false);
+      mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
     });
 
     it("no reintenta la sync si el alumno no tiene el flag prendido", async () => {
@@ -164,6 +164,15 @@ describe("Perfil page", () => {
       mockGetComisionActiva.mockResolvedValue(null);
       await PerfilPage();
       expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    });
+
+    it("no rompe el render si el wrapper throwea (el flag persistido en DB mantiene el banner)", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
+      );
+      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
+
+      await expect(PerfilPage()).resolves.toBeDefined();
     });
   });
 });

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -1,7 +1,8 @@
 import { auth } from "@/lib/auth";
-import { getAlumnoByGithub } from "@/lib/repositories";
+import { getAlumnoByGithub, getComisionActiva } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
+import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import type { PdepUser } from "@/types";
 
 export default async function PerfilPage() {
@@ -13,6 +14,17 @@ export default async function PerfilPage() {
 
   const alumno = await getAlumnoByGithub(githubUsername);
   if (!alumno) redirect("/registro");
+
+  // Si el alumno tiene sync de grupos pendiente, reintentamos al montar
+  // el perfil. Si funciona, el flag se limpia acá mismo y el banner global
+  // desaparece en el próximo render. Si sigue fallando, el wrapper lo
+  // deja prendido y el banner sigue visible.
+  if (alumno.gruposSyncFallidoEn) {
+    const comisionActiva = await getComisionActiva();
+    if (comisionActiva) {
+      await intentarSincronizarGrupos(githubUsername, comisionActiva);
+    }
+  }
 
   return (
     <div className="max-w-md mx-auto">

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -17,12 +17,17 @@ export default async function PerfilPage() {
 
   // Si el alumno tiene sync de grupos pendiente, reintentamos al montar
   // el perfil. Si funciona, el flag se limpia acá mismo y el banner global
-  // desaparece en el próximo render. Si sigue fallando, el wrapper lo
-  // deja prendido y el banner sigue visible.
+  // desaparece en el próximo render. Si sigue fallando, el wrapper deja el
+  // flag prendido y el banner sigue visible — no queremos que la excepción
+  // rompa el render del perfil.
   if (alumno.gruposSyncFallidoEn) {
     const comisionActiva = await getComisionActiva();
     if (comisionActiva) {
-      await intentarSincronizarGrupos(githubUsername, comisionActiva);
+      try {
+        await intentarSincronizarGrupos(githubUsername, comisionActiva);
+      } catch {
+        // Flag persistente en DB se encarga del banner en este render.
+      }
     }
   }
 

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -35,7 +35,7 @@ export class Alumno {
   // cuando un reintento exitoso lo resuelve. Mientras esté prendido, el header
   // muestra un banner persistente y el perfil reintenta la sync al montar.
   @Property({ type: 'datetime', nullable: true })
-  gruposSyncFallidoEn?: Date;
+  gruposSyncFallidoEn: Date | null = null;
 
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -30,6 +30,13 @@ export class Alumno {
   @ManyToOne(() => Comision, { nullable: true })
   registroConfirmadoEn?: Comision;
 
+  // Timestamp del último fallo al sincronizar los grupos del alumno desde la
+  // planilla. Se prende cuando `sincronizarGruposDelAlumno` throwea y se limpia
+  // cuando un reintento exitoso lo resuelve. Mientras esté prendido, el header
+  // muestra un banner persistente y el perfil reintenta la sync al montar.
+  @Property({ type: 'datetime', nullable: true })
+  gruposSyncFallidoEn?: Date;
+
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;
   }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -119,6 +119,39 @@ export async function marcarRegistroConfirmado(
   await em.flush();
 }
 
+export async function marcarGruposSyncFallido(githubUsername: string): Promise<void> {
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, {
+    githubUsername: githubUsername.toLowerCase().trim(),
+  });
+  if (!alumno) return;
+  alumno.gruposSyncFallidoEn = new Date();
+  await em.flush();
+}
+
+export async function marcarGruposSyncOk(githubUsername: string): Promise<void> {
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, {
+    githubUsername: githubUsername.toLowerCase().trim(),
+  });
+  // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
+  // exitosa del happy path.
+  if (!alumno || !alumno.gruposSyncFallidoEn) return;
+  alumno.gruposSyncFallidoEn = undefined;
+  await em.flush();
+}
+
+export async function getAlumnosConGruposSyncPendiente(
+  comisionId: string
+): Promise<Alumno[]> {
+  const em = await getEM();
+  return em.find(
+    Alumno,
+    { comision: { id: comisionId }, gruposSyncFallidoEn: { $ne: null } },
+    { orderBy: { apellido: "ASC", nombre: "ASC" } }
+  );
+}
+
 /** Crea o actualiza múltiples alumnos en un solo flush. */
 export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   if (dataList.length === 0) return 0;

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -137,7 +137,7 @@ export async function marcarGruposSyncOk(githubUsername: string): Promise<void> 
   // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
   // exitosa del happy path.
   if (!alumno || !alumno.gruposSyncFallidoEn) return;
-  alumno.gruposSyncFallidoEn = undefined;
+  alumno.gruposSyncFallidoEn = null;
   await em.flush();
 }
 

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -6,6 +6,9 @@ export {
   upsertAlumno,
   upsertAlumnos,
   marcarRegistroConfirmado,
+  marcarGruposSyncFallido,
+  marcarGruposSyncOk,
+  getAlumnosConGruposSyncPendiente,
   countAlumnos,
   LegajoConflictError,
 } from "./AlumnoRepository";

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -6,7 +6,6 @@ const mockGetComisionActiva = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
-const mockSincronizarGruposDelAlumno = vi.fn();
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -41,11 +40,6 @@ vi.mock("@/lib/sheets", async () => {
       mockUpsertarAlumnoEnSheets(...args),
   };
 });
-
-vi.mock("@/lib/services/grupoSync", () => ({
-  sincronizarGruposDelAlumno: (...args: unknown[]) =>
-    mockSincronizarGruposDelAlumno(...args),
-}));
 
 import { confirmarDatosAlumno } from "./alumnoRegistro";
 
@@ -82,12 +76,11 @@ describe("confirmarDatosAlumno", () => {
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
-    mockSincronizarGruposDelAlumno.mockResolvedValue(undefined);
   });
 
-  it("devuelve { ok: true } cuando todo el flujo funciona", async () => {
+  it("devuelve { ok: true, comision } cuando todo el flujo funciona", async () => {
     const resultado = await confirmarDatosAlumno(validInput);
-    expect(resultado).toEqual({ ok: true });
+    expect(resultado).toEqual({ ok: true, comision: comisionActiva });
   });
 
   it("persiste en DB antes de tocar Sheets (DB-primero)", async () => {
@@ -232,40 +225,5 @@ describe("confirmarDatosAlumno", () => {
   it("deja propagar errores inesperados del upsert en DB (no-LegajoConflictError)", async () => {
     mockUpsertAlumno.mockRejectedValue(new Error("conexión caída"));
     await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("conexión caída");
-  });
-
-  describe("hook de sincronización de grupos", () => {
-    it("llama a sincronizarGruposDelAlumno con el github y la comisión, después de marcar registroConfirmadoEn", async () => {
-      await confirmarDatosAlumno(validInput);
-      expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith(
-        validInput.githubUsername,
-        comisionActiva
-      );
-      const ordenLlamadas = [
-        mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
-        mockSincronizarGruposDelAlumno.mock.invocationCallOrder[0],
-      ];
-      expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
-    });
-
-    it("devuelve { ok: true } aunque la sincronización de grupos falle (best-effort)", async () => {
-      const { logger } = await import("@/lib/logger");
-      const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
-      mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("algo falló"));
-
-      const resultado = await confirmarDatosAlumno(validInput);
-
-      expect(resultado).toEqual({ ok: true });
-      expect(errorSpy).toHaveBeenCalled();
-      errorSpy.mockRestore();
-    });
-
-    it("no se llama si el registro falla antes (ej. conflicto de legajo)", async () => {
-      mockUpsertAlumno.mockRejectedValue(
-        new FakeLegajoConflictError("12345", "otro-alumno")
-      );
-      await confirmarDatosAlumno(validInput);
-      expect(mockSincronizarGruposDelAlumno).not.toHaveBeenCalled();
-    });
   });
 });

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -5,15 +5,17 @@ import {
   marcarRegistroConfirmado,
   LegajoConflictError,
 } from "@/lib/repositories";
-import { sincronizarGruposDelAlumno } from "@/lib/services/grupoSync";
+import { Comision } from "@/domain/entities";
 import { logger } from "@/lib/logger";
 
 /**
  * Resultado de `confirmarDatosAlumno` — discriminated union con el status HTTP
- * sugerido y, cuando aplica, el `field` para que el form lo pinte inline.
+ * sugerido y, cuando aplica, el `field` para que el form lo pinte inline. En
+ * el caso OK devolvemos la `comision` para que el handler pueda encadenar
+ * acciones accesorias (sync de grupos, Google Groups) sin volver a consultarla.
  */
 export type ResultadoConfirmacion =
-  | { ok: true }
+  | { ok: true; comision: Comision }
   | {
       ok: false;
       status: 400 | 409;
@@ -28,7 +30,7 @@ export type ResultadoConfirmacion =
  *
  * El handler es quien agrega lo específico: registro hace la validación de
  * coherencia github↔sesión antes de llamar, y después de un resultado OK
- * dispara el hook de Google Groups.
+ * dispara los hooks accesorios (Google Groups, sync de grupos desde planilla).
  */
 export async function confirmarDatosAlumno(
   input: RegistroInput
@@ -100,22 +102,5 @@ export async function confirmarDatosAlumno(
     throw error;
   }
 
-  // Sincronización de grupos: best-effort. El registro del alumno ya está OK;
-  // si la hoja de grupos no existe, no se puede leer o el upsert falla, lo
-  // logueamos y seguimos — no queremos abortar un registro confirmado por
-  // un problema en una funcionalidad secundaria.
-  try {
-    await sincronizarGruposDelAlumno(input.githubUsername, comisionActiva);
-  } catch (error) {
-    logger.error(
-      {
-        err: error,
-        githubUsername: input.githubUsername,
-        comisionId: comisionActiva.id,
-      },
-      "Falló sincronización de grupos desde planilla — registro ya confirmado"
-    );
-  }
-
-  return { ok: true };
+  return { ok: true, comision: comisionActiva };
 }

--- a/src/lib/services/grupoSync.test.ts
+++ b/src/lib/services/grupoSync.test.ts
@@ -157,6 +157,24 @@ describe("sincronizarGruposDelAlumno", () => {
     ).rejects.toThrow("DB conflict");
   });
 
+  it("reutiliza asignacionesPrefetched y no vuelve a leer la hoja", async () => {
+    const prefetched = [
+      { githubUsername: "juangarcia", paradigma: "funcional" as const, nombreGrupo: "Los Lambdas" },
+    ];
+    mockEmFind.mockResolvedValue([grupalAssignmentFake]);
+
+    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos, prefetched);
+
+    expect(mockGetAsignacionesGrupos).not.toHaveBeenCalled();
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(1);
+    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledWith({
+      nombreGrupo: "Los Lambdas",
+      paradigma: "funcional",
+      assignment: grupalAssignmentFake,
+      alumno: alumnoFake,
+    });
+  });
+
   it("no hace nada si el alumno no está en DB (edge: borrado entre confirm y sync)", async () => {
     mockGetAsignacionesGrupos.mockResolvedValue([
       { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },

--- a/src/lib/services/grupoSync.test.ts
+++ b/src/lib/services/grupoSync.test.ts
@@ -135,40 +135,26 @@ describe("sincronizarGruposDelAlumno", () => {
     expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(1);
   });
 
-  it("loguea y no throwea si getAsignacionesGrupos falla (evita abortar registro)", async () => {
-    const { logger } = await import("@/lib/logger");
-    const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
+  it("propaga el error si getAsignacionesGrupos falla (el caller decide qué mostrar)", async () => {
     mockGetAsignacionesGrupos.mockRejectedValue(new Error("Sheets caído"));
 
     await expect(
       sincronizarGruposDelAlumno("juangarcia", comisionConGrupos)
-    ).resolves.toBeUndefined();
+    ).rejects.toThrow("Sheets caído");
 
-    expect(errorSpy).toHaveBeenCalledOnce();
     expect(mockUpsertGrupoConMiembro).not.toHaveBeenCalled();
-    errorSpy.mockRestore();
   });
 
-  it("loguea y sigue si un upsert falla, sin abortar los otros", async () => {
-    const { logger } = await import("@/lib/logger");
-    const errorSpy = vi.spyOn(logger, "error").mockImplementation((() => {}) as never);
-
+  it("propaga el error si un upsert falla (sin tragar)", async () => {
     mockGetAsignacionesGrupos.mockResolvedValue([
       { githubUsername: "juangarcia", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
     ]);
-    mockEmFind.mockResolvedValue([
-      grupalAssignmentFake,
-      { ...grupalAssignmentFake, id: "asg2" },
-    ]);
-    mockUpsertGrupoConMiembro
-      .mockRejectedValueOnce(new Error("DB conflict"))
-      .mockResolvedValueOnce(undefined);
+    mockEmFind.mockResolvedValue([grupalAssignmentFake]);
+    mockUpsertGrupoConMiembro.mockRejectedValue(new Error("DB conflict"));
 
-    await sincronizarGruposDelAlumno("juangarcia", comisionConGrupos);
-
-    expect(mockUpsertGrupoConMiembro).toHaveBeenCalledTimes(2);
-    expect(errorSpy).toHaveBeenCalledOnce();
-    errorSpy.mockRestore();
+    await expect(
+      sincronizarGruposDelAlumno("juangarcia", comisionConGrupos)
+    ).rejects.toThrow("DB conflict");
   });
 
   it("no hace nada si el alumno no está en DB (edge: borrado entre confirm y sync)", async () => {

--- a/src/lib/services/grupoSync.ts
+++ b/src/lib/services/grupoSync.ts
@@ -1,5 +1,4 @@
 import { getEM } from "@/lib/db";
-import { logger } from "@/lib/logger";
 import { Alumno, GrupalAssignment, type Comision } from "@/domain/entities";
 import { getAsignacionesGrupos } from "@/lib/sheets";
 import { upsertGrupoConMiembro } from "@/lib/repositories";
@@ -9,9 +8,8 @@ import { upsertGrupoConMiembro } from "@/lib/repositories";
  * materializa en DB los grupos que le corresponden, uno por cada GrupalAssignment
  * del mismo paradigma que ya exista en la comisión.
  *
- * Es idempotente y best-effort: si no hay `columnConfig.grupos`, no hace nada;
- * si la lectura de Sheets falla, lo logueamos y devolvemos sin romper (el caller
- * —el registro— ya confirmó al alumno antes de llamarnos).
+ * Es idempotente. Comando puro: o cumple, o throwea — la decisión de qué mostrar
+ * al usuario ante una falla vive en el handler HTTP que orquesta el registro.
  *
  * Limitación consciente: si todavía no existe el `GrupalAssignment` del paradigma,
  * el grupo no se materializa. Se resuelve la próxima vez que el alumno reingrese
@@ -26,16 +24,7 @@ export async function sincronizarGruposDelAlumno(
 
   const ghNorm = githubUsername.toLowerCase().trim();
 
-  let asignaciones;
-  try {
-    asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
-  } catch (error) {
-    logger.error(
-      { err: error, githubUsername: ghNorm, comisionId: comision.id },
-      "No se pudo leer la hoja de grupos — skip sincronización"
-    );
-    return;
-  }
+  const asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
 
   const deEsteAlumno = asignaciones.filter((a) => a.githubUsername === ghNorm);
   if (deEsteAlumno.length === 0) return;
@@ -50,25 +39,12 @@ export async function sincronizarGruposDelAlumno(
       paradigma: asig.paradigma,
     });
     for (const assignment of grupales) {
-      try {
-        await upsertGrupoConMiembro({
-          nombreGrupo: asig.nombreGrupo,
-          paradigma: asig.paradigma,
-          assignment,
-          alumno,
-        });
-      } catch (error) {
-        logger.error(
-          {
-            err: error,
-            githubUsername: ghNorm,
-            assignmentId: assignment.id,
-            nombreGrupo: asig.nombreGrupo,
-            paradigma: asig.paradigma,
-          },
-          "No se pudo upsertar grupo desde planilla"
-        );
-      }
+      await upsertGrupoConMiembro({
+        nombreGrupo: asig.nombreGrupo,
+        paradigma: asig.paradigma,
+        assignment,
+        alumno,
+      });
     }
   }
 }

--- a/src/lib/services/grupoSync.ts
+++ b/src/lib/services/grupoSync.ts
@@ -1,6 +1,6 @@
 import { getEM } from "@/lib/db";
 import { Alumno, GrupalAssignment, type Comision } from "@/domain/entities";
-import { getAsignacionesGrupos } from "@/lib/sheets";
+import { getAsignacionesGrupos, type AsignacionGrupoRow } from "@/lib/sheets";
 import { upsertGrupoConMiembro } from "@/lib/repositories";
 
 /**
@@ -14,17 +14,24 @@ import { upsertGrupoConMiembro } from "@/lib/repositories";
  * Limitación consciente: si todavía no existe el `GrupalAssignment` del paradigma,
  * el grupo no se materializa. Se resuelve la próxima vez que el alumno reingrese
  * al perfil, o por un comando de sincronización masiva (fuera de alcance acá).
+ *
+ * `asignacionesPrefetched` permite al caller reutilizar una lectura previa de la
+ * hoja cuando sincroniza a varios alumnos seguidos (resync masivo), evitando
+ * N lecturas a Sheets. Si se omite, la función lee la hoja por sí misma.
  */
 export async function sincronizarGruposDelAlumno(
   githubUsername: string,
-  comision: Comision
+  comision: Comision,
+  asignacionesPrefetched?: AsignacionGrupoRow[]
 ): Promise<void> {
   const gruposConfig = comision.columnConfig?.grupos;
   if (!gruposConfig) return;
 
   const ghNorm = githubUsername.toLowerCase().trim();
 
-  const asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
+  const asignaciones =
+    asignacionesPrefetched ??
+    (await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig));
 
   const deEsteAlumno = asignaciones.filter((a) => a.githubUsername === ghNorm);
   if (deEsteAlumno.length === 0) return;

--- a/src/lib/services/intentarSincronizarGrupos.test.ts
+++ b/src/lib/services/intentarSincronizarGrupos.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockSincronizarGruposDelAlumno = vi.fn();
+const mockMarcarGruposSyncOk = vi.fn();
+const mockMarcarGruposSyncFallido = vi.fn();
+
+vi.mock("./grupoSync", () => ({
+  sincronizarGruposDelAlumno: (...args: unknown[]) =>
+    mockSincronizarGruposDelAlumno(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  marcarGruposSyncOk: (...args: unknown[]) => mockMarcarGruposSyncOk(...args),
+  marcarGruposSyncFallido: (...args: unknown[]) =>
+    mockMarcarGruposSyncFallido(...args),
+}));
+
+import { intentarSincronizarGrupos } from "./intentarSincronizarGrupos";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const comision = {
+  id: "c1",
+  spreadsheetId: "sheet-xyz",
+  columnConfig: {},
+} as unknown as Parameters<typeof intentarSincronizarGrupos>[1];
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("intentarSincronizarGrupos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSincronizarGruposDelAlumno.mockResolvedValue(undefined);
+    mockMarcarGruposSyncOk.mockResolvedValue(undefined);
+    mockMarcarGruposSyncFallido.mockResolvedValue(undefined);
+  });
+
+  it("retorna false y limpia el flag cuando la sync funciona", async () => {
+    const result = await intentarSincronizarGrupos("juangarcia", comision);
+
+    expect(result).toBe(false);
+    expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith("juangarcia", comision);
+    expect(mockMarcarGruposSyncOk).toHaveBeenCalledWith("juangarcia");
+    expect(mockMarcarGruposSyncFallido).not.toHaveBeenCalled();
+  });
+
+  it("retorna true, loguea y prende el flag cuando la sync throwea", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("Sheets caído"));
+
+    const result = await intentarSincronizarGrupos("juangarcia", comision);
+
+    expect(result).toBe(true);
+    expect(mockMarcarGruposSyncFallido).toHaveBeenCalledWith("juangarcia");
+    expect(mockMarcarGruposSyncOk).not.toHaveBeenCalled();
+    expect(errorSpy).toHaveBeenCalled();
+    const [context] = errorSpy.mock.calls[0];
+    expect(context).toMatchObject({ githubUsername: "juangarcia", comisionId: "c1" });
+    errorSpy.mockRestore();
+  });
+
+  it("no propaga el error: es un wrapper que absorbe para reportar por su return", async () => {
+    const errorSpy = vi
+      .spyOn((await import("@/lib/logger")).logger, "error")
+      .mockImplementation(() => {});
+    mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("boom"));
+
+    await expect(
+      intentarSincronizarGrupos("juangarcia", comision)
+    ).resolves.toBe(true);
+
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/services/intentarSincronizarGrupos.test.ts
+++ b/src/lib/services/intentarSincronizarGrupos.test.ts
@@ -37,23 +37,26 @@ describe("intentarSincronizarGrupos", () => {
     mockMarcarGruposSyncFallido.mockResolvedValue(undefined);
   });
 
-  it("retorna false y limpia el flag cuando la sync funciona", async () => {
-    const result = await intentarSincronizarGrupos("juangarcia", comision);
+  it("limpia el flag cuando la sync funciona", async () => {
+    await expect(
+      intentarSincronizarGrupos("juangarcia", comision)
+    ).resolves.toBeUndefined();
 
-    expect(result).toBe(false);
-    expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith("juangarcia", comision);
+    expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith("juangarcia", comision, undefined);
     expect(mockMarcarGruposSyncOk).toHaveBeenCalledWith("juangarcia");
     expect(mockMarcarGruposSyncFallido).not.toHaveBeenCalled();
   });
 
-  it("retorna true, loguea y prende el flag cuando la sync throwea", async () => {
+  it("loguea, prende el flag y propaga cuando la sync throwea", async () => {
     const { logger } = await import("@/lib/logger");
     const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-    mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("Sheets caído"));
+    const syncError = new Error("Sheets caído");
+    mockSincronizarGruposDelAlumno.mockRejectedValue(syncError);
 
-    const result = await intentarSincronizarGrupos("juangarcia", comision);
+    await expect(
+      intentarSincronizarGrupos("juangarcia", comision)
+    ).rejects.toBe(syncError);
 
-    expect(result).toBe(true);
     expect(mockMarcarGruposSyncFallido).toHaveBeenCalledWith("juangarcia");
     expect(mockMarcarGruposSyncOk).not.toHaveBeenCalled();
     expect(errorSpy).toHaveBeenCalled();
@@ -62,16 +65,47 @@ describe("intentarSincronizarGrupos", () => {
     errorSpy.mockRestore();
   });
 
-  it("no propaga el error: es un wrapper que absorbe para reportar por su return", async () => {
-    const errorSpy = vi
-      .spyOn((await import("@/lib/logger")).logger, "error")
-      .mockImplementation(() => {});
-    mockSincronizarGruposDelAlumno.mockRejectedValue(new Error("boom"));
+  it("si marcarGruposSyncFallido también falla, loguea ambos y propaga el error original de sync", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const syncError = new Error("Sheets caído");
+    const flagError = new Error("DB hipada");
+    mockSincronizarGruposDelAlumno.mockRejectedValue(syncError);
+    mockMarcarGruposSyncFallido.mockRejectedValue(flagError);
 
     await expect(
       intentarSincronizarGrupos("juangarcia", comision)
-    ).resolves.toBe(true);
+    ).rejects.toBe(syncError);
 
+    // El error original (sync) se propaga; el de flag solo se loguea para
+    // diagnóstico — la causa real es la sync, y nunca queremos enmascararla.
+    expect(errorSpy).toHaveBeenCalledTimes(2);
     errorSpy.mockRestore();
+  });
+
+  it("si marcarGruposSyncOk falla tras una sync exitosa, propaga ese error", async () => {
+    const flagError = new Error("DB hipada al limpiar flag");
+    mockMarcarGruposSyncOk.mockRejectedValue(flagError);
+
+    await expect(
+      intentarSincronizarGrupos("juangarcia", comision)
+    ).rejects.toBe(flagError);
+
+    expect(mockSincronizarGruposDelAlumno).toHaveBeenCalled();
+    expect(mockMarcarGruposSyncFallido).not.toHaveBeenCalled();
+  });
+
+  it("forwardea asignacionesPrefetched al comando puro (resync masivo con lectura única)", async () => {
+    const prefetched = [
+      { githubUsername: "juangarcia", paradigma: "funcional" as const, nombreGrupo: "X" },
+    ];
+
+    await intentarSincronizarGrupos("juangarcia", comision, prefetched);
+
+    expect(mockSincronizarGruposDelAlumno).toHaveBeenCalledWith(
+      "juangarcia",
+      comision,
+      prefetched
+    );
   });
 });

--- a/src/lib/services/intentarSincronizarGrupos.ts
+++ b/src/lib/services/intentarSincronizarGrupos.ts
@@ -1,28 +1,31 @@
 import { logger } from "@/lib/logger";
 import type { Comision } from "@/domain/entities";
 import { marcarGruposSyncFallido, marcarGruposSyncOk } from "@/lib/repositories";
+import type { AsignacionGrupoRow } from "@/lib/sheets";
 import { sincronizarGruposDelAlumno } from "./grupoSync";
 
 /**
- * Envuelve al comando puro `sincronizarGruposDelAlumno` con la lógica de
- * estado que comparten todos los callers: loguear el error, prender o
- * limpiar el flag `gruposSyncFallidoEn` según corresponda, y reportar al
- * caller si quedó en error para que propague el warning al usuario.
+ * Comando que sincroniza los grupos del alumno y persiste el resultado en el
+ * flag `gruposSyncFallidoEn`. Si la sync funciona: limpia el flag. Si falla:
+ * loguea, prende el flag para disparar el retry automático en `/perfil`, y
+ * propaga la excepción para que cada caller decida qué hacer (respuesta
+ * degradada, contador de errores, silencio, etc.).
  *
- * Los handlers HTTP (registro, perfil) y la page `/perfil` al montar usan
- * este wrapper — no `sincronizarGruposDelAlumno` directo — para que el
- * estado persistente quede consistente en cada intento.
+ * La persistencia del flag en el camino de error es best-effort: si esa
+ * escritura también falla, se loguea pero se propaga el error original —
+ * perder el retry automático es un efecto colateral aceptable frente a
+ * enmascarar la causa real.
  *
- * @returns `true` si la sincronización falló (flag prendido), `false` si fue OK.
+ * `asignacionesPrefetched` se propaga al comando puro para que el resync
+ * masivo (admin) pueda leer la hoja una sola vez y reutilizar el resultado.
  */
 export async function intentarSincronizarGrupos(
   githubUsername: string,
-  comision: Comision
-): Promise<boolean> {
+  comision: Comision,
+  asignacionesPrefetched?: AsignacionGrupoRow[]
+): Promise<void> {
   try {
-    await sincronizarGruposDelAlumno(githubUsername, comision);
-    await marcarGruposSyncOk(githubUsername);
-    return false;
+    await sincronizarGruposDelAlumno(githubUsername, comision, asignacionesPrefetched);
   } catch (error) {
     logger.error(
       {
@@ -32,7 +35,20 @@ export async function intentarSincronizarGrupos(
       },
       "Falló sincronización de grupos desde planilla"
     );
-    await marcarGruposSyncFallido(githubUsername);
-    return true;
+    try {
+      await marcarGruposSyncFallido(githubUsername);
+    } catch (flagError) {
+      logger.error(
+        {
+          err: flagError,
+          githubUsername,
+          comisionId: comision.id,
+        },
+        "Falló al persistir el flag gruposSyncFallidoEn (retry automático no disparará)"
+      );
+    }
+    throw error;
   }
+
+  await marcarGruposSyncOk(githubUsername);
 }

--- a/src/lib/services/intentarSincronizarGrupos.ts
+++ b/src/lib/services/intentarSincronizarGrupos.ts
@@ -1,0 +1,38 @@
+import { logger } from "@/lib/logger";
+import type { Comision } from "@/domain/entities";
+import { marcarGruposSyncFallido, marcarGruposSyncOk } from "@/lib/repositories";
+import { sincronizarGruposDelAlumno } from "./grupoSync";
+
+/**
+ * Envuelve al comando puro `sincronizarGruposDelAlumno` con la lógica de
+ * estado que comparten todos los callers: loguear el error, prender o
+ * limpiar el flag `gruposSyncFallidoEn` según corresponda, y reportar al
+ * caller si quedó en error para que propague el warning al usuario.
+ *
+ * Los handlers HTTP (registro, perfil) y la page `/perfil` al montar usan
+ * este wrapper — no `sincronizarGruposDelAlumno` directo — para que el
+ * estado persistente quede consistente en cada intento.
+ *
+ * @returns `true` si la sincronización falló (flag prendido), `false` si fue OK.
+ */
+export async function intentarSincronizarGrupos(
+  githubUsername: string,
+  comision: Comision
+): Promise<boolean> {
+  try {
+    await sincronizarGruposDelAlumno(githubUsername, comision);
+    await marcarGruposSyncOk(githubUsername);
+    return false;
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        githubUsername,
+        comisionId: comision.id,
+      },
+      "Falló sincronización de grupos desde planilla"
+    );
+    await marcarGruposSyncFallido(githubUsername);
+    return true;
+  }
+}


### PR DESCRIPTION
## Contexto

El flujo de sincronización de grupos desde la planilla (`sincronizarGruposDelAlumno`) se comía los errores silenciosamente: si fallaba, se logueaba a Pino y se seguía devolviendo `{ ok: true }`. El alumno no se enteraba, y los docentes tampoco tenían forma de ver ni remediar el problema sin abrir la DB.

Este PR aplica la regla "todo catch que loguea debe decidir explícitamente qué ve el usuario" al caso de `sincronizarGruposDelAlumno`, y resuelve además la consistencia del estado: si no quedó bien, queda el error visible hasta que se arregle.

## Cambios

**Dominio**
- `Alumno.gruposSyncFallidoEn: Date | null` — timestamp que se prende cuando la sync tira y se limpia cuando un reintento funciona. Migración auto-generada por mikro-orm.
- Repo functions: `marcarGruposSyncFallido`, `marcarGruposSyncOk` (idempotente), `getAlumnosConGruposSyncPendiente(comisionId)`.

**Wrapper**
- `intentarSincronizarGrupos(ghUsername, comision): Promise<boolean>` — envuelve el comando puro `sincronizarGruposDelAlumno` (que sigue siendo void/throw) con la lógica de estado: loguea en caso de error, actualiza el flag, y retorna un booleano para que el caller decida si propaga `gruposSync: "error"` al cliente.

**Callers**
- `POST /api/registro` y `PATCH /api/perfil` usan el wrapper y reflejan el resultado en la respuesta.
- `/perfil/page.tsx` reintenta la sync al montar **solo si el flag está prendido** — si funciona, el flag se limpia y el banner global desaparece en el próximo render.

**UI**
- Nuevo `SyncPendingBanner` en el layout global: banner ámbar persistente mientras el flag esté prendido, con link a `/perfil`.
- `AlumnoForm` llama a `router.refresh()` post-submit para que el banner se re-evalúe tras una sincronización exitosa.
- Copy del warning inline unificado: *"Tus datos quedaron guardados, pero no pudimos asignarte al grupo de TP. Guardá de nuevo para reintentar; si persiste, avisale a un docente."*

**Admin**
- Nueva acción `sincronizarGruposDeLaComision` que itera los alumnos con flag prendido y reintenta por cada uno.
- Nuevo botón `SyncGruposButton` + badge "Grupos pendientes · N" en `/admin/comisiones/[id]/edit`, visible solo cuando hay pendientes.

## Fuera de alcance

- Vista admin detallada de alumnos con sync pendiente (listar individualmente, reintentar por alumno) — queda en #21 + TODO en README.
- Reconciliación automática por cron, notificaciones a admin por mail.

## Test plan

- [ ] Correr `npm run db:migration:up` en local para aplicar la migración.
- [ ] Con un alumno válido, forzar un fallo de sync (p. ej. desactivar el Sheets mock o meter una fila mal formada) y verificar:
  - [ ] El body de la respuesta de `/api/registro` (o `/api/perfil`) trae `gruposSync: "error"`.
  - [ ] El form muestra el warning ámbar post-submit con el copy nuevo.
  - [ ] En el siguiente load de cualquier página, aparece el `SyncPendingBanner` arriba.
  - [ ] En `/admin/comisiones/[id]/edit`, aparece el badge "Grupos pendientes · 1" y el botón "Resincronizar grupos".
- [ ] Arreglar el error que causa el fallo y apretar "Resincronizar grupos" desde admin:
  - [ ] El conteo pasa a `N resueltos`.
  - [ ] En el próximo render del alumno, el banner desaparece.
- [ ] Verificar que un alumno feliz (sin flag) al entrar a `/perfil` **no** dispara una consulta a Sheets.

## Notas

- 599 tests en verde (48 nuevos o ajustados).
- Los 3 errores de `tsc` que aparecen son pre-existentes en `master`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admin: nuevo control para reintentar sincronización de grupos por alumno y badge de "Grupos pendientes" en la edición de comisión.
  * Estudiantes: notificación persistente cuando falla la asignación de grupos y enlace directo para reintentar.
  * Sincronización por alumno ahora reporta contadores de éxito/error tras ejecutar la reintento.

* **Bug Fixes**
  * Las APIs de registro/perfil no fallan la operación principal si el hook de sincronización falla; solo devuelven un aviso en la respuesta.

* **Tests**
  * Cobertura ampliada para flujos administrativos, UI estudiantil y lógica de reintentos.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->