### PR TITLE
Release: consistencia DB/planilla y panel admin de grupos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - run: pnpm install --frozen-lockfile

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,24 +22,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int",
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
+          "unique": true,
+          "length": 255,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "integer"
+          "mappedType": "string"
         },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -54,29 +54,61 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "boolean",
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": null,
+          "length": 255,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "boolean"
+          "mappedType": "string"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -84,26 +116,122 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "grupos_sync_fallido_en": {
+          "name": "grupos_sync_fallido_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "alumno_sync_fallido_en": {
+          "name": "alumno_sync_fallido_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
-      "name": "comision",
+      "name": "alumno",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "comision_pkey",
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_github_username_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_legajo_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "alumno_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
+          "constraintName": "alumno_comision_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -244,7 +372,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -276,19 +404,35 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "integer"
+        },
+        "inscripciones_cerradas": {
+          "name": "inscripciones_cerradas",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         }
       },
       "name": "assignment",
@@ -296,254 +440,43 @@
       "indexes": [
         {
           "columnNames": [
-            "tipo"
-          ],
-          "composite": false,
-          "keyName": "assignment_tipo_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "assignment_pkey",
-          "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "tipo"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "assignment_tipo_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
           "constraintName": "assignment_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
           "localTableName": "public.assignment",
+          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "registro_confirmado_en_id": {
-          "name": "registro_confirmado_en_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "grupos_sync_fallido_en": {
-          "name": "grupos_sync_fallido_en",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        }
-      },
-      "name": "alumno",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "keyName": "alumno_legajo_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "keyName": "alumno_github_username_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "alumno_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "constraintName": "alumno_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        },
-        "alumno_registro_confirmado_en_id_foreign": {
-          "constraintName": "alumno_registro_confirmado_en_id_foreign",
-          "columnNames": [
-            "registro_confirmado_en_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -584,47 +517,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_assignment_id_foreign": {
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.assignment_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "assignment_alumnos_alumno_id_foreign": {
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "assignment_alumnos_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
+          "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -644,60 +578,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
+        "anio": {
+          "name": "anio",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "integer"
         },
-        "creado_por": {
-          "name": "creado_por",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -712,9 +610,25 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
+        "activa": {
+          "name": "activa",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -726,40 +640,27 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "json"
         }
       },
-      "name": "grupo",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "comision_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "constraintName": "grupo_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -786,22 +687,6 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -875,25 +760,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "repo_deleted": {
-          "name": "repo_deleted",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "false",
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
-        },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -906,65 +775,234 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "repo_deleted": {
+          "name": "repo_deleted",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "entrega_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "entrega_assignment_id_foreign": {
-          "constraintName": "entrega_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.entrega",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "entrega_alumno_id_foreign": {
-          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "entrega_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "entrega_assignment_id_foreign",
+          "localTableName": "public.entrega",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
-          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
+          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
+        },
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        }
+      },
+      "name": "grupo",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "grupo_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "grupo_assignment_id_foreign",
+          "localTableName": "public.grupo",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -1005,47 +1043,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "grupo_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_grupo_id_foreign": {
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
-          "columnNames": [
-            "grupo_id"
-          ],
-          "localTableName": "public.grupo_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "grupo_alumnos_alumno_id_foreign": {
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "grupo_alumnos_grupo_id_foreign": {
+          "columnNames": [
+            "grupo_id"
+          ],
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
+          "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260424112959_add_consistency_check_fields_to_alumno.ts
+++ b/migrations/Migration20260424112959_add_consistency_check_fields_to_alumno.ts
@@ -1,0 +1,15 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260424112959_add_consistency_check_fields_to_alumno extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "alumno" add column "alumno_sync_fallido_en" timestamptz null;`);
+    this.addSql(`alter table "alumno" add column "ultimo_sync_check_at" timestamptz null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" drop column "ultimo_sync_check_at";`);
+    this.addSql(`alter table "alumno" drop column "alumno_sync_fallido_en";`);
+  }
+
+}

--- a/migrations/Migration20260425113000_add_inscripciones_cerradas_to_assignment.ts
+++ b/migrations/Migration20260425113000_add_inscripciones_cerradas_to_assignment.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260425113000_add_inscripciones_cerradas_to_assignment extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "assignment" add column "inscripciones_cerradas" boolean not null default false;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "assignment" drop column "inscripciones_cerradas";`);
+  }
+
+}

--- a/migrations/Migration20260507120000_drop_ultimo_sync_check_at_from_alumno.ts
+++ b/migrations/Migration20260507120000_drop_ultimo_sync_check_at_from_alumno.ts
@@ -1,0 +1,13 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260507120000_drop_ultimo_sync_check_at_from_alumno extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`alter table "alumno" drop column "ultimo_sync_check_at";`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" add column "ultimo_sync_check_at" timestamptz null;`);
+  }
+
+}

--- a/src/app/admin/alumnos/page.test.tsx
+++ b/src/app/admin/alumnos/page.test.tsx
@@ -25,14 +25,14 @@ import AdminAlumnosPage from "./page";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAlumno(overrides?: Partial<Alumno>): Alumno {
-  const a = new Alumno();
-  a.legajo = "12345";
-  a.nombre = "Juan";
-  a.apellido = "Garcia";
-  a.githubUsername = "juangarcia";
-  a.email = "juan@example.com";
-  a.comision = "miércoles noche";
-  return Object.assign(a, overrides);
+  const alumno = new Alumno();
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "Garcia";
+  alumno.githubUsername = "juangarcia";
+  alumno.email = "juan@example.com";
+  alumno.comision = "miércoles noche";
+  return Object.assign(alumno, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/admin/alumnos/page.tsx
+++ b/src/app/admin/alumnos/page.tsx
@@ -55,7 +55,7 @@ export default async function AdminAlumnosPage() {
             {alumnos.map((alumno) => (
               <DataRow key={alumno.legajo}>
                 <DataCell label="Nombre" heading>
-                  {alumno.apellido}, {alumno.nombre}
+                  {alumno.nombreCompleto}
                 </DataCell>
                 <DataCell label="Legajo">
                   <span className="font-mono text-xs">{alumno.legajo}</span>

--- a/src/app/admin/alumnos/page.tsx
+++ b/src/app/admin/alumnos/page.tsx
@@ -52,27 +52,27 @@ export default async function AdminAlumnosPage() {
             <DataHeaderCell>Email</DataHeaderCell>
           </DataHeader>
           <DataBody>
-            {alumnos.map((a) => (
-              <DataRow key={a.legajo}>
+            {alumnos.map((alumno) => (
+              <DataRow key={alumno.legajo}>
                 <DataCell label="Nombre" heading>
-                  {a.apellido}, {a.nombre}
+                  {alumno.apellido}, {alumno.nombre}
                 </DataCell>
                 <DataCell label="Legajo">
-                  <span className="font-mono text-xs">{a.legajo}</span>
+                  <span className="font-mono text-xs">{alumno.legajo}</span>
                 </DataCell>
                 <DataCell label="GitHub">
                   <a
-                    href={`https://github.com/${a.githubUsername}`}
+                    href={`https://github.com/${alumno.githubUsername}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="font-mono text-xs text-pdep-600 hover:underline break-all"
                   >
-                    {a.githubUsername}
+                    {alumno.githubUsername}
                   </a>
                 </DataCell>
                 <DataCell label="Email">
                   <span className="text-gray-500 text-xs break-all">
-                    {a.email}
+                    {alumno.email}
                   </span>
                 </DataCell>
               </DataRow>

--- a/src/app/admin/assignments/[id]/edit/page.test.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
+import { IndividualAssignment } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -60,7 +61,7 @@ import EditAssignmentPage from "./page";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: object) {
-  return {
+  return Object.assign(new IndividualAssignment(), {
     id: "a1",
     titulo: "Kata Funcional",
     descripcion: "Primera kata",
@@ -71,7 +72,7 @@ function makeAssignment(overrides?: object) {
     createdAt: new Date("2026-01-01"),
     slug: "kata-funcional",
     ...overrides,
-  };
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/admin/assignments/[id]/edit/page.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.tsx
@@ -4,8 +4,6 @@ import { listarTemplates } from "@/lib/github";
 import { redirect } from "next/navigation";
 import { AssignmentForm } from "../../assignment-form";
 import { actualizarAssignment } from "../../actions";
-import { GrupalAssignment } from "@/domain/entities";
-
 export default async function EditAssignmentPage({
   params,
 }: {
@@ -33,9 +31,7 @@ export default async function EditAssignmentPage({
           tipo: assignment.tipo,
           paradigma: assignment.paradigma,
           deadline: assignment.deadline?.toISOString().slice(0, 10),
-          ...(assignment instanceof GrupalAssignment && {
-            maxIntegrantes: assignment.maxIntegrantes,
-          }),
+          ...assignment.extraFormDefaults(),
         }}
         submitLabel="Guardar cambios"
       />

--- a/src/app/admin/assignments/[id]/entregas-table.test.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.test.tsx
@@ -12,6 +12,7 @@ function makeRow(overrides?: Partial<EntregaRow>): EntregaRow {
     repoName: "kata-funcional-usuario1",
     repoUrl: "https://github.com/org/kata-funcional-usuario1",
     repoDeleted: false,
+    estadoRepo: "activo",
     createdAt: "2/1/2026",
     nombreCompleto: "García, Juan",
     ...overrides,
@@ -130,11 +131,18 @@ describe("EntregasTable", () => {
     expect(html).toContain('target="_blank"');
   });
 
-  it('muestra "Sin repo" cuando no hay repoUrl', () => {
+  it('muestra "Sin repo" cuando estadoRepo es "sin-repo"', () => {
     const html = renderToStaticMarkup(
-      <EntregasTable entregas={[makeRow({ repoUrl: undefined })]} />
+      <EntregasTable entregas={[makeRow({ estadoRepo: "sin-repo", repoUrl: undefined })]} />
     );
     expect(html).toContain("Sin repo");
+  });
+
+  it('muestra "Repositorio borrado" cuando estadoRepo es "borrado"', () => {
+    const html = renderToStaticMarkup(
+      <EntregasTable entregas={[makeRow({ estadoRepo: "borrado" })]} />
+    );
+    expect(html).toContain("Repositorio borrado");
   });
 
   it("muestra la fecha de la entrega", () => {

--- a/src/app/admin/assignments/[id]/entregas-table.tsx
+++ b/src/app/admin/assignments/[id]/entregas-table.tsx
@@ -9,6 +9,7 @@ import {
   DataRow,
   DataCell,
 } from "@/app/components/DataTable";
+import { matcheaEntregaQuery } from "@/lib/entrega-query";
 
 export type EntregaRow = {
   id: string;
@@ -16,18 +17,13 @@ export type EntregaRow = {
   repoName?: string;
   repoUrl?: string;
   repoDeleted: boolean;
+  estadoRepo: "borrado" | "activo" | "sin-repo";
   createdAt: string;
   nombreCompleto: string;
 };
 
 export function filterEntregas(entregas: EntregaRow[], rawQuery: string): EntregaRow[] {
-  const query = rawQuery.toLowerCase().trim();
-  if (!query) return entregas;
-  return entregas.filter(
-    (entrega) =>
-      entrega.githubUsernames.some((username) => username.toLowerCase().includes(query)) ||
-      (entrega.repoName ?? "").toLowerCase().includes(query)
-  );
+  return entregas.filter((entrega) => matcheaEntregaQuery(entrega, rawQuery));
 }
 
 export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
@@ -76,11 +72,10 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
                   </span>
                 </DataCell>
                 <DataCell label="Repositorio">
-                  {entrega.repoDeleted ? (
-                    <span className="text-red-400 text-xs">
-                      Repositorio borrado
-                    </span>
-                  ) : entrega.repoUrl ? (
+                  {entrega.estadoRepo === "borrado" && (
+                    <span className="text-red-400 text-xs">Repositorio borrado</span>
+                  )}
+                  {entrega.estadoRepo === "activo" && (
                     <a
                       href={entrega.repoUrl}
                       target="_blank"
@@ -102,7 +97,8 @@ export function EntregasTable({ entregas }: { entregas: EntregaRow[] }) {
                       </svg>
                       Ir al repo
                     </a>
-                  ) : (
+                  )}
+                  {entrega.estadoRepo === "sin-repo" && (
                     <span className="text-gray-400 text-xs">Sin repo</span>
                   )}
                 </DataCell>

--- a/src/app/admin/assignments/[id]/grupos-panel.test.tsx
+++ b/src/app/admin/assignments/[id]/grupos-panel.test.tsx
@@ -20,6 +20,7 @@ function makeGrupo(overrides: Partial<GrupoAdminResumen> = {}): GrupoAdminResume
     nombre: "Los Lambdas",
     maxIntegrantes: 3,
     estaLleno: false,
+    etiquetaCupo: "2/3 integrantes",
     miembros: [
       { username: "ana", nombreCompleto: "García, Ana" },
       { username: "bob", nombreCompleto: "Smith, Bob" },
@@ -213,11 +214,11 @@ describe("GruposPanel", () => {
         <GruposPanel
           assignmentId="a1"
           inscripcionesCerradas={false}
-          grupos={[makeGrupo({ estaLleno: true, maxIntegrantes: 2 })]}
+          grupos={[makeGrupo({ estaLleno: true, maxIntegrantes: 2, etiquetaCupo: "Completo (2/2)" })]}
           alumnosSinGrupo={[]}
         />
       );
-      expect(screen.getByText(/Completo/)).toBeInTheDocument();
+      expect(screen.getByText("Completo (2/2)")).toBeInTheDocument();
     });
   });
 

--- a/src/app/admin/assignments/[id]/grupos-panel.test.tsx
+++ b/src/app/admin/assignments/[id]/grupos-panel.test.tsx
@@ -1,0 +1,274 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GruposPanel } from "./grupos-panel";
+import type { GrupoAdminResumen, AlumnoSinGrupoResumen } from "./grupos-panel";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRouterRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeGrupo(overrides: Partial<GrupoAdminResumen> = {}): GrupoAdminResumen {
+  return {
+    id: "g1",
+    nombre: "Los Lambdas",
+    maxIntegrantes: 3,
+    estaLleno: false,
+    miembros: [
+      { username: "ana", nombreCompleto: "García, Ana" },
+      { username: "bob", nombreCompleto: "Smith, Bob" },
+    ],
+    ...overrides,
+  };
+}
+
+function makeAlumnoSinGrupo(overrides: Partial<AlumnoSinGrupoResumen> = {}): AlumnoSinGrupoResumen {
+  return { username: "carlos", nombreCompleto: "López, Carlos", ...overrides };
+}
+
+function mockFetch(ok: boolean, data: object = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok, json: async () => data })
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("GruposPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouterRefresh.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("toggle inscripciones", () => {
+    it('muestra "Cerrar inscripciones" cuando están abiertas', () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByTestId("toggle-inscripciones")).toHaveTextContent(
+        "Cerrar inscripciones"
+      );
+    });
+
+    it('muestra "Abrir inscripciones" cuando están cerradas', () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={true}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByTestId("toggle-inscripciones")).toHaveTextContent(
+        "Abrir inscripciones"
+      );
+    });
+
+    it("llama al endpoint correcto con cerrada=true al cerrar", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+
+      await user.click(screen.getByTestId("toggle-inscripciones"));
+
+      expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/inscripciones", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cerrada: true }),
+      });
+    });
+
+    it("llama al endpoint correcto con cerrada=false al abrir", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={true}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+
+      await user.click(screen.getByTestId("toggle-inscripciones"));
+
+      expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/inscripciones", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cerrada: false }),
+      });
+    });
+
+    it("llama a router.refresh() después del toggle exitoso", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+
+      await user.click(screen.getByTestId("toggle-inscripciones"));
+
+      await waitFor(() => expect(mockRouterRefresh).toHaveBeenCalled());
+    });
+
+    it("muestra error si el toggle falla", async () => {
+      const user = userEvent.setup();
+      mockFetch(false, { error: "Sin permisos" });
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+
+      await user.click(screen.getByTestId("toggle-inscripciones"));
+
+      expect(await screen.findByText("Sin permisos")).toBeInTheDocument();
+    });
+  });
+
+  describe("lista de grupos", () => {
+    it("muestra el nombre de cada grupo", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[makeGrupo({ nombre: "Los Lambdas" }), makeGrupo({ id: "g2", nombre: "Los Monads" })]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByText("Los Lambdas")).toBeInTheDocument();
+      expect(screen.getByText("Los Monads")).toBeInTheDocument();
+    });
+
+    it("muestra el nombre completo y username de cada miembro", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[makeGrupo()]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByText("García, Ana")).toBeInTheDocument();
+      expect(screen.getByText("@ana")).toBeInTheDocument();
+    });
+
+    it("muestra mensaje cuando no hay grupos", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByText(/no hay grupos/i)).toBeInTheDocument();
+    });
+
+    it("muestra el contador de grupos en el encabezado", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[makeGrupo(), makeGrupo({ id: "g2" })]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByText(/Grupos \(2\)/)).toBeInTheDocument();
+    });
+
+    it('muestra badge "Completo" para grupos llenos', () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[makeGrupo({ estaLleno: true, maxIntegrantes: 2 })]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.getByText(/Completo/)).toBeInTheDocument();
+    });
+  });
+
+  describe("alumnos sin grupo", () => {
+    it("muestra la sección cuando hay alumnos sin grupo", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[makeAlumnoSinGrupo()]}
+        />
+      );
+      expect(screen.getByTestId("alumnos-sin-grupo")).toBeInTheDocument();
+    });
+
+    it("no muestra la sección cuando todos tienen grupo", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[]}
+        />
+      );
+      expect(screen.queryByTestId("alumnos-sin-grupo")).not.toBeInTheDocument();
+    });
+
+    it("muestra el nombre completo y username del alumno sin grupo", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[{ username: "pedro", nombreCompleto: "Pérez, Pedro" }]}
+        />
+      );
+      expect(screen.getByText("Pérez, Pedro")).toBeInTheDocument();
+      expect(screen.getByText("@pedro")).toBeInTheDocument();
+    });
+
+    it("muestra el contador de alumnos sin grupo", () => {
+      render(
+        <GruposPanel
+          assignmentId="a1"
+          inscripcionesCerradas={false}
+          grupos={[]}
+          alumnosSinGrupo={[makeAlumnoSinGrupo(), makeAlumnoSinGrupo({ username: "diana" })]}
+        />
+      );
+      expect(screen.getByText(/Sin grupo \(2\)/)).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/admin/assignments/[id]/grupos-panel.tsx
+++ b/src/app/admin/assignments/[id]/grupos-panel.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useApiCall } from "@/app/hooks/useApiCall";
+
+export type GrupoAdminResumen = {
+  id: string;
+  nombre: string;
+  maxIntegrantes: number;
+  estaLleno: boolean;
+  miembros: { username: string; nombreCompleto: string }[];
+};
+
+export type AlumnoSinGrupoResumen = {
+  username: string;
+  nombreCompleto: string;
+};
+
+export function GruposPanel({
+  assignmentId,
+  inscripcionesCerradas: initialCerradas,
+  grupos,
+  alumnosSinGrupo,
+}: {
+  assignmentId: string;
+  inscripcionesCerradas: boolean;
+  grupos: GrupoAdminResumen[];
+  alumnosSinGrupo: AlumnoSinGrupoResumen[];
+}) {
+  const router = useRouter();
+  const { loading, error, call } = useApiCall();
+  const [cerradas, setCerradas] = useState(initialCerradas);
+
+  async function handleToggle() {
+    await call(async () => {
+      const res = await fetch(`/api/assignments/${assignmentId}/inscripciones`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ cerrada: !cerradas }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Error al cambiar el estado");
+      }
+      setCerradas((current) => !current);
+      router.refresh();
+    });
+  }
+
+  return (
+    <div className="space-y-6 mt-6">
+      <div className="bg-white border border-gray-200 rounded-lg p-6">
+        <div className="flex items-center justify-between gap-4">
+          <div>
+            <h2 className="text-base font-semibold">Inscripciones a grupos</h2>
+            <p className="text-sm text-gray-500 mt-1">
+              {cerradas
+                ? "Cerradas — los alumnos no pueden crear ni unirse a grupos."
+                : "Abiertas — los alumnos pueden crear y unirse a grupos."}
+            </p>
+          </div>
+          <button
+            onClick={handleToggle}
+            disabled={loading}
+            data-testid="toggle-inscripciones"
+            className={`text-sm px-4 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${
+              cerradas
+                ? "bg-green-600 text-white hover:bg-green-700"
+                : "bg-amber-600 text-white hover:bg-amber-700"
+            }`}
+          >
+            {cerradas ? "Abrir inscripciones" : "Cerrar inscripciones"}
+          </button>
+        </div>
+        {error && (
+          <p className="text-sm text-red-600 mt-3">{error}</p>
+        )}
+      </div>
+
+      <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
+        <div className="px-4 py-3 border-b border-gray-200">
+          <h2 className="text-base font-semibold">Grupos ({grupos.length})</h2>
+        </div>
+        {grupos.length === 0 ? (
+          <p className="text-sm text-gray-500 p-4">
+            Todavía no hay grupos para este TP.
+          </p>
+        ) : (
+          <ul className="divide-y divide-gray-100" data-testid="grupos-list">
+            {grupos.map((grupo) => (
+              <li key={grupo.id} className="p-4">
+                <div className="flex items-center justify-between mb-2">
+                  <span className="font-medium text-sm">{grupo.nombre}</span>
+                  <span
+                    className={`text-xs px-2 py-0.5 rounded-full ${
+                      grupo.estaLleno
+                        ? "bg-red-100 text-red-700"
+                        : "bg-green-100 text-green-700"
+                    }`}
+                  >
+                    {grupo.estaLleno
+                      ? `Completo (${grupo.maxIntegrantes}/${grupo.maxIntegrantes})`
+                      : `${grupo.miembros.length}/${grupo.maxIntegrantes}`}
+                  </span>
+                </div>
+                <ul className="space-y-0.5">
+                  {grupo.miembros.map((miembro) => (
+                    <li key={miembro.username} className="text-xs text-gray-600">
+                      {miembro.nombreCompleto}{" "}
+                      <span className="text-gray-400">@{miembro.username}</span>
+                    </li>
+                  ))}
+                </ul>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      {alumnosSinGrupo.length > 0 && (
+        <div
+          className="bg-amber-50 border border-amber-200 rounded-lg p-4"
+          data-testid="alumnos-sin-grupo"
+        >
+          <h2 className="text-sm font-semibold text-amber-800 mb-2">
+            Sin grupo ({alumnosSinGrupo.length})
+          </h2>
+          <ul className="space-y-0.5">
+            {alumnosSinGrupo.map((alumno) => (
+              <li key={alumno.username} className="text-xs text-amber-700">
+                {alumno.nombreCompleto}{" "}
+                <span className="text-amber-500">@{alumno.username}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/assignments/[id]/grupos-panel.tsx
+++ b/src/app/admin/assignments/[id]/grupos-panel.tsx
@@ -34,13 +34,13 @@ export function GruposPanel({
 
   async function handleToggle() {
     await call(async () => {
-      const res = await fetch(`/api/assignments/${assignmentId}/inscripciones`, {
+      const response = await fetch(`/api/assignments/${assignmentId}/inscripciones`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ cerrada: !cerradas }),
       });
-      if (!res.ok) {
-        const data = await res.json();
+      if (!response.ok) {
+        const data = await response.json();
         throw new Error(data.error ?? "Error al cambiar el estado");
       }
       setCerradas((current) => !current);

--- a/src/app/admin/assignments/[id]/grupos-panel.tsx
+++ b/src/app/admin/assignments/[id]/grupos-panel.tsx
@@ -9,6 +9,7 @@ export type GrupoAdminResumen = {
   nombre: string;
   maxIntegrantes: number;
   estaLleno: boolean;
+  etiquetaCupo: string;
   miembros: { username: string; nombreCompleto: string }[];
 };
 
@@ -99,9 +100,7 @@ export function GruposPanel({
                         : "bg-green-100 text-green-700"
                     }`}
                   >
-                    {grupo.estaLleno
-                      ? `Completo (${grupo.maxIntegrantes}/${grupo.maxIntegrantes})`
-                      : `${grupo.miembros.length}/${grupo.maxIntegrantes}`}
+                    {grupo.etiquetaCupo}
                   </span>
                 </div>
                 <ul className="space-y-0.5">

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -145,7 +145,18 @@ function makeGrupo(overrides?: Partial<Grupo>): Grupo {
   grupo.paradigma = "objetos";
   grupo.maxIntegrantes = 3;
   grupo.creadoPor = "usuario1";
-  return Object.assign(grupo, overrides);
+  const miembros: string[] = [];
+  const fakeMethods = {
+    isOpen: () => true,
+    estaLleno: () => false,
+    etiquetaCupo: () => `${miembros.length}/${grupo.maxIntegrantes} integrantes`,
+    usernamesDeMiembros: () => miembros,
+    usernamesCanonicos: () => miembros.map((username) => username.toLowerCase()),
+    alumnos: {
+      getItems: () => [] as ReturnType<typeof makeAlumno>[],
+    },
+  };
+  return Object.assign(grupo, fakeMethods, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────
@@ -392,6 +403,7 @@ describe("Admin Assignment Detail Page", () => {
         makeAlumno({ id: "al2", githubUsername: "usuario2" }),
         makeAlumno({ id: "al3", githubUsername: "usuario3" }),
       ]);
+      const miembros = ["usuario1"];
       const grupoConMiembro = {
         id: "g1",
         nombre: "Grupo 1",
@@ -399,8 +411,12 @@ describe("Admin Assignment Detail Page", () => {
         maxIntegrantes: 3,
         creadoPor: "usuario1",
         isOpen: () => true,
+        estaLleno: () => false,
+        etiquetaCupo: () => `${miembros.length}/3 integrantes`,
+        usernamesDeMiembros: () => miembros,
+        usernamesCanonicos: () => miembros.map((username) => username.toLowerCase()),
         alumnos: {
-          getItems: () => [makeAlumno({ id: "al1", githubUsername: "usuario1" })],
+          getItems: () => miembros.map((username) => makeAlumno({ githubUsername: username })),
         },
       };
       mockGetGruposDeAssignment.mockResolvedValue([grupoConMiembro]);

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -60,6 +60,28 @@ vi.mock("../delete-repos-button", () => ({
   ),
 }));
 
+vi.mock("./grupos-panel", () => ({
+  GruposPanel: ({
+    assignmentId,
+    inscripcionesCerradas,
+    grupos,
+    alumnosSinGrupo,
+  }: {
+    assignmentId: string;
+    inscripcionesCerradas: boolean;
+    grupos: { id: string }[];
+    alumnosSinGrupo: { username: string }[];
+  }) => (
+    <div
+      data-testid="grupos-panel"
+      data-assignment={assignmentId}
+      data-cerradas={String(inscripcionesCerradas)}
+      data-grupos={grupos.length}
+      data-sin-grupo={alumnosSinGrupo.length}
+    />
+  ),
+}));
+
 import AssignmentDetailPage from "./page";
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -318,11 +340,79 @@ describe("Admin Assignment Detail Page", () => {
       mockGetAlumnos.mockResolvedValue([
         makeAlumno({ githubUsername: "usuario1", apellido: "García", nombre: "Juan" }),
       ]);
-      // No podemos inspeccionar los props del mock directamente, pero podemos
-      // verificar que el page no falla al construir el nombre completo
       await expect(
         AssignmentDetailPage({ params: { id: "a1" } })
       ).resolves.toBeDefined();
+    });
+  });
+
+  describe("panel de grupos (assignments grupales)", () => {
+    it("no muestra GruposPanel para assignments individuales", async () => {
+      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      const element = await AssignmentDetailPage({ params: { id: "a1" } });
+      expect(renderToStaticMarkup(element)).not.toContain("grupos-panel");
+    });
+
+    it("muestra GruposPanel para assignments grupales", async () => {
+      mockGetAssignment.mockResolvedValue(makeGrupalAssignment({ id: "a2" }));
+      const element = await AssignmentDetailPage({ params: { id: "a2" } });
+      expect(renderToStaticMarkup(element)).toContain('data-testid="grupos-panel"');
+    });
+
+    it("pasa inscripcionesCerradas=true cuando el assignment las tiene cerradas", async () => {
+      mockGetAssignment.mockResolvedValue(
+        makeGrupalAssignment({ id: "a2", inscripcionesCerradas: true })
+      );
+      const element = await AssignmentDetailPage({ params: { id: "a2" } });
+      expect(renderToStaticMarkup(element)).toContain('data-cerradas="true"');
+    });
+
+    it("pasa inscripcionesCerradas=false cuando están abiertas", async () => {
+      mockGetAssignment.mockResolvedValue(
+        makeGrupalAssignment({ id: "a2", inscripcionesCerradas: false })
+      );
+      const element = await AssignmentDetailPage({ params: { id: "a2" } });
+      expect(renderToStaticMarkup(element)).toContain('data-cerradas="false"');
+    });
+
+    it("pasa los grupos al panel", async () => {
+      mockGetAssignment.mockResolvedValue(makeGrupalAssignment({ id: "a2" }));
+      mockGetGruposDeAssignment.mockResolvedValue([
+        makeGrupo({ id: "g1" }),
+        makeGrupo({ id: "g2" }),
+      ]);
+      const element = await AssignmentDetailPage({ params: { id: "a2" } });
+      expect(renderToStaticMarkup(element)).toContain('data-grupos="2"');
+    });
+
+    it("calcula correctamente los alumnos sin grupo", async () => {
+      mockGetAssignment.mockResolvedValue(makeGrupalAssignment({ id: "a2" }));
+      mockGetAlumnos.mockResolvedValue([
+        makeAlumno({ id: "al1", githubUsername: "usuario1" }),
+        makeAlumno({ id: "al2", githubUsername: "usuario2" }),
+        makeAlumno({ id: "al3", githubUsername: "usuario3" }),
+      ]);
+      const grupoConMiembro = {
+        id: "g1",
+        nombre: "Grupo 1",
+        paradigma: "objetos",
+        maxIntegrantes: 3,
+        creadoPor: "usuario1",
+        isOpen: () => true,
+        alumnos: {
+          getItems: () => [makeAlumno({ id: "al1", githubUsername: "usuario1" })],
+        },
+      };
+      mockGetGruposDeAssignment.mockResolvedValue([grupoConMiembro]);
+
+      const element = await AssignmentDetailPage({ params: { id: "a2" } });
+      expect(renderToStaticMarkup(element)).toContain('data-sin-grupo="2"');
+    });
+
+    it("no llama a getGruposDeAssignment para assignments individuales", async () => {
+      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      await AssignmentDetailPage({ params: { id: "a1" } });
+      expect(mockGetGruposDeAssignment).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -89,63 +89,63 @@ import AssignmentDetailPage from "./page";
 function makeIndividualAssignment(
   overrides?: Partial<IndividualAssignment>
 ): IndividualAssignment {
-  const a = new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.descripcion = "Descripción de la kata";
-  a.templateRepo = "kata-template";
-  a.tipo = "individual";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date("2026-01-01");
-  return Object.assign(a, overrides);
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "Descripción de la kata";
+  assignment.templateRepo = "kata-template";
+  assignment.tipo = "individual";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
 }
 
 function makeGrupalAssignment(
   overrides?: Partial<GrupalAssignment>
 ): GrupalAssignment {
-  const a = new GrupalAssignment();
-  a.id = "a2";
-  a.titulo = "TP Objetos";
-  a.descripcion = "Trabajo práctico grupal";
-  a.templateRepo = "tp-objetos-template";
-  a.tipo = "grupal";
-  a.paradigma = "objetos";
-  a.slug = "tp-objetos";
-  a.createdAt = new Date("2026-01-01");
-  a.maxIntegrantes = 3;
-  return Object.assign(a, overrides);
+  const assignment = new GrupalAssignment();
+  assignment.id = "a2";
+  assignment.titulo = "TP Objetos";
+  assignment.descripcion = "Trabajo práctico grupal";
+  assignment.templateRepo = "tp-objetos-template";
+  assignment.tipo = "grupal";
+  assignment.paradigma = "objetos";
+  assignment.slug = "tp-objetos";
+  assignment.createdAt = new Date("2026-01-01");
+  assignment.maxIntegrantes = 3;
+  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
-  const e = new Entrega();
-  e.id = "e1";
-  e.githubUsernames = ["usuario1"];
-  e.repoName = "kata-funcional-usuario1";
-  e.repoUrl = "https://github.com/org/kata-funcional-usuario1";
-  e.createdAt = new Date("2026-01-02");
-  return Object.assign(e, overrides);
+  const entrega = new Entrega();
+  entrega.id = "e1";
+  entrega.githubUsernames = ["usuario1"];
+  entrega.repoName = "kata-funcional-usuario1";
+  entrega.repoUrl = "https://github.com/org/kata-funcional-usuario1";
+  entrega.createdAt = new Date("2026-01-02");
+  return Object.assign(entrega, overrides);
 }
 
 function makeAlumno(overrides?: Partial<Alumno>): Alumno {
-  const a = new Alumno();
-  a.id = "al1";
-  a.legajo = "12345";
-  a.nombre = "Juan";
-  a.apellido = "García";
-  a.githubUsername = "usuario1";
-  a.email = "juan@test.com";
-  return Object.assign(a, overrides);
+  const alumno = new Alumno();
+  alumno.id = "al1";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "García";
+  alumno.githubUsername = "usuario1";
+  alumno.email = "juan@test.com";
+  return Object.assign(alumno, overrides);
 }
 
 function makeGrupo(overrides?: Partial<Grupo>): Grupo {
-  const g = new Grupo();
-  g.id = "g1";
-  g.nombre = "Grupo 1";
-  g.paradigma = "objetos";
-  g.maxIntegrantes = 3;
-  g.creadoPor = "usuario1";
-  return Object.assign(g, overrides);
+  const grupo = new Grupo();
+  grupo.id = "g1";
+  grupo.nombre = "Grupo 1";
+  grupo.paradigma = "objetos";
+  grupo.maxIntegrantes = 3;
+  grupo.creadoPor = "usuario1";
+  return Object.assign(grupo, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -9,7 +9,10 @@ import { redirect } from "next/navigation";
 import Link from "next/link";
 import { EntregasTable } from "./entregas-table";
 import { DeleteReposButton } from "../delete-repos-button";
-import type { Alumno } from "@/domain/entities";
+import { GruposPanel } from "./grupos-panel";
+import type { GrupoAdminResumen, AlumnoSinGrupoResumen } from "./grupos-panel";
+import { GrupalAssignment } from "@/domain/entities";
+import type { Alumno, Grupo } from "@/domain/entities";
 
 export default async function AssignmentDetailPage({
   params,
@@ -21,16 +24,18 @@ export default async function AssignmentDetailPage({
   const assignment = await getAssignment(params.id);
   if (!assignment) redirect("/admin/assignments");
 
-  // `getAlumnos` se dispara una sola vez: Individual reutiliza la misma
-  // promise vía el thunk para calcular su total, y el map de nombres también
-  // consume el resultado. Grupal ignora el thunk y pide los grupos.
+  const gruposPromise: Promise<Grupo[]> = assignment instanceof GrupalAssignment
+    ? getGruposDeAssignment(params.id)
+    : Promise.resolve([]);
+
   const alumnosPromise = getAlumnos();
-  const [entregas, alumnos, total] = await Promise.all([
+  const [entregas, alumnos, grupos, total] = await Promise.all([
     getEntregas(params.id),
     alumnosPromise,
+    gruposPromise,
     assignment.totalEsperado({
       getAlumnosDelCurso: () => alumnosPromise,
-      getGruposDeAssignment,
+      getGruposDeAssignment: (_assignmentId: string) => gruposPromise,
     }),
   ]);
 
@@ -40,6 +45,44 @@ export default async function AssignmentDetailPage({
   const alumnosPorUsername = new Map<string, Alumno>(
     alumnos.map((alumno) => [alumno.githubUsername.toLowerCase(), alumno])
   );
+
+  let gruposPanel: React.ReactNode = null;
+  if (assignment instanceof GrupalAssignment) {
+    const alumnosConGrupoSet = new Set(
+      grupos.flatMap((grupo) =>
+        grupo.alumnos.getItems().map((alumno) => alumno.githubUsername.toLowerCase())
+      )
+    );
+
+    const gruposSerializados: GrupoAdminResumen[] = grupos.map((grupo) => ({
+      id: grupo.id,
+      nombre: grupo.nombre,
+      maxIntegrantes: grupo.maxIntegrantes,
+      estaLleno: !grupo.isOpen(),
+      miembros: grupo.alumnos.getItems().map((alumno) => ({
+        username: alumno.githubUsername,
+        nombreCompleto:
+          alumnosPorUsername.get(alumno.githubUsername.toLowerCase())
+            ?.nombreCompleto ?? alumno.githubUsername,
+      })),
+    }));
+
+    const alumnosSinGrupoSerializados: AlumnoSinGrupoResumen[] = alumnos
+      .filter((alumno) => !alumnosConGrupoSet.has(alumno.githubUsername.toLowerCase()))
+      .map((alumno) => ({
+        username: alumno.githubUsername,
+        nombreCompleto: alumno.nombreCompleto,
+      }));
+
+    gruposPanel = (
+      <GruposPanel
+        assignmentId={params.id}
+        inscripcionesCerradas={assignment.inscripcionesCerradas}
+        grupos={gruposSerializados}
+        alumnosSinGrupo={alumnosSinGrupoSerializados}
+      />
+    );
+  }
 
   const entregaRows = entregas.map((entrega) => ({
     id: entrega.id,
@@ -129,6 +172,8 @@ export default async function AssignmentDetailPage({
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <EntregasTable entregas={entregaRows} />
       </div>
+
+      {gruposPanel}
     </div>
   );
 }

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -11,8 +11,8 @@ import { EntregasTable } from "./entregas-table";
 import { DeleteReposButton } from "../delete-repos-button";
 import { GruposPanel } from "./grupos-panel";
 import type { GrupoAdminResumen, AlumnoSinGrupoResumen } from "./grupos-panel";
-import { GrupalAssignment } from "@/domain/entities";
-import type { Alumno, Grupo } from "@/domain/entities";
+import { GrupalAssignment, Alumno } from "@/domain/entities";
+import type { Grupo } from "@/domain/entities";
 
 export default async function AssignmentDetailPage({
   params,
@@ -24,9 +24,7 @@ export default async function AssignmentDetailPage({
   const assignment = await getAssignment(params.id);
   if (!assignment) redirect("/admin/assignments");
 
-  const gruposPromise: Promise<Grupo[]> = assignment instanceof GrupalAssignment
-    ? getGruposDeAssignment(params.id)
-    : Promise.resolve([]);
+  const gruposPromise = assignment.cargarGruposCon(getGruposDeAssignment);
 
   const alumnosPromise = getAlumnos();
   const [entregas, alumnos, grupos, total] = await Promise.all([
@@ -43,32 +41,26 @@ export default async function AssignmentDetailPage({
   const pendientes = Math.max(0, total - aceptadas);
 
   const alumnosPorUsername = new Map<string, Alumno>(
-    alumnos.map((alumno) => [alumno.githubUsername.toLowerCase(), alumno])
+    alumnos.map((alumno) => [alumno.usernameCanonico, alumno])
   );
 
   let gruposPanel: React.ReactNode = null;
   if (assignment instanceof GrupalAssignment) {
-    const alumnosConGrupoSet = new Set(
-      grupos.flatMap((grupo) =>
-        grupo.alumnos.getItems().map((alumno) => alumno.githubUsername.toLowerCase())
-      )
-    );
-
     const gruposSerializados: GrupoAdminResumen[] = grupos.map((grupo) => ({
       id: grupo.id,
       nombre: grupo.nombre,
       maxIntegrantes: grupo.maxIntegrantes,
-      estaLleno: !grupo.isOpen(),
-      miembros: grupo.alumnos.getItems().map((alumno) => ({
-        username: alumno.githubUsername,
+      estaLleno: grupo.estaLleno(),
+      etiquetaCupo: grupo.etiquetaCupo(),
+      miembros: grupo.usernamesDeMiembros().map((username) => ({
+        username,
         nombreCompleto:
-          alumnosPorUsername.get(alumno.githubUsername.toLowerCase())
-            ?.nombreCompleto ?? alumno.githubUsername,
+          alumnosPorUsername.get(Alumno.normalizarUsername(username))?.nombreCompleto ?? username,
       })),
     }));
 
-    const alumnosSinGrupoSerializados: AlumnoSinGrupoResumen[] = alumnos
-      .filter((alumno) => !alumnosConGrupoSet.has(alumno.githubUsername.toLowerCase()))
+    const alumnosSinGrupoSerializados: AlumnoSinGrupoResumen[] = assignment
+      .alumnosSinGrupo(alumnos, grupos)
       .map((alumno) => ({
         username: alumno.githubUsername,
         nombreCompleto: alumno.nombreCompleto,
@@ -90,11 +82,12 @@ export default async function AssignmentDetailPage({
     repoName: entrega.repoName,
     repoUrl: entrega.repoUrl,
     repoDeleted: entrega.repoDeleted,
+    estadoRepo: entrega.estadoRepo(),
     createdAt: new Date(entrega.createdAt).toLocaleDateString("es-AR"),
     nombreCompleto: entrega.githubUsernames
       .map((username) => {
-        const alumno = alumnosPorUsername.get(username.toLowerCase());
-        return alumno ? `${alumno.apellido}, ${alumno.nombre}` : "—";
+        const alumno = alumnosPorUsername.get(Alumno.normalizarUsername(username));
+        return alumno ? alumno.nombreCompleto : "—";
       })
       .join(" / "),
   }));
@@ -115,7 +108,7 @@ export default async function AssignmentDetailPage({
         <div className="flex items-center gap-3">
           <DeleteReposButton
             assignmentId={assignment.id}
-            activeRepoCount={entregas.filter((entrega) => entrega.repoName && !entrega.repoDeleted).length}
+            activeRepoCount={entregas.filter((entrega) => entrega.hasRepo()).length}
           />
           <Link
             href={`/admin/assignments/${assignment.id}/edit`}

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -46,9 +46,9 @@ function TemplateRepoCombobox({
   const [open, setOpen] = useState(false);
 
   const filtered = query
-    ? templates.filter((t) =>
-        t.name.toLowerCase().includes(query.toLowerCase()) ||
-        t.description.toLowerCase().includes(query.toLowerCase())
+    ? templates.filter((template) =>
+        template.name.toLowerCase().includes(query.toLowerCase()) ||
+        template.description.toLowerCase().includes(query.toLowerCase())
       )
     : templates;
 
@@ -58,10 +58,10 @@ function TemplateRepoCombobox({
     setOpen(false);
   }
 
-  function handleBlur(e: React.FocusEvent<HTMLDivElement>) {
-    if (!e.currentTarget.contains(e.relatedTarget)) {
+  function handleBlur(event: React.FocusEvent<HTMLDivElement>) {
+    if (!event.currentTarget.contains(event.relatedTarget)) {
       setOpen(false);
-      if (!templates.find((t) => t.name === query)) {
+      if (!templates.find((template) => template.name === query)) {
         setQuery(selected);
       }
     }
@@ -79,8 +79,8 @@ function TemplateRepoCombobox({
       <input
         type="text"
         value={query}
-        onChange={(e) => {
-          setQuery(e.target.value);
+        onChange={(event) => {
+          setQuery(event.target.value);
           setSelected("");
           setOpen(true);
         }}
@@ -92,20 +92,20 @@ function TemplateRepoCombobox({
 
       {open && filtered.length > 0 && (
         <ul className="absolute z-10 mt-1 w-full max-h-56 overflow-auto rounded-lg border border-gray-200 bg-white shadow-lg text-sm">
-          {filtered.map((t) => (
+          {filtered.map((template) => (
             <li
-              key={t.name}
-              onMouseDown={(e) => {
-                e.preventDefault(); // evitar que el blur cierre antes
-                handleSelect(t.name);
+              key={template.name}
+              onMouseDown={(event) => {
+                event.preventDefault();
+                handleSelect(template.name);
               }}
               className={`cursor-pointer px-3 py-2 hover:bg-pdep-50 ${
-                selected === t.name ? "bg-pdep-50 font-medium" : ""
+                selected === template.name ? "bg-pdep-50 font-medium" : ""
               }`}
             >
-              <span className="font-mono">{t.name}</span>
-              {t.description && (
-                <span className="text-gray-400 ml-2">— {t.description}</span>
+              <span className="font-mono">{template.name}</span>
+              {template.description && (
+                <span className="text-gray-400 ml-2">— {template.description}</span>
               )}
             </li>
           ))}
@@ -135,15 +135,15 @@ export function AssignmentForm({
   const [slug, setSlug] = useState(defaultValues.slug ?? "");
   const [slugEdited, setSlugEdited] = useState(!!defaultValues.slug);
 
-  function handleTituloChange(e: React.ChangeEvent<HTMLInputElement>) {
+  function handleTituloChange(event: React.ChangeEvent<HTMLInputElement>) {
     if (!slugEdited) {
-      setSlug(slugify(e.target.value));
+      setSlug(slugify(event.target.value));
     }
   }
 
-  function handleSlugChange(e: React.ChangeEvent<HTMLInputElement>) {
-    setSlug(e.target.value);
-    setSlugEdited(e.target.value !== "");
+  function handleSlugChange(event: React.ChangeEvent<HTMLInputElement>) {
+    setSlug(event.target.value);
+    setSlugEdited(event.target.value !== "");
   }
 
   return (
@@ -234,9 +234,9 @@ export function AssignmentForm({
               defaultValue={defaultValues.paradigma ?? "funcional"}
               className={`${INPUT_CLASS} appearance-none pr-8`}
             >
-              {PARADIGMAS.map((p) => (
-                <option key={p} value={p}>
-                  {p.charAt(0).toUpperCase() + p.slice(1)}
+              {PARADIGMAS.map((paradigma) => (
+                <option key={paradigma} value={paradigma}>
+                  {paradigma.charAt(0).toUpperCase() + paradigma.slice(1)}
                 </option>
               ))}
             </select>
@@ -256,7 +256,7 @@ export function AssignmentForm({
               name="tipo"
               required
               value={tipo}
-              onChange={(e) => setTipo(e.target.value)}
+              onChange={(event) => setTipo(event.target.value)}
               className={`${INPUT_CLASS} appearance-none pr-8`}
             >
               <option value="individual">Individual</option>
@@ -299,7 +299,7 @@ export function AssignmentForm({
           type="date"
           defaultValue={defaultValues.deadline}
           className={INPUT_CLASS}
-          onChange={(e) => e.target.blur()}
+          onChange={(event) => event.target.blur()}
         />
       </div>
 

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useFormState } from "react-dom";
 import { PARADIGMAS } from "@/types";
+import { GRUPAL_MIN_MAX_INTEGRANTES } from "@/domain/entities/domain-constants";
 import type { AssignmentFormState } from "@/lib/assignment-schema";
 import { slugify } from "@/lib/naming";
 import { INPUT_CLASS, INPUT_ERROR_CLASS, FieldError, SubmitButton } from "../ui";
@@ -280,7 +281,7 @@ export function AssignmentForm({
           <input
             name="maxIntegrantes"
             type="number"
-            min={2}
+            min={GRUPAL_MIN_MAX_INTEGRANTES}
             defaultValue={defaultValues.maxIntegrantes}
             placeholder="Ej: 3"
             className={errors.maxIntegrantes ? INPUT_ERROR_CLASS : INPUT_CLASS}

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -299,7 +299,7 @@ export function AssignmentForm({
           type="date"
           defaultValue={defaultValues.deadline}
           className={INPUT_CLASS}
-          onChange={(event) => event.target.blur()}
+
         />
       </div>
 

--- a/src/app/admin/assignments/delete-repos-button.tsx
+++ b/src/app/admin/assignments/delete-repos-button.tsx
@@ -22,10 +22,10 @@ export function DeleteReposButton({
       return;
 
     await call(async () => {
-      const res = await fetch(`/api/assignments/${assignmentId}/repos`, { method: "DELETE" });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? `Error ${res.status}`);
+      const response = await fetch(`/api/assignments/${assignmentId}/repos`, { method: "DELETE" });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? `Error ${response.status}`);
       }
       router.refresh();
     });

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -46,16 +46,16 @@ import AdminAssignmentsPage from "./page";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const a = new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.descripcion = "Descripción de la kata";
-  a.templateRepo = "kata-template";
-  a.tipo = "individual";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date("2026-01-01");
-  return Object.assign(a, overrides);
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "Descripción de la kata";
+  assignment.templateRepo = "kata-template";
+  assignment.tipo = "individual";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/admin/comisiones/[id]/edit/page.test.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.test.tsx
@@ -8,6 +8,7 @@ const mockRequireAdmin = vi.fn();
 const mockGetComision = vi.fn();
 const mockCountAlumnos = vi.fn();
 const mockGetAlumnos = vi.fn();
+const mockGetSheetNames = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnosConGruposSyncPendiente = vi.fn();
 
@@ -24,6 +25,7 @@ vi.mock("@/lib/repositories", () => ({
 
 vi.mock("@/lib/sheets", () => ({
   getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
+  getSheetNames: (...args: unknown[]) => mockGetSheetNames(...args),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -58,9 +60,11 @@ vi.mock("../../comision-form", () => ({
   ComisionForm: ({
     submitLabel,
     defaultValues,
+    initialSheetNames,
   }: {
     submitLabel: string;
     defaultValues?: Record<string, unknown>;
+    initialSheetNames?: string[];
   }) =>
     React.createElement("div", {
       "data-testid": "comision-form",
@@ -68,6 +72,7 @@ vi.mock("../../comision-form", () => ({
       "data-default-anio": defaultValues?.anio,
       "data-default-spreadsheet-id": defaultValues?.spreadsheetId,
       "data-default-activa": defaultValues?.activa,
+      "data-initial-sheet-names": initialSheetNames?.join(","),
     }),
 }));
 
@@ -99,6 +104,7 @@ describe("Edit Comision page", () => {
     mockGetAlumnos.mockResolvedValue([]);
     mockCountAlumnos.mockResolvedValue(0);
     mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+    mockGetSheetNames.mockResolvedValue(["Alumnos", "Grupos"]);
   });
 
   it("siempre llama a requireAdmin", async () => {
@@ -142,6 +148,22 @@ describe("Edit Comision page", () => {
       mockGetComision.mockResolvedValue(makeComision({ activa: true }));
       const element = await EditComisionPage({ params: { id: "c1" } });
       expect(renderToStaticMarkup(element as React.ReactElement)).toContain('data-default-activa="true"');
+    });
+
+    it("pasa los nombres de hojas al formulario cuando getSheetNames responde", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetSheetNames.mockResolvedValue(["Alumnos", "Grupos"]);
+      const element = await EditComisionPage({ params: { id: "c1" } });
+      expect(renderToStaticMarkup(element as React.ReactElement)).toContain("Alumnos,Grupos");
+    });
+
+    it("no pasa initialSheetNames cuando getSheetNames falla, pero la página sigue funcionando", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetSheetNames.mockRejectedValue(new Error("sin acceso"));
+      const element = await EditComisionPage({ params: { id: "c1" } });
+      const html = renderToStaticMarkup(element as React.ReactElement);
+      expect(html).toContain('data-testid="comision-form"');
+      expect(html).not.toContain("data-initial-sheet-names=");
     });
   });
 
@@ -230,6 +252,33 @@ describe("Edit Comision page", () => {
       expect(html).toContain("Grupos pendientes");
       expect(html).toContain("2");
       expect(html).toContain('data-testid="sync-grupos-button"');
+    });
+
+    it("muestra la lista con nombres de los alumnos con sync pendiente", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+        { githubUsername: "ana", nombre: "Ana", apellido: "García", nombreCompleto: "García, Ana" },
+        { githubUsername: "bruno", nombre: "Bruno", apellido: "Ruiz", nombreCompleto: "Ruiz, Bruno" },
+      ]);
+
+      const html = renderToStaticMarkup(
+        await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
+      );
+      expect(html).toContain('data-testid="pendientes-grupos-lista"');
+      expect(html).toContain("García, Ana");
+      expect(html).toContain("@ana");
+      expect(html).toContain("Ruiz, Bruno");
+      expect(html).toContain("@bruno");
+    });
+
+    it("no muestra la lista cuando no hay alumnos con sync pendiente", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+
+      const html = renderToStaticMarkup(
+        await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
+      );
+      expect(html).not.toContain('data-testid="pendientes-grupos-lista"');
     });
 
     it("no muestra el badge si no hay alumnos pendientes", async () => {

--- a/src/app/admin/comisiones/[id]/edit/page.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.tsx
@@ -4,7 +4,8 @@ import {
   countAlumnos,
   getAlumnosConGruposSyncPendiente,
 } from "@/lib/repositories";
-import { getAlumnos } from "@/lib/sheets";
+import type { Alumno } from "@/domain/entities";
+import { getAlumnos, getSheetNames } from "@/lib/sheets";
 import { redirect } from "next/navigation";
 import { ComisionForm } from "../../comision-form";
 import { actualizarComision } from "../../actions";
@@ -22,12 +23,13 @@ export default async function EditComisionPage({
   if (!comision) redirect("/admin/comisiones");
 
   // Comparar counts en paralelo; si alguno falla no rompemos la página
-  const [countSheet, countDB, pendientesGrupos] = await Promise.all([
+  const [countSheet, countDB, pendientesGrupos, sheetNames] = await Promise.all([
     getAlumnos(comision.spreadsheetId, comision.columnConfig)
-      .then((a) => a.length)
+      .then((alumnos) => alumnos.length)
       .catch(() => null),
     countAlumnos().catch(() => null),
     getAlumnosConGruposSyncPendiente(comision.id).catch(() => [] as unknown[]),
+    getSheetNames(comision.spreadsheetId).catch(() => null),
   ]);
 
   const desynced =
@@ -64,6 +66,25 @@ export default async function EditComisionPage({
         )}
       </div>
 
+      {cantPendientesGrupos > 0 && (
+        <div
+          className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+          data-testid="pendientes-grupos-lista"
+        >
+          <p className="text-xs font-semibold text-red-700 mb-2">
+            Alumnos con sync de grupos pendiente:
+          </p>
+          <ul className="space-y-0.5">
+            {(pendientesGrupos as Alumno[]).map((alumno) => (
+              <li key={alumno.githubUsername} className="text-xs text-red-700">
+                {alumno.nombreCompleto}{" "}
+                <span className="text-red-400">@{alumno.githubUsername}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
       <ComisionForm
         action={actualizarComision}
         defaultValues={{
@@ -73,6 +94,7 @@ export default async function EditComisionPage({
           activa: comision.activa,
           columnConfig: comision.columnConfig,
         }}
+        initialSheetNames={sheetNames ?? undefined}
         submitLabel="Guardar cambios"
       />
     </div>

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -10,7 +10,7 @@ const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnos = vi.fn();
 const mockGetAsignacionesGrupos = vi.fn();
-const mockGetAlumnosConGruposSyncPendiente = vi.fn();
+const mockGetAlumnosByComision = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
 
 vi.mock("@/lib/session", () => ({
@@ -37,8 +37,8 @@ vi.mock("@/lib/repositories", () => ({
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
   upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
-  getAlumnosConGruposSyncPendiente: (...args: unknown[]) =>
-    mockGetAlumnosConGruposSyncPendiente(...args),
+  getAlumnosByComision: (...args: unknown[]) =>
+    mockGetAlumnosByComision(...args),
   LegajoConflictError: FakeLegajoConflictError,
 }));
 
@@ -311,7 +311,7 @@ describe("sincronizarGruposDeLaComision", () => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetComision.mockResolvedValue(comision);
-    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+    mockGetAlumnosByComision.mockResolvedValue([]);
     mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
     mockGetAsignacionesGrupos.mockResolvedValue(asignacionesFake);
   });
@@ -323,16 +323,28 @@ describe("sincronizarGruposDeLaComision", () => {
     expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
   });
 
-  it("devuelve ok con 0 sincronizados cuando no hay alumnos pendientes", async () => {
+  it("devuelve ok con 0 sincronizados cuando no hay alumnos en la comisión", async () => {
     const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
     expect(result).toEqual({ status: "ok", sincronizados: 0, aunConError: 0 });
     expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
-    // Sin pendientes no hace falta leer la hoja.
     expect(mockGetAsignacionesGrupos).not.toHaveBeenCalled();
   });
 
+  it("corre para todos los alumnos de la comisión (no solo los pendientes)", async () => {
+    mockGetAlumnosByComision.mockResolvedValue([
+      { githubUsername: "ana", gruposSyncFallidoEn: null },
+      { githubUsername: "bruno", gruposSyncFallidoEn: null },
+    ]);
+
+    await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
+
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledTimes(2);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("ana", comision, asignacionesFake);
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("bruno", comision, asignacionesFake);
+  });
+
   it("lee la hoja de grupos una sola vez y reutiliza el resultado en cada alumno", async () => {
-    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+    mockGetAlumnosByComision.mockResolvedValue([
       { githubUsername: "ana" },
       { githubUsername: "bruno" },
       { githubUsername: "cintia" },
@@ -349,7 +361,7 @@ describe("sincronizarGruposDeLaComision", () => {
   });
 
   it("devuelve error y no sincroniza nada si la lectura única de la hoja falla", async () => {
-    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([{ githubUsername: "ana" }]);
+    mockGetAlumnosByComision.mockResolvedValue([{ githubUsername: "ana" }]);
     mockGetAsignacionesGrupos.mockRejectedValue(new Error("No se pudo leer la hoja de grupos: rate limited"));
 
     const result = await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
@@ -361,9 +373,9 @@ describe("sincronizarGruposDeLaComision", () => {
     expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
   });
 
-  it("no lee la hoja si la comisión no tiene config de grupos (no-op que limpia flags)", async () => {
+  it("no lee la hoja si la comisión no tiene config de grupos", async () => {
     mockGetComision.mockResolvedValue({ id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {} });
-    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([{ githubUsername: "ana" }]);
+    mockGetAlumnosByComision.mockResolvedValue([{ githubUsername: "ana" }]);
 
     await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());
 
@@ -376,7 +388,7 @@ describe("sincronizarGruposDeLaComision", () => {
   });
 
   it("cuenta cuántos se resolvieron y cuántos siguen con error", async () => {
-    mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([
+    mockGetAlumnosByComision.mockResolvedValue([
       { githubUsername: "ana" },
       { githubUsername: "bruno" },
       { githubUsername: "cintia" },

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -296,6 +296,7 @@ describe("sincronizarGruposDeLaComision", () => {
     id: "c1",
     spreadsheetId: "sheet-xyz",
     columnConfig: { grupos: gruposConfig },
+    gruposConfig: () => gruposConfig,
   };
   const asignacionesFake = [
     { githubUsername: "ana", paradigma: "funcional", nombreGrupo: "Los Lambdas" },
@@ -374,7 +375,7 @@ describe("sincronizarGruposDeLaComision", () => {
   });
 
   it("no lee la hoja si la comisión no tiene config de grupos", async () => {
-    mockGetComision.mockResolvedValue({ id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {} });
+    mockGetComision.mockResolvedValue({ id: "c1", spreadsheetId: "sheet-xyz", columnConfig: {}, gruposConfig: () => undefined });
     mockGetAlumnosByComision.mockResolvedValue([{ githubUsername: "ana" }]);
 
     await sincronizarGruposDeLaComision({ status: "idle" }, makeFd());

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -225,7 +225,7 @@ export async function sincronizarGruposDeLaComision(
   // Sheets (cada alumno releía la hoja entera). Si la lectura falla reportamos
   // el error global y no modificamos los flags.
   let asignaciones: AsignacionGrupoRow[] | undefined;
-  const gruposConfig = comision.columnConfig?.grupos;
+  const gruposConfig = comision.gruposConfig();
   if (gruposConfig && alumnos.length > 0) {
     try {
       asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -7,9 +7,9 @@ import {
   getComision,
   upsertAlumnos,
   LegajoConflictError,
-  getAlumnosConGruposSyncPendiente,
+  getAlumnosByComision,
 } from "@/lib/repositories";
-import { getAlumnos, getAsignacionesGrupos, type AsignacionGrupoRow } from "@/lib/sheets";
+import { getAlumnos, getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
@@ -19,6 +19,18 @@ import { DEFAULT_COLUMN_CONFIG, type GruposColumnConfig } from "@/types";
 export type ComisionFormState =
   | { ok: false; errors: Record<string, string[] | undefined> }
   | null;
+
+export async function fetchSheetNames(
+  spreadsheetId: string
+): Promise<string[] | { error: string }> {
+  await requireAdmin();
+  if (!spreadsheetId.trim()) return { error: "Ingresá el ID de la planilla primero" };
+  try {
+    return await getSheetNames(spreadsheetId);
+  } catch (error) {
+    return { error: (error as Error).message };
+  }
+}
 
 const ColumnIndexSchema = z.coerce
   .number({ invalid_type_error: "Debe ser un número de columna" })
@@ -193,10 +205,10 @@ export type SyncGruposState =
   | { status: "ok"; sincronizados: number; aunConError: number }
   | { status: "error"; message: string };
 
-// Reintenta `sincronizarGruposDelAlumno` para todos los alumnos de la comisión
-// con el flag `gruposSyncFallidoEn` prendido. El wrapper `intentarSincronizarGrupos`
-// se encarga del logging y de limpiar/mantener el flag por alumno; esta action
-// solo agrega un resumen para que el admin lo vea.
+// Importa los grupos desde la planilla para todos los alumnos de la comisión.
+// Útil para bootstrapping cuando la cursada ya está en marcha al desplegar.
+// El wrapper `intentarSincronizarGrupos` se encarga del logging y de actualizar
+// el flag por alumno; esta action solo agrega un resumen para que el admin lo vea.
 export async function sincronizarGruposDeLaComision(
   _prevState: SyncGruposState,
   formData: FormData
@@ -207,16 +219,14 @@ export async function sincronizarGruposDeLaComision(
   const comision = await getComision(id);
   if (!comision) return { status: "error", message: "Comisión no encontrada" };
 
-  const pendientes = await getAlumnosConGruposSyncPendiente(id);
+  const alumnos = await getAlumnosByComision(id);
 
-  // Lectura única de la hoja de grupos: con un solo pendiente el costo es el
-  // mismo que antes, pero con N evitamos N lecturas a Sheets (cada alumno
-  // releía la hoja entera). Si la lectura falla reportamos el error global y
-  // no tocamos los flags — ya estaban en fallido y un retry masivo sobre una
-  // hoja inaccesible no aporta información nueva.
+  // Lectura única de la hoja de grupos: con N alumnos evitamos N lecturas a
+  // Sheets (cada alumno releía la hoja entera). Si la lectura falla reportamos
+  // el error global y no modificamos los flags.
   let asignaciones: AsignacionGrupoRow[] | undefined;
   const gruposConfig = comision.columnConfig?.grupos;
-  if (gruposConfig && pendientes.length > 0) {
+  if (gruposConfig && alumnos.length > 0) {
     try {
       asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
     } catch (e) {
@@ -226,7 +236,7 @@ export async function sincronizarGruposDeLaComision(
 
   let sincronizados = 0;
   let aunConError = 0;
-  for (const alumno of pendientes) {
+  for (const alumno of alumnos) {
     try {
       await intentarSincronizarGrupos(alumno.githubUsername, comision, asignaciones);
       sincronizados++;

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -41,7 +41,7 @@ const ColumnIndexSchema = z.coerce
 // "" → undefined para columnas opcionales de grupos: la UI envía string vacío
 // cuando el admin elige "(sin columna)".
 const OptionalColumnIndexSchema = z.preprocess(
-  (v) => (v === "" || v === undefined || v === null ? undefined : v),
+  (value) => (value === "" || value === undefined || value === null ? undefined : value),
   ColumnIndexSchema.optional()
 );
 
@@ -52,7 +52,7 @@ const ComisionSchema = z.object({
     .min(2020, "Año inválido")
     .max(2100, "Año inválido"),
   spreadsheetId: z.string().min(1, "El ID de la planilla es obligatorio"),
-  activa: z.coerce.boolean().optional().transform((v) => v ?? false),
+  activa: z.coerce.boolean().optional().transform((value) => value ?? false),
   sheetName: z.string().min(1, "El nombre de la hoja es obligatorio"),
   headerRows: z.coerce.number().int().min(0).max(10),
   col_legajo: ColumnIndexSchema,
@@ -60,7 +60,7 @@ const ComisionSchema = z.object({
   col_nombre: ColumnIndexSchema,
   col_githubUsername: ColumnIndexSchema,
   col_email: ColumnIndexSchema,
-  grupos_enabled: z.coerce.boolean().optional().transform((v) => v ?? false),
+  grupos_enabled: z.coerce.boolean().optional().transform((value) => value ?? false),
   grupos_sheetName: z.string().optional(),
   grupos_headerRows: z.coerce.number().int().min(0).max(10).optional(),
   grupos_col_githubUsername: OptionalColumnIndexSchema,
@@ -182,18 +182,18 @@ export async function sincronizarAlumnos(
   let alumnos;
   try {
     alumnos = await getAlumnos(comision.spreadsheetId, comision.columnConfig);
-  } catch (e) {
-    return { status: "error", message: `No se pudo leer la planilla: ${(e as Error).message}` };
+  } catch (error) {
+    return { status: "error", message: `No se pudo leer la planilla: ${(error as Error).message}` };
   }
 
   let sincronizados: number;
   try {
     sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
-  } catch (e) {
-    if (e instanceof LegajoConflictError) {
-      return { status: "error", message: e.message };
+  } catch (error) {
+    if (error instanceof LegajoConflictError) {
+      return { status: "error", message: error.message };
     }
-    throw e;
+    throw error;
   }
 
   revalidatePath("/admin/comisiones");
@@ -229,8 +229,8 @@ export async function sincronizarGruposDeLaComision(
   if (gruposConfig && alumnos.length > 0) {
     try {
       asignaciones = await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig);
-    } catch (e) {
-      return { status: "error", message: (e as Error).message };
+    } catch (error) {
+      return { status: "error", message: (error as Error).message };
     }
   }
 

--- a/src/app/admin/comisiones/comision-form.test.tsx
+++ b/src/app/admin/comisiones/comision-form.test.tsx
@@ -4,6 +4,7 @@ import type { ComisionFormState } from "./actions";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockUseFormState = vi.fn();
+const mockFetchSheetNames = vi.fn();
 
 vi.mock("react-dom", async () => {
   const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
@@ -13,6 +14,10 @@ vi.mock("react-dom", async () => {
     useFormStatus: () => ({ pending: false }),
   };
 });
+
+vi.mock("./actions", () => ({
+  fetchSheetNames: (...args: unknown[]) => mockFetchSheetNames(...args),
+}));
 
 import { ComisionForm } from "./comision-form";
 
@@ -39,6 +44,9 @@ function getSpreadsheetInput(container: HTMLElement) {
 }
 function getActivaCheckbox(container: HTMLElement) {
   return container.querySelector<HTMLInputElement>('[name="activa"]')!;
+}
+function getSheetNameField(container: HTMLElement) {
+  return container.querySelector<HTMLElement>('[name="sheetName"]')!;
 }
 
 // ── Tests ────────────────────────────────────────────────────
@@ -134,6 +142,54 @@ describe("ComisionForm", () => {
       expect(
         screen.getByRole("link", { name: "Cancelar" })
       ).toHaveAttribute("href", "/admin/comisiones");
+    });
+  });
+
+  describe("campo de nombre de hoja", () => {
+    it("muestra un input de texto cuando no hay initialSheetNames", () => {
+      const { container } = render(<ComisionForm action={noop} submitLabel="Crear" />);
+      expect(getSheetNameField(container).tagName).toBe("INPUT");
+    });
+
+    it("muestra un select cuando se pasan initialSheetNames", () => {
+      const { container } = render(
+        <ComisionForm
+          action={noop}
+          submitLabel="Crear"
+          initialSheetNames={["Alumnos", "Grupos"]}
+        />
+      );
+      expect(getSheetNameField(container).tagName).toBe("SELECT");
+    });
+
+    it("el select incluye las hojas provistas", () => {
+      const { container } = render(
+        <ComisionForm
+          action={noop}
+          submitLabel="Crear"
+          initialSheetNames={["Alumnos", "Grupos"]}
+        />
+      );
+      const select = getSheetNameField(container) as HTMLSelectElement;
+      const opciones = Array.from(select.options).map((option) => option.value);
+      expect(opciones).toContain("Alumnos");
+      expect(opciones).toContain("Grupos");
+    });
+
+    it("muestra el botón 'Cargar hojas'", () => {
+      render(<ComisionForm action={noop} submitLabel="Crear" />);
+      expect(screen.getByRole("button", { name: "Cargar hojas" })).toBeInTheDocument();
+    });
+
+    it("muestra el botón 'Recargar hojas' cuando ya hay hojas cargadas", () => {
+      render(
+        <ComisionForm
+          action={noop}
+          submitLabel="Crear"
+          initialSheetNames={["Alumnos"]}
+        />
+      );
+      expect(screen.getByRole("button", { name: "Recargar hojas" })).toBeInTheDocument();
     });
   });
 });

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -135,12 +135,17 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
     }
     setLoadingSheets(true);
     setLoadSheetsError(null);
-    const result = await fetchSheetNames(spreadsheetId);
-    setLoadingSheets(false);
-    if ("error" in result) {
-      setLoadSheetsError(result.error);
-    } else {
-      setSheetNames(result);
+    try {
+      const result = await fetchSheetNames(spreadsheetId);
+      if ("error" in result) {
+        setLoadSheetsError(result.error);
+      } else {
+        setSheetNames(result);
+      }
+    } catch (error) {
+      setLoadSheetsError(String(error));
+    } finally {
+      setLoadingSheets(false);
     }
   }
 

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -119,8 +119,8 @@ function SheetNameSelect({
 export function ComisionForm({ action, defaultValues = {}, submitLabel, initialSheetNames }: Props) {
   const [state, formAction] = useFormState(action, null);
   const errors = state?.errors ?? {};
-  const cfg = defaultValues.columnConfig ?? DEFAULT_COLUMN_CONFIG;
-  const grupos = cfg.grupos;
+  const config = defaultValues.columnConfig ?? DEFAULT_COLUMN_CONFIG;
+  const grupos = config.grupos;
   const [gruposEnabled, setGruposEnabled] = useState(Boolean(grupos));
   const [sheetNames, setSheetNames] = useState<string[] | null>(initialSheetNames ?? null);
   const [loadingSheets, setLoadingSheets] = useState(false);
@@ -227,7 +227,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
           <SheetNameSelect
             name="sheetName"
             label="Nombre de la hoja"
-            defaultValue={cfg.sheetName}
+            defaultValue={config.sheetName}
             error={errors.sheetName?.[0]}
             sheetNames={sheetNames}
           />
@@ -240,7 +240,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
               type="number"
               min={0}
               max={10}
-              defaultValue={cfg.headerRows}
+              defaultValue={config.headerRows}
               className={`${INPUT_CLASS} text-sm`}
             />
             <FieldError message={errors.headerRows?.[0]} />
@@ -249,11 +249,11 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
 
         {/* Selectores de columna */}
         <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-          <ColSelect name="col_legajo" label="Legajo" defaultValue={cfg.legajo} error={errors.col_legajo?.[0]} />
-          <ColSelect name="col_apellido" label="Apellido" defaultValue={cfg.apellido} error={errors.col_apellido?.[0]} />
-          <ColSelect name="col_nombre" label="Nombre" defaultValue={cfg.nombre} error={errors.col_nombre?.[0]} />
-          <ColSelect name="col_githubUsername" label="Usuario GitHub" defaultValue={cfg.githubUsername} error={errors.col_githubUsername?.[0]} />
-          <ColSelect name="col_email" label="Email" defaultValue={cfg.email} error={errors.col_email?.[0]} />
+          <ColSelect name="col_legajo" label="Legajo" defaultValue={config.legajo} error={errors.col_legajo?.[0]} />
+          <ColSelect name="col_apellido" label="Apellido" defaultValue={config.apellido} error={errors.col_apellido?.[0]} />
+          <ColSelect name="col_nombre" label="Nombre" defaultValue={config.nombre} error={errors.col_nombre?.[0]} />
+          <ColSelect name="col_githubUsername" label="Usuario GitHub" defaultValue={config.githubUsername} error={errors.col_githubUsername?.[0]} />
+          <ColSelect name="col_email" label="Email" defaultValue={config.email} error={errors.col_email?.[0]} />
         </div>
       </fieldset>
 
@@ -288,7 +288,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
               <SheetNameSelect
                 name="grupos_sheetName"
                 label="Nombre de la hoja (grupos)"
-                defaultValue={grupos?.sheetName ?? cfg.sheetName}
+                defaultValue={grupos?.sheetName ?? config.sheetName}
                 error={errors.grupos_sheetName?.[0]}
                 sheetNames={sheetNames}
               />
@@ -301,7 +301,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
                   type="number"
                   min={0}
                   max={10}
-                  defaultValue={grupos?.headerRows ?? cfg.headerRows}
+                  defaultValue={grupos?.headerRows ?? config.headerRows}
                   className={`${INPUT_CLASS} text-sm`}
                 />
                 <FieldError message={errors.grupos_headerRows?.[0]} />
@@ -312,7 +312,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
               <ColSelect
                 name="grupos_col_githubUsername"
                 label="Usuario GitHub"
-                defaultValue={grupos?.githubUsername ?? cfg.githubUsername}
+                defaultValue={grupos?.githubUsername ?? config.githubUsername}
                 error={errors.grupos_col_githubUsername?.[0]}
               />
               <ColSelect

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -1,15 +1,16 @@
 "use client";
 
 import { useFormState } from "react-dom";
-import { useState } from "react";
+import { useState, useRef } from "react";
 import type { ComisionFormState } from "./actions";
+import { fetchSheetNames } from "./actions";
 import { INPUT_CLASS, INPUT_ERROR_CLASS, FieldError, SubmitButton } from "../ui";
 import { DEFAULT_COLUMN_CONFIG, type ColumnConfig } from "@/types";
 
 // A=0, B=1, … Z=25
-const COL_OPTIONS = Array.from({ length: 26 }, (_, i) => ({
-  value: i,
-  label: String.fromCharCode(65 + i),
+const COL_OPTIONS = Array.from({ length: 26 }, (_, colIndex) => ({
+  value: colIndex,
+  label: String.fromCharCode(65 + colIndex),
 }));
 
 type DefaultValues = {
@@ -24,6 +25,7 @@ type Props = {
   action: (prevState: ComisionFormState, formData: FormData) => Promise<ComisionFormState>;
   defaultValues?: DefaultValues;
   submitLabel: string;
+  initialSheetNames?: string[];
 };
 
 function ColSelect({
@@ -59,12 +61,88 @@ function ColSelect({
   );
 }
 
-export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props) {
+function SheetNameSelect({
+  name,
+  label,
+  defaultValue,
+  error,
+  sheetNames,
+}: {
+  name: string;
+  label: string;
+  defaultValue: string | undefined;
+  error?: string;
+  sheetNames: string[] | null;
+}) {
+  if (sheetNames === null) {
+    return (
+      <div>
+        <label className="block text-xs font-medium text-gray-600 mb-1">{label}</label>
+        <input
+          name={name}
+          defaultValue={defaultValue}
+          placeholder="Alumnos"
+          className={`${error ? INPUT_ERROR_CLASS : INPUT_CLASS} text-sm font-mono`}
+        />
+        <FieldError message={error} />
+      </div>
+    );
+  }
+
+  // Si el valor guardado no está en la lista (hoja renombrada), lo incluimos para no perderlo
+  const options =
+    defaultValue && !sheetNames.includes(defaultValue)
+      ? [defaultValue, ...sheetNames]
+      : sheetNames;
+
+  return (
+    <div>
+      <label className="block text-xs font-medium text-gray-600 mb-1">{label}</label>
+      <select
+        name={name}
+        defaultValue={defaultValue}
+        className={`w-full rounded-md border px-2 py-1.5 text-sm font-mono ${
+          error ? "border-red-400 bg-red-50" : "border-gray-300 bg-white"
+        } focus:ring-2 focus:ring-pdep-500 focus:border-pdep-500 outline-none`}
+      >
+        {options.map((sheetName) => (
+          <option key={sheetName} value={sheetName}>
+            {sheetName}
+          </option>
+        ))}
+      </select>
+      <FieldError message={error} />
+    </div>
+  );
+}
+
+export function ComisionForm({ action, defaultValues = {}, submitLabel, initialSheetNames }: Props) {
   const [state, formAction] = useFormState(action, null);
   const errors = state?.errors ?? {};
   const cfg = defaultValues.columnConfig ?? DEFAULT_COLUMN_CONFIG;
   const grupos = cfg.grupos;
   const [gruposEnabled, setGruposEnabled] = useState(Boolean(grupos));
+  const [sheetNames, setSheetNames] = useState<string[] | null>(initialSheetNames ?? null);
+  const [loadingSheets, setLoadingSheets] = useState(false);
+  const [loadSheetsError, setLoadSheetsError] = useState<string | null>(null);
+  const spreadsheetIdRef = useRef<HTMLInputElement>(null);
+
+  async function handleLoadSheets() {
+    const spreadsheetId = spreadsheetIdRef.current?.value ?? "";
+    if (!spreadsheetId.trim()) {
+      setLoadSheetsError("Ingresá el ID de la planilla primero");
+      return;
+    }
+    setLoadingSheets(true);
+    setLoadSheetsError(null);
+    const result = await fetchSheetNames(spreadsheetId);
+    setLoadingSheets(false);
+    if ("error" in result) {
+      setLoadSheetsError(result.error);
+    } else {
+      setSheetNames(result);
+    }
+  }
 
   return (
     <form action={formAction} className="space-y-5">
@@ -90,16 +168,30 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         <label className="block text-sm font-medium text-gray-700 mb-1">
           ID de la planilla de Google Sheets *
         </label>
-        <input
-          name="spreadsheetId"
-          required
-          defaultValue={defaultValues.spreadsheetId}
-          placeholder="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
-          className={`${errors.spreadsheetId ? INPUT_ERROR_CLASS : INPUT_CLASS} font-mono text-xs`}
-        />
+        <div className="flex gap-2">
+          <input
+            ref={spreadsheetIdRef}
+            name="spreadsheetId"
+            required
+            defaultValue={defaultValues.spreadsheetId}
+            placeholder="1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms"
+            className={`flex-1 ${errors.spreadsheetId ? INPUT_ERROR_CLASS : INPUT_CLASS} font-mono text-xs`}
+          />
+          <button
+            type="button"
+            onClick={handleLoadSheets}
+            disabled={loadingSheets}
+            className="shrink-0 px-3 py-2 text-xs font-medium rounded-md border border-gray-300 text-gray-600 hover:bg-gray-50 transition-colors disabled:opacity-50"
+          >
+            {loadingSheets ? "Cargando…" : sheetNames ? "Recargar hojas" : "Cargar hojas"}
+          </button>
+        </div>
         <p className="text-gray-400 text-xs mt-1">
           Se encuentra en la URL: docs.google.com/spreadsheets/d/<strong>ID</strong>/edit
         </p>
+        {loadSheetsError && (
+          <p className="text-red-500 text-xs mt-1">{loadSheetsError}</p>
+        )}
         <FieldError message={errors.spreadsheetId?.[0]} />
       </div>
 
@@ -132,18 +224,13 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
 
         {/* Nombre de la hoja y filas de encabezado */}
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-          <div>
-            <label className="block text-xs font-medium text-gray-600 mb-1">
-              Nombre de la hoja
-            </label>
-            <input
-              name="sheetName"
-              defaultValue={cfg.sheetName}
-              placeholder="Alumnos"
-              className={`${INPUT_CLASS} text-sm font-mono`}
-            />
-            <FieldError message={errors.sheetName?.[0]} />
-          </div>
+          <SheetNameSelect
+            name="sheetName"
+            label="Nombre de la hoja"
+            defaultValue={cfg.sheetName}
+            error={errors.sheetName?.[0]}
+            sheetNames={sheetNames}
+          />
           <div>
             <label className="block text-xs font-medium text-gray-600 mb-1">
               Filas de encabezado
@@ -187,7 +274,7 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
             name="grupos_enabled"
             type="checkbox"
             checked={gruposEnabled}
-            onChange={(e) => setGruposEnabled(e.target.checked)}
+            onChange={(changeEvent) => setGruposEnabled(changeEvent.target.checked)}
             className="h-4 w-4 rounded border-gray-300 text-pdep-600 focus:ring-pdep-500"
           />
           <label htmlFor="grupos_enabled" className="text-sm font-medium text-gray-700">
@@ -198,18 +285,13 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel }: Props)
         {gruposEnabled && (
           <>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
-              <div>
-                <label className="block text-xs font-medium text-gray-600 mb-1">
-                  Nombre de la hoja (grupos)
-                </label>
-                <input
-                  name="grupos_sheetName"
-                  defaultValue={grupos?.sheetName ?? cfg.sheetName}
-                  placeholder="Alumnos"
-                  className={`${INPUT_CLASS} text-sm font-mono`}
-                />
-                <FieldError message={errors.grupos_sheetName?.[0]} />
-              </div>
+              <SheetNameSelect
+                name="grupos_sheetName"
+                label="Nombre de la hoja (grupos)"
+                defaultValue={grupos?.sheetName ?? cfg.sheetName}
+                error={errors.grupos_sheetName?.[0]}
+                sheetNames={sheetNames}
+              />
               <div>
                 <label className="block text-xs font-medium text-gray-600 mb-1">
                   Filas de encabezado (grupos)

--- a/src/app/admin/comisiones/comision-form.tsx
+++ b/src/app/admin/comisiones/comision-form.tsx
@@ -6,6 +6,7 @@ import type { ComisionFormState } from "./actions";
 import { fetchSheetNames } from "./actions";
 import { INPUT_CLASS, INPUT_ERROR_CLASS, FieldError, SubmitButton } from "../ui";
 import { DEFAULT_COLUMN_CONFIG, type ColumnConfig } from "@/types";
+import { COMISION_ANIO_MIN, COMISION_ANIO_MAX } from "@/domain/entities/domain-constants";
 
 // A=0, B=1, … Z=25
 const COL_OPTIONS = Array.from({ length: 26 }, (_, colIndex) => ({
@@ -159,8 +160,8 @@ export function ComisionForm({ action, defaultValues = {}, submitLabel, initialS
         <input
           name="anio"
           type="number"
-          min={2020}
-          max={2100}
+          min={COMISION_ANIO_MIN}
+          max={COMISION_ANIO_MAX}
           required
           defaultValue={defaultValues.anio ?? new Date().getFullYear()}
           className={errors.anio ? INPUT_ERROR_CLASS : INPUT_CLASS}

--- a/src/app/admin/comisiones/page.tsx
+++ b/src/app/admin/comisiones/page.tsx
@@ -38,18 +38,18 @@ export default async function AdminComisionesPage() {
             <DataHeaderCell>Acciones</DataHeaderCell>
           </DataHeader>
           <DataBody>
-            {comisiones.map((c) => (
-              <DataRow key={c.id}>
+            {comisiones.map((comision) => (
+              <DataRow key={comision.id}>
                 <DataCell label="Año" heading>
-                  {c.anio}
+                  {comision.anio}
                 </DataCell>
                 <DataCell label="Planilla">
                   <span className="font-mono text-xs text-gray-500 break-all md:truncate md:block">
-                    {c.spreadsheetId}
+                    {comision.spreadsheetId}
                   </span>
                 </DataCell>
                 <DataCell label="Estado">
-                  {c.activa ? (
+                  {comision.activa ? (
                     <span className="inline-flex items-center gap-1 text-xs font-medium bg-green-100 text-green-700 px-2 py-0.5 rounded-full">
                       <span className="h-1.5 w-1.5 rounded-full bg-green-500" />
                       Activa
@@ -61,12 +61,12 @@ export default async function AdminComisionesPage() {
                 <DataCell label="Acciones">
                   <div className="flex items-center gap-3 flex-wrap">
                     <a
-                      href={`/admin/comisiones/${c.id}/edit`}
+                      href={`/admin/comisiones/${comision.id}/edit`}
                       className="text-pdep-600 hover:text-pdep-800 text-xs font-medium"
                     >
                       Editar
                     </a>
-                    <DeleteComisionButton id={c.id} anio={c.anio} />
+                    <DeleteComisionButton id={comision.id} anio={comision.anio} />
                   </div>
                 </DataCell>
               </DataRow>

--- a/src/app/admin/delete-button.tsx
+++ b/src/app/admin/delete-button.tsx
@@ -19,14 +19,14 @@ export function DeleteButton({
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(endpoint, { method: "DELETE" });
-      if (!res.ok) {
-        const body = await res.json().catch(() => ({}));
-        throw new Error(body.error ?? `Error ${res.status}`);
+      const response = await fetch(endpoint, { method: "DELETE" });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? `Error ${response.status}`);
       }
       router.refresh();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Error desconocido");
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Error desconocido");
     } finally {
       setLoading(false);
     }

--- a/src/app/admin/grupos/page.test.tsx
+++ b/src/app/admin/grupos/page.test.tsx
@@ -23,7 +23,7 @@ function makeGrupo(overrides?: object) {
     id: "los-lambdas",
     nombre: "Los Lambdas",
     paradigma: "funcional",
-    alumnos: { getItems: () => [{ githubUsername: "juangarcia" }, { githubUsername: "mariaperez" }] },
+    usernamesDeMiembros: () => ["juangarcia", "mariaperez"],
     assignment: { id: "a1", titulo: "Kata Funcional" },
   };
   return { ...base, ...overrides };
@@ -148,13 +148,7 @@ describe("Admin Grupos page", () => {
     it("muestra los miembros del grupo", async () => {
       mockGetGrupos.mockResolvedValue([
         makeGrupo({
-          alumnos: {
-            getItems: () => [
-              { githubUsername: "user1" },
-              { githubUsername: "user2" },
-              { githubUsername: "user3" },
-            ],
-          },
+          usernamesDeMiembros: () => ["user1", "user2", "user3"],
         }),
       ]);
       const element = await AdminGruposPage({ searchParams: {} });

--- a/src/app/admin/grupos/page.tsx
+++ b/src/app/admin/grupos/page.tsx
@@ -76,12 +76,12 @@ export default async function AdminGruposPage({
                 {grupo.assignment.titulo}
               </p>
               <div className="flex flex-wrap gap-1.5">
-                {grupo.alumnos.getItems().map((alumno) => (
+                {grupo.usernamesDeMiembros().map((username) => (
                   <span
-                    key={alumno.githubUsername}
+                    key={username}
                     className="text-xs font-mono bg-gray-100 text-gray-700 px-2 py-1 rounded"
                   >
-                    {alumno.githubUsername}
+                    {username}
                   </span>
                 ))}
               </div>

--- a/src/app/admin/grupos/page.tsx
+++ b/src/app/admin/grupos/page.tsx
@@ -38,17 +38,17 @@ export default async function AdminGruposPage({
         >
           Todos
         </a>
-        {PARADIGMAS.map((p) => (
+        {PARADIGMAS.map((paradigma) => (
           <a
-            key={p}
-            href={`/admin/grupos?paradigma=${p}`}
+            key={paradigma}
+            href={`/admin/grupos?paradigma=${paradigma}`}
             className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
-              paradigmaFilter === p
+              paradigmaFilter === paradigma
                 ? "bg-pdep-600 text-white"
                 : "bg-gray-100 text-gray-600 hover:bg-gray-200"
             }`}
           >
-            {p.charAt(0).toUpperCase() + p.slice(1)}
+            {paradigma.charAt(0).toUpperCase() + paradigma.slice(1)}
           </a>
         ))}
       </div>
@@ -76,12 +76,12 @@ export default async function AdminGruposPage({
                 {grupo.assignment.titulo}
               </p>
               <div className="flex flex-wrap gap-1.5">
-                {grupo.alumnos.getItems().map((a) => (
+                {grupo.alumnos.getItems().map((alumno) => (
                   <span
-                    key={a.githubUsername}
+                    key={alumno.githubUsername}
                     className="text-xs font-mono bg-gray-100 text-gray-700 px-2 py-1 rounded"
                   >
-                    {a.githubUsername}
+                    {alumno.githubUsername}
                   </span>
                 ))}
               </div>

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -59,28 +59,28 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
 type AssignmentOverrides = Partial<IndividualAssignment & GrupalAssignment>;
 
 function makeAssignment(overrides?: AssignmentOverrides): Assignment {
-  const a: Assignment =
+  const assignment: Assignment =
     overrides?.tipo === "grupal"
       ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
       : new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.descripcion = "";
-  a.templateRepo = "kata-template";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date("2026-01-01");
-  return Object.assign(a, overrides);
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "";
+  assignment.templateRepo = "kata-template";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
-  const e = new Entrega();
-  e.id = "e1";
-  e.repoName = "kata-funcional-juangarcia";
-  e.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-juangarcia";
-  e.githubUsernames = ["juangarcia"];
-  e.createdAt = new Date();
-  return Object.assign(e, overrides);
+  const entrega = new Entrega();
+  entrega.id = "e1";
+  entrega.repoName = "kata-funcional-juangarcia";
+  entrega.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-juangarcia";
+  entrega.githubUsernames = ["juangarcia"];
+  entrega.createdAt = new Date();
+  return Object.assign(entrega, overrides);
 }
 
 function makeRequest(): Request {
@@ -109,9 +109,9 @@ describe("POST /api/assignments/[id]/accept", () => {
   describe("rate limiting", () => {
     it("devuelve 429 cuando el rate limit está activo", async () => {
       mockCheckRateLimit.mockReturnValue(false);
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(429);
-      const data = await res.json();
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(429);
+      const data = await response.json();
       expect(data.error).toBeDefined();
     });
 
@@ -130,37 +130,37 @@ describe("POST /api/assignments/[id]/accept", () => {
   describe("autenticación", () => {
     it("devuelve 500 si requireUser lanza (no autenticado)", async () => {
       mockRequireUser.mockRejectedValue(new Error("redirect"));
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(500);
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(500);
     });
   });
 
   describe("validaciones", () => {
     it("devuelve 404 si el assignment no existe", async () => {
       mockGetAssignment.mockResolvedValue(undefined);
-      const res = await POST(makeRequest(), { params: { id: "no-existe" } });
-      expect(res.status).toBe(404);
+      const response = await POST(makeRequest(), { params: { id: "no-existe" } });
+      expect(response.status).toBe(404);
     });
 
     it("devuelve 409 si el usuario ya tiene entrega", async () => {
       mockGetEntregaDeUsuario.mockResolvedValue(makeEntrega());
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(409);
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(409);
     });
 
     it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
       mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
       mockGetGrupoDeAlumno.mockResolvedValue(undefined);
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(400);
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(400);
     });
   });
 
   describe("creación exitosa (individual)", () => {
     it("devuelve 200 con la entrega creada", async () => {
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(200);
-      const data = await res.json();
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(200);
+      const data = await response.json();
       expect(data.repoName).toBe("kata-funcional-juangarcia");
     });
 
@@ -197,8 +197,8 @@ describe("POST /api/assignments/[id]/accept", () => {
       mockCreateEntrega.mockResolvedValue(
         makeEntrega({ repoName: "kata-funcional-los-lambdas" })
       );
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(200);
     });
 
     it("llama a crearEntrega con los usernames del grupo", async () => {
@@ -242,8 +242,8 @@ describe("POST /api/assignments/[id]/accept", () => {
     });
 
     it("registra la entrega sin crear un nuevo repo si ya existe", async () => {
-      const res = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(), { params: { id: "a1" } });
+      expect(response.status).toBe(200);
       expect(mockCrearEntrega).not.toHaveBeenCalled();
       expect(mockCreateEntrega).toHaveBeenCalled();
     });

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -182,6 +182,7 @@ describe("POST /api/assignments/[id]/accept", () => {
         id,
         nombre: "Los Lambdas",
         alumnos: { getItems: () => githubUsernames.map((username) => ({ githubUsername: username })) },
+        usernamesDeMiembros: () => githubUsernames,
       };
     }
 

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -16,6 +16,7 @@ const mockGetEntregaDeUsuario = vi.fn();
 const mockCreateEntrega = vi.fn();
 const mockCrearEntrega = vi.fn();
 const mockRepoExists = vi.fn();
+const mockAddCollaborators = vi.fn();
 const mockGetGrupoDeAlumno = vi.fn();
 
 vi.mock("@/lib/session", () => ({
@@ -38,6 +39,7 @@ vi.mock("@/lib/repositories", () => ({
 vi.mock("@/lib/github", () => ({
   crearEntrega: (opts: unknown) => mockCrearEntrega(opts),
   repoExists: (name: string) => mockRepoExists(name),
+  addCollaborators: (repoName: string, usernames: string[]) => mockAddCollaborators(repoName, usernames),
 }));
 
 import { POST } from "./route";
@@ -234,12 +236,24 @@ describe("POST /api/assignments/[id]/accept", () => {
   });
 
   describe("repo ya existe", () => {
-    it("registra la entrega sin crear un nuevo repo si ya existe", async () => {
+    beforeEach(() => {
       mockRepoExists.mockResolvedValue(true);
+      mockAddCollaborators.mockResolvedValue(undefined);
+    });
+
+    it("registra la entrega sin crear un nuevo repo si ya existe", async () => {
       const res = await POST(makeRequest(), { params: { id: "a1" } });
       expect(res.status).toBe(200);
       expect(mockCrearEntrega).not.toHaveBeenCalled();
       expect(mockCreateEntrega).toHaveBeenCalled();
+    });
+
+    it("agrega al usuario como colaborador del repo existente", async () => {
+      await POST(makeRequest(), { params: { id: "a1" } });
+      expect(mockAddCollaborators).toHaveBeenCalledWith(
+        expect.any(String),
+        ["juangarcia"]
+      );
     });
   });
 });

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { getAssignment, getEntregaDeUsuario, createEntrega, getGrupoDeAlumnoEnAssignment } from "@/lib/repositories";
 import { GrupoNoAsignadoError, type ParticipantesResueltos } from "@/domain/entities";
-import { crearEntrega, repoExists } from "@/lib/github";
+import { crearEntrega, repoExists, addCollaborators } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { internalServerError } from "@/lib/api-errors";
@@ -59,8 +59,12 @@ export async function POST(
     // ── Nombre del repo ──────────────────────────────────────
     const candidateRepoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
 
-    // Verificar que no exista ya (por si otro miembro del grupo aceptó)
+    // Verificar que no exista ya (por si otro miembro del grupo aceptó primero)
     if (await repoExists(candidateRepoName)) {
+      // El repo fue creado por otro miembro: agregar al usuario actual como
+      // colaborador y registrar la entrega. Sin este addCollaborators el
+      // alumno quedaría sin acceso al repo que ya existe en GitHub.
+      await addCollaborators(candidateRepoName, [user.githubUsername]);
       const org = process.env.GITHUB_ORG ?? "pdep-mn-utn";
       const entrega = await createEntrega({
         assignmentId: assignment.id,

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -51,10 +51,7 @@ export async function POST(
     }
     const { usernames, grupoId } = participantes;
 
-    // ── Extraer nombre del template (sin org) ────────────────
-    const templateRepo = assignment.templateRepo.includes("/")
-      ? assignment.templateRepo.split("/").pop()!
-      : assignment.templateRepo;
+    const templateRepo = assignment.nombreDelTemplate();
 
     // ── Nombre del repo ──────────────────────────────────────
     const candidateRepoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PdepUser } from "@/types";
+import {
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  GrupoLlenoError,
+} from "@/domain/entities";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockUnirseAGrupo = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  unirseAGrupo: (params: unknown) => mockUnirseAGrupo(params),
+}));
+
+import { POST } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeUser(overrides?: Partial<PdepUser>): PdepUser {
+  return {
+    githubUsername: "ana",
+    name: "Ana García",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+function makeAlumno(id = "alumno-ana", github = "ana") {
+  return { id, githubUsername: github };
+}
+
+function makeGrupoEntity(overrides = {}) {
+  return {
+    id: "g1",
+    nombre: "Los Lambdas",
+    paradigma: "funcional",
+    maxIntegrantes: 3,
+    isOpen: () => true,
+    alumnos: { getItems: () => [{ githubUsername: "bob" }, { githubUsername: "ana" }] },
+    ...overrides,
+  };
+}
+
+function makeRequest(): Request {
+  return new Request(
+    "http://localhost/api/assignments/a1/grupos/g1/join",
+    { method: "POST" }
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockUnirseAGrupo.mockResolvedValue(makeGrupoEntity());
+  });
+
+  it("devuelve 200 con el grupo actualizado", async () => {
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.id).toBe("g1");
+    expect(data.miembros).toContain("ana");
+  });
+
+  it("llama a unirseAGrupo con grupoId y alumnoId", async () => {
+    await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(mockUnirseAGrupo).toHaveBeenCalledWith({
+      grupoId: "g1",
+      alumnoId: "alumno-ana",
+    });
+  });
+
+  it("devuelve 404 si el alumno no está registrado", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(404);
+    expect(mockUnirseAGrupo).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 409 si las inscripciones están cerradas", async () => {
+    mockUnirseAGrupo.mockRejectedValue(new InscripcionesCerradasError("a1"));
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(409);
+  });
+
+  it("devuelve 409 si el alumno ya está en otro grupo del assignment", async () => {
+    mockUnirseAGrupo.mockRejectedValue(
+      new AlumnoYaEnGrupoDelAssignmentError("a1", "ana")
+    );
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(409);
+  });
+
+  it("devuelve 409 si el grupo está lleno", async () => {
+    mockUnirseAGrupo.mockRejectedValue(new GrupoLlenoError("g1", 3));
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(409);
+  });
+
+  it("devuelve 500 para errores inesperados", async () => {
+    mockUnirseAGrupo.mockRejectedValue(new Error("DB exploded"));
+    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
@@ -69,9 +69,9 @@ describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
   });
 
   it("devuelve 200 con el grupo actualizado", async () => {
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.id).toBe("g1");
     expect(data.miembros).toContain("ana");
   });
@@ -86,34 +86,34 @@ describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
 
   it("devuelve 404 si el alumno no está registrado", async () => {
     mockGetAlumnoByGithub.mockResolvedValue(null);
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(404);
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(404);
     expect(mockUnirseAGrupo).not.toHaveBeenCalled();
   });
 
   it("devuelve 409 si las inscripciones están cerradas", async () => {
     mockUnirseAGrupo.mockRejectedValue(new InscripcionesCerradasError("a1"));
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(409);
   });
 
   it("devuelve 409 si el alumno ya está en otro grupo del assignment", async () => {
     mockUnirseAGrupo.mockRejectedValue(
       new AlumnoYaEnGrupoDelAssignmentError("a1", "ana")
     );
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(409);
   });
 
   it("devuelve 409 si el grupo está lleno", async () => {
     mockUnirseAGrupo.mockRejectedValue(new GrupoLlenoError("g1", 3));
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(409);
   });
 
   it("devuelve 500 para errores inesperados", async () => {
     mockUnirseAGrupo.mockRejectedValue(new Error("DB exploded"));
-    const res = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(res.status).toBe(500);
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
@@ -47,6 +47,7 @@ function makeGrupoEntity(overrides = {}) {
     maxIntegrantes: 3,
     isOpen: () => true,
     alumnos: { getItems: () => [{ githubUsername: "bob" }, { githubUsername: "ana" }] },
+    usernamesDeMiembros: () => ["bob", "ana"],
     ...overrides,
   };
 }

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
@@ -1,0 +1,69 @@
+import { NextResponse } from "next/server";
+import { requireUser } from "@/lib/session";
+import { getAlumnoByGithub, unirseAGrupo } from "@/lib/repositories";
+import {
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  GrupoLlenoError,
+} from "@/domain/entities";
+import { internalServerError } from "@/lib/api-errors";
+import type { Grupo } from "@/domain/entities";
+
+function serializarGrupo(grupo: Grupo) {
+  return {
+    id: grupo.id,
+    nombre: grupo.nombre,
+    paradigma: grupo.paradigma,
+    maxIntegrantes: grupo.maxIntegrantes,
+    estaLleno: !grupo.isOpen(),
+    miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+  };
+}
+
+export async function POST(
+  _req: Request,
+  { params }: { params: { id: string; grupoId: string } }
+) {
+  try {
+    const user = await requireUser();
+
+    const alumno = await getAlumnoByGithub(user.githubUsername);
+    if (!alumno) {
+      return NextResponse.json(
+        { error: "Alumno no registrado" },
+        { status: 404 }
+      );
+    }
+
+    const grupo = await unirseAGrupo({
+      grupoId: params.grupoId,
+      alumnoId: alumno.id,
+    });
+
+    return NextResponse.json(serializarGrupo(grupo));
+  } catch (error) {
+    if (error instanceof InscripcionesCerradasError) {
+      return NextResponse.json(
+        { error: "Las inscripciones a grupos están cerradas" },
+        { status: 409 }
+      );
+    }
+    if (error instanceof AlumnoYaEnGrupoDelAssignmentError) {
+      return NextResponse.json(
+        { error: "Ya estás en un grupo para este TP" },
+        { status: 409 }
+      );
+    }
+    if (error instanceof GrupoLlenoError) {
+      return NextResponse.json(
+        { error: "El grupo ya está completo" },
+        { status: 409 }
+      );
+    }
+    return internalServerError(
+      "POST /api/assignments/[id]/grupos/[grupoId]/join",
+      error,
+      { assignmentId: params.id, grupoId: params.grupoId }
+    );
+  }
+}

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
@@ -16,7 +16,7 @@ function serializarGrupo(grupo: Grupo) {
     paradigma: grupo.paradigma,
     maxIntegrantes: grupo.maxIntegrantes,
     estaLleno: !grupo.isOpen(),
-    miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+    miembros: grupo.usernamesDeMiembros(),
   };
 }
 

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -71,9 +71,9 @@ describe("GET /api/assignments/[id]/grupos", () => {
   });
 
   it("devuelve 200 con la lista de grupos serializados", async () => {
-    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data).toHaveLength(1);
     expect(data[0]).toMatchObject({
       id: "g1",
@@ -86,16 +86,16 @@ describe("GET /api/assignments/[id]/grupos", () => {
 
   it("devuelve lista vacía si no hay grupos", async () => {
     mockGetGruposDeAssignment.mockResolvedValue([]);
-    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data).toEqual([]);
   });
 
   it("devuelve 500 si el usuario no está autenticado", async () => {
     mockRequireUser.mockRejectedValue(new Error("redirect"));
-    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
-    expect(res.status).toBe(500);
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(response.status).toBe(500);
   });
 });
 
@@ -108,9 +108,9 @@ describe("POST /api/assignments/[id]/grupos", () => {
   });
 
   it("crea el grupo y devuelve 201 con el grupo serializado", async () => {
-    const res = await POST(makeRequest({ nombre: "Los Lambdas" }), { params: { id: "a1" } });
-    expect(res.status).toBe(201);
-    const data = await res.json();
+    const response = await POST(makeRequest({ nombre: "Los Lambdas" }), { params: { id: "a1" } });
+    expect(response.status).toBe(201);
+    const data = await response.json();
     expect(data.nombre).toBe("Los Lambdas");
     expect(data.miembros).toContain("ana");
   });
@@ -125,38 +125,38 @@ describe("POST /api/assignments/[id]/grupos", () => {
   });
 
   it("devuelve 400 si el body no tiene nombre", async () => {
-    const res = await POST(makeRequest({}), { params: { id: "a1" } });
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest({}), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
   });
 
   it("devuelve 404 si el alumno no está registrado", async () => {
     mockGetAlumnoByGithub.mockResolvedValue(null);
-    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(res.status).toBe(404);
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(404);
     expect(mockCrearGrupo).not.toHaveBeenCalled();
   });
 
   it("devuelve 400 si el assignment no es grupal", async () => {
     mockCrearGrupo.mockRejectedValue(new AssignmentNoGrupalError("a1"));
-    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
   });
 
   it("devuelve 409 si las inscripciones están cerradas", async () => {
     mockCrearGrupo.mockRejectedValue(new InscripcionesCerradasError("a1"));
-    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(409);
   });
 
   it("devuelve 409 si el alumno ya está en otro grupo del assignment", async () => {
     mockCrearGrupo.mockRejectedValue(new AlumnoYaEnGrupoDelAssignmentError("a1", "ana"));
-    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(409);
   });
 
   it("devuelve 500 para errores inesperados", async () => {
     mockCrearGrupo.mockRejectedValue(new Error("DB exploded"));
-    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(res.status).toBe(500);
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PdepUser } from "@/types";
+import {
+  AssignmentNoGrupalError,
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+} from "@/domain/entities";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockGetGruposDeAssignment = vi.fn();
+const mockCrearGrupo = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  getGruposDeAssignment: (id: string) => mockGetGruposDeAssignment(id),
+  crearGrupo: (params: unknown) => mockCrearGrupo(params),
+}));
+
+import { GET, POST } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeUser(overrides?: Partial<PdepUser>): PdepUser {
+  return {
+    githubUsername: "ana",
+    name: "Ana García",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+function makeAlumno(id = "alumno-ana", github = "ana") {
+  return { id, githubUsername: github };
+}
+
+function makeGrupoEntity(overrides = {}) {
+  return {
+    id: "g1",
+    nombre: "Los Lambdas",
+    paradigma: "funcional",
+    maxIntegrantes: 3,
+    isOpen: () => true,
+    alumnos: { getItems: () => [{ githubUsername: "ana" }] },
+    ...overrides,
+  };
+}
+
+function makeRequest(body?: unknown, method = "POST"): Request {
+  return new Request("http://localhost/api/assignments/a1/grupos", {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("GET /api/assignments/[id]/grupos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetGruposDeAssignment.mockResolvedValue([makeGrupoEntity()]);
+  });
+
+  it("devuelve 200 con la lista de grupos serializados", async () => {
+    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toHaveLength(1);
+    expect(data[0]).toMatchObject({
+      id: "g1",
+      nombre: "Los Lambdas",
+      maxIntegrantes: 3,
+      estaLleno: false,
+      miembros: ["ana"],
+    });
+  });
+
+  it("devuelve lista vacía si no hay grupos", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([]);
+    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data).toEqual([]);
+  });
+
+  it("devuelve 500 si el usuario no está autenticado", async () => {
+    mockRequireUser.mockRejectedValue(new Error("redirect"));
+    const res = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(res.status).toBe(500);
+  });
+});
+
+describe("POST /api/assignments/[id]/grupos", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockCrearGrupo.mockResolvedValue(makeGrupoEntity());
+  });
+
+  it("crea el grupo y devuelve 201 con el grupo serializado", async () => {
+    const res = await POST(makeRequest({ nombre: "Los Lambdas" }), { params: { id: "a1" } });
+    expect(res.status).toBe(201);
+    const data = await res.json();
+    expect(data.nombre).toBe("Los Lambdas");
+    expect(data.miembros).toContain("ana");
+  });
+
+  it("llama a crearGrupo con assignmentId, alumnoId y nombre", async () => {
+    await POST(makeRequest({ nombre: "Los Lambdas" }), { params: { id: "a1" } });
+    expect(mockCrearGrupo).toHaveBeenCalledWith({
+      assignmentId: "a1",
+      alumnoId: "alumno-ana",
+      nombre: "Los Lambdas",
+    });
+  });
+
+  it("devuelve 400 si el body no tiene nombre", async () => {
+    const res = await POST(makeRequest({}), { params: { id: "a1" } });
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 404 si el alumno no está registrado", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(res.status).toBe(404);
+    expect(mockCrearGrupo).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 400 si el assignment no es grupal", async () => {
+    mockCrearGrupo.mockRejectedValue(new AssignmentNoGrupalError("a1"));
+    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(res.status).toBe(400);
+  });
+
+  it("devuelve 409 si las inscripciones están cerradas", async () => {
+    mockCrearGrupo.mockRejectedValue(new InscripcionesCerradasError("a1"));
+    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(res.status).toBe(409);
+  });
+
+  it("devuelve 409 si el alumno ya está en otro grupo del assignment", async () => {
+    mockCrearGrupo.mockRejectedValue(new AlumnoYaEnGrupoDelAssignmentError("a1", "ana"));
+    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(res.status).toBe(409);
+  });
+
+  it("devuelve 500 para errores inesperados", async () => {
+    mockCrearGrupo.mockRejectedValue(new Error("DB exploded"));
+    const res = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -49,6 +49,7 @@ function makeGrupoEntity(overrides = {}) {
     maxIntegrantes: 3,
     isOpen: () => true,
     alumnos: { getItems: () => [{ githubUsername: "ana" }] },
+    usernamesDeMiembros: () => ["ana"],
     ...overrides,
   };
 }

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -25,7 +25,7 @@ function serializarGrupo(grupo: Grupo) {
     paradigma: grupo.paradigma,
     maxIntegrantes: grupo.maxIntegrantes,
     estaLleno: !grupo.isOpen(),
-    miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+    miembros: grupo.usernamesDeMiembros(),
   };
 }
 

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { requireUser } from "@/lib/session";
+import {
+  getAlumnoByGithub,
+  getGruposDeAssignment,
+  crearGrupo,
+} from "@/lib/repositories";
+import {
+  AssignmentNoGrupalError,
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+} from "@/domain/entities";
+import { internalServerError } from "@/lib/api-errors";
+import type { Grupo } from "@/domain/entities";
+
+const CrearGrupoSchema = z.object({
+  nombre: z.string().min(1).max(100),
+});
+
+function serializarGrupo(grupo: Grupo) {
+  return {
+    id: grupo.id,
+    nombre: grupo.nombre,
+    paradigma: grupo.paradigma,
+    maxIntegrantes: grupo.maxIntegrantes,
+    estaLleno: !grupo.isOpen(),
+    miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+  };
+}
+
+export async function GET(
+  _req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    await requireUser();
+    const grupos = await getGruposDeAssignment(params.id);
+    return NextResponse.json(grupos.map(serializarGrupo));
+  } catch (error) {
+    return internalServerError("GET /api/assignments/[id]/grupos", error, {
+      assignmentId: params.id,
+    });
+  }
+}
+
+export async function POST(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  try {
+    const user = await requireUser();
+
+    const body = await req.json().catch(() => null);
+    const parsed = CrearGrupoSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Datos inválidos", fields: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const alumno = await getAlumnoByGithub(user.githubUsername);
+    if (!alumno) {
+      return NextResponse.json(
+        { error: "Alumno no registrado" },
+        { status: 404 }
+      );
+    }
+
+    const grupo = await crearGrupo({
+      assignmentId: params.id,
+      alumnoId: alumno.id,
+      nombre: parsed.data.nombre,
+    });
+
+    return NextResponse.json(serializarGrupo(grupo), { status: 201 });
+  } catch (error) {
+    if (error instanceof AssignmentNoGrupalError) {
+      return NextResponse.json(
+        { error: "Este assignment no es grupal" },
+        { status: 400 }
+      );
+    }
+    if (error instanceof InscripcionesCerradasError) {
+      return NextResponse.json(
+        { error: "Las inscripciones a grupos están cerradas" },
+        { status: 409 }
+      );
+    }
+    if (error instanceof AlumnoYaEnGrupoDelAssignmentError) {
+      return NextResponse.json(
+        { error: "Ya estás en un grupo para este TP" },
+        { status: 409 }
+      );
+    }
+    return internalServerError("POST /api/assignments/[id]/grupos", error, {
+      assignmentId: params.id,
+    });
+  }
+}

--- a/src/app/api/assignments/[id]/inscripciones/route.test.ts
+++ b/src/app/api/assignments/[id]/inscripciones/route.test.ts
@@ -48,8 +48,8 @@ describe("PATCH /api/assignments/[id]/inscripciones", () => {
     mockGuardAdmin.mockResolvedValue(
       NextResponse.json({ error: "No autorizado" }, { status: 401 })
     );
-    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
-    expect(res.status).toBe(401);
+    const response = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(response.status).toBe(401);
     expect(mockSetInscripcionesCerradas).not.toHaveBeenCalled();
   });
 
@@ -57,9 +57,9 @@ describe("PATCH /api/assignments/[id]/inscripciones", () => {
     mockSetInscripcionesCerradas.mockResolvedValue(
       makeAssignment({ inscripcionesCerradas: true })
     );
-    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.inscripcionesCerradas).toBe(true);
     expect(mockSetInscripcionesCerradas).toHaveBeenCalledWith("a1", true);
   });
@@ -68,28 +68,28 @@ describe("PATCH /api/assignments/[id]/inscripciones", () => {
     mockSetInscripcionesCerradas.mockResolvedValue(
       makeAssignment({ inscripcionesCerradas: false })
     );
-    const res = await PATCH(makeRequest({ cerrada: false }), { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await PATCH(makeRequest({ cerrada: false }), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.inscripcionesCerradas).toBe(false);
     expect(mockSetInscripcionesCerradas).toHaveBeenCalledWith("a1", false);
   });
 
   it("devuelve 400 si el body no tiene el campo cerrada", async () => {
-    const res = await PATCH(makeRequest({}), { params: { id: "a1" } });
-    expect(res.status).toBe(400);
+    const response = await PATCH(makeRequest({}), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
     expect(mockSetInscripcionesCerradas).not.toHaveBeenCalled();
   });
 
   it("devuelve 404 si el assignment grupal no existe", async () => {
     mockSetInscripcionesCerradas.mockResolvedValue(null);
-    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "no-existe" } });
-    expect(res.status).toBe(404);
+    const response = await PATCH(makeRequest({ cerrada: true }), { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
   });
 
   it("devuelve 500 para errores inesperados", async () => {
     mockSetInscripcionesCerradas.mockRejectedValue(new Error("DB exploded"));
-    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
-    expect(res.status).toBe(500);
+    const response = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/inscripciones/route.test.ts
+++ b/src/app/api/assignments/[id]/inscripciones/route.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGuardAdmin = vi.fn();
+const mockSetInscripcionesCerradas = vi.fn();
+
+vi.mock("@/lib/api-auth", () => ({
+  guardAdmin: () => mockGuardAdmin(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  setInscripcionesCerradas: (id: string, cerrada: boolean) =>
+    mockSetInscripcionesCerradas(id, cerrada),
+}));
+
+import { PATCH } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeAssignment(overrides = {}) {
+  return {
+    id: "a1",
+    inscripcionesCerradas: false,
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/assignments/a1/inscripciones", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("PATCH /api/assignments/[id]/inscripciones", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGuardAdmin.mockResolvedValue(null);
+    mockSetInscripcionesCerradas.mockResolvedValue(makeAssignment());
+  });
+
+  it("devuelve 401 si no es admin", async () => {
+    mockGuardAdmin.mockResolvedValue(
+      NextResponse.json({ error: "No autorizado" }, { status: 401 })
+    );
+    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(res.status).toBe(401);
+    expect(mockSetInscripcionesCerradas).not.toHaveBeenCalled();
+  });
+
+  it("cierra las inscripciones y devuelve 200", async () => {
+    mockSetInscripcionesCerradas.mockResolvedValue(
+      makeAssignment({ inscripcionesCerradas: true })
+    );
+    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.inscripcionesCerradas).toBe(true);
+    expect(mockSetInscripcionesCerradas).toHaveBeenCalledWith("a1", true);
+  });
+
+  it("abre las inscripciones y devuelve 200", async () => {
+    mockSetInscripcionesCerradas.mockResolvedValue(
+      makeAssignment({ inscripcionesCerradas: false })
+    );
+    const res = await PATCH(makeRequest({ cerrada: false }), { params: { id: "a1" } });
+    expect(res.status).toBe(200);
+    const data = await res.json();
+    expect(data.inscripcionesCerradas).toBe(false);
+    expect(mockSetInscripcionesCerradas).toHaveBeenCalledWith("a1", false);
+  });
+
+  it("devuelve 400 si el body no tiene el campo cerrada", async () => {
+    const res = await PATCH(makeRequest({}), { params: { id: "a1" } });
+    expect(res.status).toBe(400);
+    expect(mockSetInscripcionesCerradas).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 404 si el assignment grupal no existe", async () => {
+    mockSetInscripcionesCerradas.mockResolvedValue(null);
+    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "no-existe" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("devuelve 500 para errores inesperados", async () => {
+    mockSetInscripcionesCerradas.mockRejectedValue(new Error("DB exploded"));
+    const res = await PATCH(makeRequest({ cerrada: true }), { params: { id: "a1" } });
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/app/api/assignments/[id]/inscripciones/route.ts
+++ b/src/app/api/assignments/[id]/inscripciones/route.ts
@@ -1,0 +1,51 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { guardAdmin } from "@/lib/api-auth";
+import { setInscripcionesCerradas } from "@/lib/repositories";
+import { internalServerError } from "@/lib/api-errors";
+
+const InscripcionesSchema = z.object({
+  cerrada: z.boolean(),
+});
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const unauthorized = await guardAdmin();
+  if (unauthorized) return unauthorized;
+
+  try {
+    const body = await req.json().catch(() => null);
+    const parsed = InscripcionesSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Datos inválidos", fields: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const assignment = await setInscripcionesCerradas(
+      params.id,
+      parsed.data.cerrada
+    );
+
+    if (!assignment) {
+      return NextResponse.json(
+        { error: "Assignment grupal no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    return NextResponse.json({
+      id: assignment.id,
+      inscripcionesCerradas: assignment.inscripcionesCerradas,
+    });
+  } catch (error) {
+    return internalServerError(
+      "PATCH /api/assignments/[id]/inscripciones",
+      error,
+      { assignmentId: params.id }
+    );
+  }
+}

--- a/src/app/api/assignments/[id]/repos/route.test.ts
+++ b/src/app/api/assignments/[id]/repos/route.test.ts
@@ -29,25 +29,25 @@ import { DELETE } from "./route";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const a = new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.templateRepo = "kata-template";
-  a.tipo = "individual";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date("2026-01-01");
-  return Object.assign(a, overrides);
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.templateRepo = "kata-template";
+  assignment.tipo = "individual";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(repoName?: string): Entrega {
-  const e = new Entrega();
-  e.id = crypto.randomUUID();
-  e.repoName = repoName;
-  e.repoUrl = repoName ? `https://github.com/org/${repoName}` : undefined;
-  e.githubUsernames = ["alumno1"];
-  e.createdAt = new Date();
-  return e;
+  const entrega = new Entrega();
+  entrega.id = crypto.randomUUID();
+  entrega.repoName = repoName;
+  entrega.repoUrl = repoName ? `https://github.com/org/${repoName}` : undefined;
+  entrega.githubUsernames = ["alumno1"];
+  entrega.createdAt = new Date();
+  return entrega;
 }
 
 function makeRequest(): Request {
@@ -70,15 +70,15 @@ describe("DELETE /api/assignments/[id]/repos", () => {
     mockGuardAdmin.mockResolvedValue(
       new Response(JSON.stringify({ error: "No autorizado" }), { status: 401 })
     );
-    const res = await DELETE(makeRequest(), { params: { id: "a1" } });
-    expect(res.status).toBe(401);
+    const response = await DELETE(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(401);
   });
 
   it("devuelve 404 si el assignment no existe", async () => {
     mockGetAssignment.mockResolvedValue(null);
-    const res = await DELETE(makeRequest(), { params: { id: "no-existe" } });
-    expect(res.status).toBe(404);
-    const data = await res.json();
+    const response = await DELETE(makeRequest(), { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
+    const data = await response.json();
     expect(data.error).toContain("no encontrado");
   });
 
@@ -89,10 +89,10 @@ describe("DELETE /api/assignments/[id]/repos", () => {
       makeEntrega("kata-funcional-alumno2"),
     ]);
 
-    const res = await DELETE(makeRequest(), { params: { id: "a1" } });
+    const response = await DELETE(makeRequest(), { params: { id: "a1" } });
 
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.ok).toBe(true);
     expect(data.deleted).toBe(2);
   });
@@ -118,9 +118,9 @@ describe("DELETE /api/assignments/[id]/repos", () => {
       makeEntrega(undefined), // pendiente, sin repo
     ]);
 
-    const res = await DELETE(makeRequest(), { params: { id: "a1" } });
+    const response = await DELETE(makeRequest(), { params: { id: "a1" } });
 
-    const data = await res.json();
+    const data = await response.json();
     expect(data.deleted).toBe(1);
     expect(mockDeleteRepo).toHaveBeenCalledTimes(1);
     expect(mockDeleteRepo).toHaveBeenCalledWith("kata-funcional-alumno1");
@@ -130,10 +130,10 @@ describe("DELETE /api/assignments/[id]/repos", () => {
     mockGetAssignment.mockResolvedValue(makeAssignment());
     mockGetEntregas.mockResolvedValue([]);
 
-    const res = await DELETE(makeRequest(), { params: { id: "a1" } });
+    const response = await DELETE(makeRequest(), { params: { id: "a1" } });
 
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.ok).toBe(true);
     expect(data.deleted).toBe(0);
     expect(mockDeleteRepo).not.toHaveBeenCalled();

--- a/src/app/api/assignments/[id]/repos/route.ts
+++ b/src/app/api/assignments/[id]/repos/route.ts
@@ -16,7 +16,7 @@ export async function DELETE(
   }
 
   const entregas = await getEntregas(params.id);
-  const repoNames = entregas.map((e) => e.repoName).filter(Boolean) as string[];
+  const repoNames = entregas.map((entrega) => entrega.repoName).filter(Boolean) as string[];
 
   if (repoNames.length === 0) {
     return NextResponse.json({ ok: true, deleted: 0 });

--- a/src/app/api/assignments/[id]/route.test.ts
+++ b/src/app/api/assignments/[id]/route.test.ts
@@ -23,16 +23,16 @@ import { DELETE, PATCH } from "./route";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const a = new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.descripcion = "";
-  a.templateRepo = "kata-template";
-  a.tipo = "individual";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date("2026-01-01");
-  return Object.assign(a, overrides);
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "";
+  assignment.templateRepo = "kata-template";
+  assignment.tipo = "individual";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
 }
 
 function makeRequest(method: string, body?: unknown): Request {
@@ -54,23 +54,23 @@ describe("DELETE /api/assignments/[id]", () => {
 
   it("devuelve 401 si no es admin", async () => {
     mockRequireAdmin.mockRejectedValue(new Error("redirect"));
-    const res = await DELETE(makeRequest("DELETE"), { params: { id: "a1" } });
-    expect(res.status).toBe(401);
+    const response = await DELETE(makeRequest("DELETE"), { params: { id: "a1" } });
+    expect(response.status).toBe(401);
   });
 
   it("devuelve 404 si el assignment no existe", async () => {
     mockGetAssignment.mockResolvedValue(undefined);
-    const res = await DELETE(makeRequest("DELETE"), { params: { id: "no-existe" } });
-    expect(res.status).toBe(404);
-    const data = await res.json();
+    const response = await DELETE(makeRequest("DELETE"), { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
+    const data = await response.json();
     expect(data.error).toContain("no encontrado");
   });
 
   it("elimina el assignment y devuelve ok: true", async () => {
     mockGetAssignment.mockResolvedValue(makeAssignment());
-    const res = await DELETE(makeRequest("DELETE"), { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const response = await DELETE(makeRequest("DELETE"), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.ok).toBe(true);
   });
 
@@ -91,16 +91,16 @@ describe("PATCH /api/assignments/[id]", () => {
 
   it("devuelve 401 si no es admin", async () => {
     mockRequireAdmin.mockRejectedValue(new Error("redirect"));
-    const req = makeRequest("PATCH", { titulo: "Nuevo" });
-    const res = await PATCH(req, { params: { id: "a1" } });
-    expect(res.status).toBe(401);
+    const request = makeRequest("PATCH", { titulo: "Nuevo" });
+    const response = await PATCH(request, { params: { id: "a1" } });
+    expect(response.status).toBe(401);
   });
 
   it("devuelve 404 si el assignment no existe", async () => {
     mockGetAssignment.mockResolvedValue(undefined);
-    const req = makeRequest("PATCH", { titulo: "Nuevo" });
-    const res = await PATCH(req, { params: { id: "no-existe" } });
-    expect(res.status).toBe(404);
+    const request = makeRequest("PATCH", { titulo: "Nuevo" });
+    const response = await PATCH(request, { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
   });
 
   it("actualiza el assignment y devuelve el objeto actualizado", async () => {
@@ -109,10 +109,10 @@ describe("PATCH /api/assignments/[id]", () => {
     mockGetAssignment.mockResolvedValue(original);
     mockUpdateAssignment.mockResolvedValue(updated);
 
-    const req = makeRequest("PATCH", { titulo: "Actualizado" });
-    const res = await PATCH(req, { params: { id: "a1" } });
-    expect(res.status).toBe(200);
-    const data = await res.json();
+    const request = makeRequest("PATCH", { titulo: "Actualizado" });
+    const response = await PATCH(request, { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
     expect(data.titulo).toBe("Actualizado");
   });
 
@@ -120,8 +120,8 @@ describe("PATCH /api/assignments/[id]", () => {
     mockGetAssignment.mockResolvedValue(makeAssignment());
     mockUpdateAssignment.mockResolvedValue(makeAssignment({ paradigma: "logico" }));
 
-    const req = makeRequest("PATCH", { paradigma: "logico" });
-    await PATCH(req, { params: { id: "a1" } });
+    const request = makeRequest("PATCH", { paradigma: "logico" });
+    await PATCH(request, { params: { id: "a1" } });
     expect(mockUpdateAssignment).toHaveBeenCalledWith("a1", { paradigma: "logico" });
   });
 });

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -93,8 +93,8 @@ describe("PATCH /api/perfil", () => {
   });
 
   it("actualiza Sheets y DB en un mismo request", async () => {
-    const res = await PATCH(makeRequest(validBody));
-    expect(res.status).toBe(200);
+    const response = await PATCH(makeRequest(validBody));
+    expect(response.status).toBe(200);
     expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledTimes(1);
     expect(mockUpsertAlumno).toHaveBeenCalledTimes(1);
   });
@@ -126,8 +126,8 @@ describe("PATCH /api/perfil", () => {
     mockUpsertAlumno.mockRejectedValue(
       new FakeLegajoConflictError("12345", "otro-alumno")
     );
-    const res = await PATCH(makeRequest(validBody));
-    expect(res.status).toBe(400);
+    const response = await PATCH(makeRequest(validBody));
+    expect(response.status).toBe(400);
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
@@ -135,32 +135,32 @@ describe("PATCH /api/perfil", () => {
     mockUpsertAlumno.mockRejectedValue(
       new FakeLegajoConflictError("12345", "otro-alumno")
     );
-    const res = await PATCH(makeRequest(validBody));
-    const json = await res.json();
-    expect(res.status).toBe(400);
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
     expect(json.error).toContain("otro-alumno");
   });
 
   it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const res = await PATCH(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(res.status).toBe(400);
+    const response = await PATCH(makeRequest({ ...validBody, email: "no-es-email" }));
+    expect(response.status).toBe(400);
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    const res = await PATCH(makeRequest(validBody));
-    expect(res.status).toBe(409);
+    const response = await PATCH(makeRequest(validBody));
+    expect(response.status).toBe(409);
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
     mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
-    const res = await PATCH(makeRequest(validBody));
-    expect(res.status).toBe(500);
+    const response = await PATCH(makeRequest(validBody));
+    expect(response.status).toBe(500);
   });
 
   describe("sincronización de grupos desde planilla", () => {
@@ -174,19 +174,19 @@ describe("PATCH /api/perfil", () => {
     });
 
     it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const res = await PATCH(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await PATCH(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json.gruposSync).toBeUndefined();
     });
 
     it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
       mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
 
-      const res = await PATCH(makeRequest(validBody));
-      const json = await res.json();
+      const response = await PATCH(makeRequest(validBody));
+      const json = await response.json();
 
-      expect(res.status).toBe(200);
+      expect(response.status).toBe(200);
       expect(json.gruposSync).toBe("error");
       expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
     });

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -101,16 +101,16 @@ describe("POST /api/registro", () => {
   });
 
   it("usa el githubUsername del usuario autenticado cuando coincide con el body", async () => {
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(200);
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(200);
     const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
   it("devuelve 400 con field=githubUsername si el body trae un github distinto al de la sesión", async () => {
-    const res = await POST(makeRequest({ ...validBody, githubUsername: "attacker" }));
-    const json = await res.json();
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest({ ...validBody, githubUsername: "attacker" }));
+    const json = await response.json();
+    expect(response.status).toBe(400);
     expect(json.field).toBe("githubUsername");
     expect(json.error).toContain("juangarcia");
     expect(json.error).toContain("attacker");
@@ -119,8 +119,8 @@ describe("POST /api/registro", () => {
   });
 
   it("compara githubUsername case-insensitive (no rechaza JuanGarcia vs juangarcia)", async () => {
-    const res = await POST(makeRequest({ ...validBody, githubUsername: "JuanGarcia" }));
-    expect(res.status).toBe(200);
+    const response = await POST(makeRequest({ ...validBody, githubUsername: "JuanGarcia" }));
+    expect(response.status).toBe(200);
     const [inputPasado] = mockUpsertAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
@@ -171,8 +171,8 @@ describe("POST /api/registro", () => {
     mockUpsertAlumno.mockRejectedValue(
       new FakeLegajoConflictError("12345", "otro-alumno")
     );
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(400);
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
@@ -180,33 +180,33 @@ describe("POST /api/registro", () => {
     mockUpsertAlumno.mockRejectedValue(
       new FakeLegajoConflictError("12345", "otro-alumno")
     );
-    const res = await POST(makeRequest(validBody));
-    const json = await res.json();
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
     expect(json.error).toContain("otro-alumno");
   });
 
   it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const res = await POST(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(res.status).toBe(400);
+    const response = await POST(makeRequest({ ...validBody, email: "no-es-email" }));
+    expect(response.status).toBe(400);
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
   });
 
   it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
     mockGetComisionActiva.mockResolvedValue(null);
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(409);
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(409);
     expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
     expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
     mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
-    const res = await POST(makeRequest(validBody));
-    expect(res.status).toBe(500);
-    const json = await res.json();
+    const response = await POST(makeRequest(validBody));
+    expect(response.status).toBe(500);
+    const json = await response.json();
     // El mensaje del error interno no debe filtrarse al cliente.
     expect(json.error).toBe("Error interno del servidor");
     expect(json.error).not.toContain("boom");
@@ -222,25 +222,25 @@ describe("POST /api/registro", () => {
 
     it("devuelve groupSubscription: 'added' en el body cuando la suscripción funciona", async () => {
       mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json).toEqual({ ok: true, groupSubscription: "added" });
     });
 
     it("devuelve groupSubscription: 'already_member' cuando el alumno ya estaba en el grupo", async () => {
       mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("already_member");
     });
 
     it("devuelve groupSubscription: 'skipped' cuando la feature está desactivada", async () => {
       mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("skipped");
     });
 
@@ -249,9 +249,9 @@ describe("POST /api/registro", () => {
         status: "error",
         error: "Sin permisos",
       });
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("error");
       // El alta en DB ya ocurrió antes de intentar la suscripción
       expect(mockUpsertAlumno).toHaveBeenCalledOnce();
@@ -300,19 +300,19 @@ describe("POST /api/registro", () => {
     });
 
     it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
-      expect(res.status).toBe(200);
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
+      expect(response.status).toBe(200);
       expect(json.gruposSync).toBeUndefined();
     });
 
     it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
       mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
 
-      const res = await POST(makeRequest(validBody));
-      const json = await res.json();
+      const response = await POST(makeRequest(validBody));
+      const json = await response.json();
 
-      expect(res.status).toBe(200);
+      expect(response.status).toBe(200);
       expect(json.gruposSync).toBe("error");
       // El alta no se deshace por un fallo en el hook accesorio
       expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
+import { Alumno } from "@/domain/entities";
+import { usernameCanonicoDe } from "@/types";
 import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 import { internalServerError } from "@/lib/api-errors";
 import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
@@ -36,8 +38,8 @@ export async function POST(req: Request) {
         { status: 400 }
       );
     }
-    const githubDelForm = body.githubUsername?.trim().toLowerCase();
-    if (githubDelForm && githubDelForm !== user.githubUsername.toLowerCase()) {
+    const githubDelForm = Alumno.normalizarUsername(body.githubUsername ?? "");
+    if (githubDelForm && githubDelForm !== usernameCanonicoDe(user)) {
       return NextResponse.json(
         {
           error: `Iniciaste sesión como @${user.githubUsername} pero completaste @${body.githubUsername}. Cerrá sesión y volvé a entrar con la cuenta correcta.`,

--- a/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
@@ -144,10 +144,12 @@ describe("GrupoSelector", () => {
       await user.type(screen.getByRole("textbox"), "Los Lambdas");
       await user.click(screen.getByRole("button", { name: /crear/i }));
 
-      expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/grupos", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ nombre: "Los Lambdas" }),
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/grupos", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ nombre: "Los Lambdas" }),
+        });
       });
     });
 
@@ -194,10 +196,12 @@ describe("GrupoSelector", () => {
 
       await user.click(screen.getByRole("button", { name: /unirme/i }));
 
-      expect(fetch).toHaveBeenCalledWith(
-        "/api/assignments/a1/grupos/g42/join",
-        { method: "POST" }
-      );
+      await waitFor(() => {
+        expect(fetch).toHaveBeenCalledWith(
+          "/api/assignments/a1/grupos/g42/join",
+          { method: "POST" }
+        );
+      });
     });
 
     it("llama a router.refresh() después de unirse exitosamente", async () => {

--- a/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { GrupoSelector } from "./grupo-selector";

--- a/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { GrupoSelector } from "./grupo-selector";
+import type { GrupoResumen } from "./mi-grupo";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRouterRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeGrupo(overrides: Partial<GrupoResumen> = {}): GrupoResumen {
+  return {
+    id: "g1",
+    nombre: "Los Lambdas",
+    paradigma: "objetos",
+    maxIntegrantes: 3,
+    estaLleno: false,
+    miembros: ["bob"],
+    ...overrides,
+  };
+}
+
+function mockFetch(ok: boolean, data: object = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok, json: async () => data })
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("GrupoSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRouterRefresh.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("inscripciones cerradas", () => {
+    it("muestra mensaje de inscripciones cerradas", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[]}
+          inscripcionesCerradas={true}
+        />
+      );
+      expect(screen.getByTestId("inscripciones-cerradas")).toBeInTheDocument();
+      expect(screen.getByText(/Las inscripciones están cerradas/)).toBeInTheDocument();
+    });
+
+    it("no muestra el formulario de creación si están cerradas", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[]}
+          inscripcionesCerradas={true}
+        />
+      );
+      expect(screen.queryByRole("textbox")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("sin grupos disponibles", () => {
+    it("muestra el formulario de crear grupo", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[]}
+          inscripcionesCerradas={false}
+        />
+      );
+      expect(screen.getByRole("textbox", { name: /nombre del grupo/i })).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /crear/i })).toBeInTheDocument();
+    });
+
+    it("el botón Crear está deshabilitado si el nombre está vacío", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[]}
+          inscripcionesCerradas={false}
+        />
+      );
+      expect(screen.getByRole("button", { name: /crear/i })).toBeDisabled();
+    });
+  });
+
+  describe("con grupos abiertos", () => {
+    it("muestra la lista de grupos con cupo", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo({ nombre: "Los Lambdas" }), makeGrupo({ id: "g2", nombre: "Los Monads" })]}
+          inscripcionesCerradas={false}
+        />
+      );
+      expect(screen.getByText("Los Lambdas")).toBeInTheDocument();
+      expect(screen.getByText("Los Monads")).toBeInTheDocument();
+    });
+
+    it("no muestra grupos llenos", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo({ estaLleno: true, nombre: "Grupo Lleno" })]}
+          inscripcionesCerradas={false}
+        />
+      );
+      expect(screen.queryByText("Grupo Lleno")).not.toBeInTheDocument();
+    });
+
+    it("muestra mensaje cuando todos los grupos están llenos", () => {
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo({ estaLleno: true })]}
+          inscripcionesCerradas={false}
+        />
+      );
+      expect(
+        screen.getByText(/todos los grupos están completos/i)
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("crear grupo", () => {
+    it("llama al endpoint correcto con el nombre ingresado", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GrupoSelector assignmentId="a1" grupos={[]} inscripcionesCerradas={false} />
+      );
+
+      await user.type(screen.getByRole("textbox"), "Los Lambdas");
+      await user.click(screen.getByRole("button", { name: /crear/i }));
+
+      expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/grupos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nombre: "Los Lambdas" }),
+      });
+    });
+
+    it("llama a router.refresh() después de crear exitosamente", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GrupoSelector assignmentId="a1" grupos={[]} inscripcionesCerradas={false} />
+      );
+
+      await user.type(screen.getByRole("textbox"), "Los Lambdas");
+      await user.click(screen.getByRole("button", { name: /crear/i }));
+
+      await waitFor(() => expect(mockRouterRefresh).toHaveBeenCalled());
+    });
+
+    it("muestra error del servidor si la creación falla", async () => {
+      const user = userEvent.setup();
+      mockFetch(false, { error: "Ya estás en un grupo para este TP" });
+      render(
+        <GrupoSelector assignmentId="a1" grupos={[]} inscripcionesCerradas={false} />
+      );
+
+      await user.type(screen.getByRole("textbox"), "Los Lambdas");
+      await user.click(screen.getByRole("button", { name: /crear/i }));
+
+      expect(
+        await screen.findByText("Ya estás en un grupo para este TP")
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("unirse a grupo", () => {
+    it("llama al endpoint de join con el grupoId correcto", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo({ id: "g42" })]}
+          inscripcionesCerradas={false}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /unirme/i }));
+
+      expect(fetch).toHaveBeenCalledWith(
+        "/api/assignments/a1/grupos/g42/join",
+        { method: "POST" }
+      );
+    });
+
+    it("llama a router.refresh() después de unirse exitosamente", async () => {
+      const user = userEvent.setup();
+      mockFetch(true);
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo()]}
+          inscripcionesCerradas={false}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /unirme/i }));
+
+      await waitFor(() => expect(mockRouterRefresh).toHaveBeenCalled());
+    });
+
+    it("muestra error si el grupo está lleno al momento de unirse", async () => {
+      const user = userEvent.setup();
+      mockFetch(false, { error: "El grupo ya está completo" });
+      render(
+        <GrupoSelector
+          assignmentId="a1"
+          grupos={[makeGrupo()]}
+          inscripcionesCerradas={false}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: /unirme/i }));
+
+      expect(
+        await screen.findByText("El grupo ya está completo")
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/app/assignments/[id]/grupo/grupo-selector.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useApiCall } from "@/app/hooks/useApiCall";
+import type { GrupoResumen } from "./mi-grupo";
+
+export function GrupoSelector({
+  assignmentId,
+  grupos,
+  inscripcionesCerradas,
+}: {
+  assignmentId: string;
+  grupos: GrupoResumen[];
+  inscripcionesCerradas: boolean;
+}) {
+  const router = useRouter();
+  const { loading, error, call } = useApiCall();
+  const [nombreNuevoGrupo, setNombreNuevoGrupo] = useState("");
+  const [grupoJoiningId, setGrupoJoiningId] = useState<string | null>(null);
+
+  async function handleCrear(event: React.FormEvent) {
+    event.preventDefault();
+    await call(async () => {
+      const res = await fetch(`/api/assignments/${assignmentId}/grupos`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ nombre: nombreNuevoGrupo }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Error al crear el grupo");
+      }
+      router.refresh();
+    });
+  }
+
+  async function handleUnirse(grupoId: string) {
+    setGrupoJoiningId(grupoId);
+    await call(async () => {
+      const res = await fetch(
+        `/api/assignments/${assignmentId}/grupos/${grupoId}/join`,
+        { method: "POST" }
+      );
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error ?? "Error al unirse al grupo");
+      }
+      router.refresh();
+    });
+    setGrupoJoiningId(null);
+  }
+
+  if (inscripcionesCerradas) {
+    return (
+      <div
+        className="bg-yellow-50 border border-yellow-200 rounded-lg p-6 text-center"
+        data-testid="inscripciones-cerradas"
+      >
+        <p className="text-yellow-800 font-medium">
+          Las inscripciones están cerradas
+        </p>
+        <p className="text-yellow-700 text-sm mt-1">
+          Contactá a tu docente para que te asigne un grupo.
+        </p>
+      </div>
+    );
+  }
+
+  const gruposAbiertos = grupos.filter((grupo) => !grupo.estaLleno);
+
+  return (
+    <div className="space-y-6">
+      {error && (
+        <p className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg px-4 py-2">
+          {error}
+        </p>
+      )}
+
+      <section>
+        <h2 className="text-base font-semibold mb-3">Crear un grupo nuevo</h2>
+        <form onSubmit={handleCrear} className="flex gap-2">
+          <input
+            type="text"
+            value={nombreNuevoGrupo}
+            onChange={(event) => setNombreNuevoGrupo(event.target.value)}
+            placeholder="Nombre del grupo"
+            disabled={loading}
+            className="flex-1 border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-pdep-500 disabled:opacity-50"
+            aria-label="Nombre del grupo"
+          />
+          <button
+            type="submit"
+            disabled={loading || !nombreNuevoGrupo.trim()}
+            className="text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {loading && !grupoJoiningId ? "Creando…" : "Crear"}
+          </button>
+        </form>
+      </section>
+
+      {gruposAbiertos.length > 0 && (
+        <section>
+          <h2 className="text-base font-semibold mb-3">
+            Grupos con cupo disponible
+          </h2>
+          <ul className="space-y-2">
+            {gruposAbiertos.map((grupo) => (
+              <li
+                key={grupo.id}
+                className="bg-white border border-gray-200 rounded-lg p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+              >
+                <div>
+                  <p className="font-medium text-sm">{grupo.nombre}</p>
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {grupo.miembros.join(", ")} —{" "}
+                    {grupo.miembros.length}/{grupo.maxIntegrantes} integrantes
+                  </p>
+                </div>
+                <button
+                  onClick={() => handleUnirse(grupo.id)}
+                  disabled={loading}
+                  className="text-sm bg-white border border-pdep-600 text-pdep-600 px-4 py-1.5 rounded-lg font-medium hover:bg-pdep-50 transition-colors disabled:opacity-50 disabled:cursor-not-allowed flex-shrink-0"
+                >
+                  {grupoJoiningId === grupo.id ? "Uniéndose…" : "Unirme"}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {grupos.length > 0 && gruposAbiertos.length === 0 && (
+        <p className="text-sm text-gray-500">
+          Todos los grupos están completos. Creá uno nuevo.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/assignments/[id]/grupo/grupo-selector.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.tsx
@@ -31,6 +31,7 @@ export function GrupoSelector({
         const data = await response.json();
         throw new Error(data.error ?? "Error al crear el grupo");
       }
+      setNombreNuevoGrupo("");
       router.refresh();
     });
   }

--- a/src/app/assignments/[id]/grupo/grupo-selector.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.tsx
@@ -22,13 +22,13 @@ export function GrupoSelector({
   async function handleCrear(event: React.FormEvent) {
     event.preventDefault();
     await call(async () => {
-      const res = await fetch(`/api/assignments/${assignmentId}/grupos`, {
+      const response = await fetch(`/api/assignments/${assignmentId}/grupos`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ nombre: nombreNuevoGrupo }),
       });
-      if (!res.ok) {
-        const data = await res.json();
+      if (!response.ok) {
+        const data = await response.json();
         throw new Error(data.error ?? "Error al crear el grupo");
       }
       router.refresh();
@@ -38,12 +38,12 @@ export function GrupoSelector({
   async function handleUnirse(grupoId: string) {
     setGrupoJoiningId(grupoId);
     await call(async () => {
-      const res = await fetch(
+      const response = await fetch(
         `/api/assignments/${assignmentId}/grupos/${grupoId}/join`,
         { method: "POST" }
       );
-      if (!res.ok) {
-        const data = await res.json();
+      if (!response.ok) {
+        const data = await response.json();
         throw new Error(data.error ?? "Error al unirse al grupo");
       }
       router.refresh();

--- a/src/app/assignments/[id]/grupo/mi-grupo.test.tsx
+++ b/src/app/assignments/[id]/grupo/mi-grupo.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MiGrupo } from "./mi-grupo";
+import type { GrupoResumen } from "./mi-grupo";
+
+vi.mock("@/app/dashboard/accept-button", () => ({
+  AcceptButton: ({ assignmentId }: { assignmentId: string }) => (
+    <button data-testid="accept-button" data-assignment={assignmentId}>
+      Aceptar TP
+    </button>
+  ),
+}));
+
+function makeGrupo(overrides: Partial<GrupoResumen> = {}): GrupoResumen {
+  return {
+    id: "g1",
+    nombre: "Los Lambdas",
+    paradigma: "objetos",
+    maxIntegrantes: 3,
+    estaLleno: false,
+    miembros: ["ana", "bob"],
+    ...overrides,
+  };
+}
+
+describe("MiGrupo", () => {
+  it("muestra el nombre del grupo", () => {
+    render(<MiGrupo grupo={makeGrupo()} assignmentId="a1" tieneEntrega={false} />);
+    expect(screen.getByText("Los Lambdas")).toBeInTheDocument();
+  });
+
+  it("lista los usernames de los miembros", () => {
+    render(<MiGrupo grupo={makeGrupo()} assignmentId="a1" tieneEntrega={false} />);
+    expect(screen.getByText("@ana")).toBeInTheDocument();
+    expect(screen.getByText("@bob")).toBeInTheDocument();
+  });
+
+  it("muestra el contador de integrantes cuando el grupo no está lleno", () => {
+    render(
+      <MiGrupo
+        grupo={makeGrupo({ miembros: ["ana", "bob"], maxIntegrantes: 3, estaLleno: false })}
+        assignmentId="a1"
+        tieneEntrega={false}
+      />
+    );
+    expect(screen.getByText(/2\/3 integrantes/)).toBeInTheDocument();
+  });
+
+  it("muestra 'Completo' cuando el grupo está lleno", () => {
+    render(
+      <MiGrupo
+        grupo={makeGrupo({ estaLleno: true, maxIntegrantes: 2 })}
+        assignmentId="a1"
+        tieneEntrega={false}
+      />
+    );
+    expect(screen.getByText(/completo/i)).toBeInTheDocument();
+  });
+
+  it("muestra AcceptButton cuando no tiene entrega", () => {
+    render(<MiGrupo grupo={makeGrupo()} assignmentId="a1" tieneEntrega={false} />);
+    expect(screen.getByTestId("accept-button")).toBeInTheDocument();
+    expect(screen.getByTestId("accept-button")).toHaveAttribute("data-assignment", "a1");
+  });
+
+  it("no muestra AcceptButton cuando ya tiene entrega", () => {
+    render(<MiGrupo grupo={makeGrupo()} assignmentId="a1" tieneEntrega={true} />);
+    expect(screen.queryByTestId("accept-button")).not.toBeInTheDocument();
+  });
+});

--- a/src/app/assignments/[id]/grupo/mi-grupo.test.tsx
+++ b/src/app/assignments/[id]/grupo/mi-grupo.test.tsx
@@ -12,15 +12,17 @@ vi.mock("@/app/dashboard/accept-button", () => ({
 }));
 
 function makeGrupo(overrides: Partial<GrupoResumen> = {}): GrupoResumen {
-  return {
+  const base: GrupoResumen = {
     id: "g1",
     nombre: "Los Lambdas",
     paradigma: "objetos",
     maxIntegrantes: 3,
     estaLleno: false,
+    etiquetaCupo: "2/3 integrantes",
     miembros: ["ana", "bob"],
     ...overrides,
   };
+  return base;
 }
 
 describe("MiGrupo", () => {
@@ -38,23 +40,23 @@ describe("MiGrupo", () => {
   it("muestra el contador de integrantes cuando el grupo no está lleno", () => {
     render(
       <MiGrupo
-        grupo={makeGrupo({ miembros: ["ana", "bob"], maxIntegrantes: 3, estaLleno: false })}
+        grupo={makeGrupo({ estaLleno: false, etiquetaCupo: "2/3 integrantes" })}
         assignmentId="a1"
         tieneEntrega={false}
       />
     );
-    expect(screen.getByText(/2\/3 integrantes/)).toBeInTheDocument();
+    expect(screen.getByText("2/3 integrantes")).toBeInTheDocument();
   });
 
   it("muestra 'Completo' cuando el grupo está lleno", () => {
     render(
       <MiGrupo
-        grupo={makeGrupo({ estaLleno: true, maxIntegrantes: 2 })}
+        grupo={makeGrupo({ estaLleno: true, etiquetaCupo: "Completo (2/2)" })}
         assignmentId="a1"
         tieneEntrega={false}
       />
     );
-    expect(screen.getByText(/completo/i)).toBeInTheDocument();
+    expect(screen.getByText("Completo (2/2)")).toBeInTheDocument();
   });
 
   it("muestra AcceptButton cuando no tiene entrega", () => {

--- a/src/app/assignments/[id]/grupo/mi-grupo.tsx
+++ b/src/app/assignments/[id]/grupo/mi-grupo.tsx
@@ -6,6 +6,7 @@ export type GrupoResumen = {
   paradigma: string;
   maxIntegrantes: number;
   estaLleno: boolean;
+  etiquetaCupo: string;
   miembros: string[];
 };
 
@@ -29,9 +30,7 @@ export function MiGrupo({
               : "bg-green-50 text-green-700"
           }`}
         >
-          {grupo.estaLleno
-            ? `Completo (${grupo.maxIntegrantes}/${grupo.maxIntegrantes})`
-            : `${grupo.miembros.length}/${grupo.maxIntegrantes} integrantes`}
+          {grupo.etiquetaCupo}
         </span>
       </div>
 

--- a/src/app/assignments/[id]/grupo/mi-grupo.tsx
+++ b/src/app/assignments/[id]/grupo/mi-grupo.tsx
@@ -1,0 +1,60 @@
+import { AcceptButton } from "@/app/dashboard/accept-button";
+
+export type GrupoResumen = {
+  id: string;
+  nombre: string;
+  paradigma: string;
+  maxIntegrantes: number;
+  estaLleno: boolean;
+  miembros: string[];
+};
+
+export function MiGrupo({
+  grupo,
+  assignmentId,
+  tieneEntrega,
+}: {
+  grupo: GrupoResumen;
+  assignmentId: string;
+  tieneEntrega: boolean;
+}) {
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-6 space-y-4">
+      <div className="flex flex-wrap items-center gap-2">
+        <h2 className="text-lg font-semibold">{grupo.nombre}</h2>
+        <span
+          className={`text-xs px-2 py-0.5 rounded-full font-medium ${
+            grupo.estaLleno
+              ? "bg-gray-100 text-gray-600"
+              : "bg-green-50 text-green-700"
+          }`}
+        >
+          {grupo.estaLleno
+            ? `Completo (${grupo.maxIntegrantes}/${grupo.maxIntegrantes})`
+            : `${grupo.miembros.length}/${grupo.maxIntegrantes} integrantes`}
+        </span>
+      </div>
+
+      <div>
+        <p className="text-sm text-gray-500 mb-1">Integrantes:</p>
+        <ul className="space-y-1">
+          {grupo.miembros.map((username) => (
+            <li key={username} className="text-sm font-mono text-gray-700">
+              @{username}
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      {!tieneEntrega && (
+        <div className="pt-2 border-t border-gray-100">
+          <p className="text-xs text-gray-400 mb-2">
+            Ya estás en el grupo. Cuando todos estén listos, aceptá el TP para
+            crear el repositorio.
+          </p>
+          <AcceptButton assignmentId={assignmentId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/app/assignments/[id]/grupo/page.test.tsx
+++ b/src/app/assignments/[id]/grupo/page.test.tsx
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { PdepUser } from "@/types";
+import { GrupalAssignment, IndividualAssignment } from "@/domain/entities";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRequireUser = vi.fn();
+const mockGetAssignment = vi.fn();
+const mockGetGruposDeAssignment = vi.fn();
+const mockGetEntregaDeUsuario = vi.fn();
+const mockNotFound = vi.fn(() => { throw new Error("NOT_FOUND"); });
+
+vi.mock("@/lib/session", () => ({
+  requireUser: () => mockRequireUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAssignment: (id: string) => mockGetAssignment(id),
+  getGruposDeAssignment: (id: string) => mockGetGruposDeAssignment(id),
+  getEntregaDeUsuario: (assignmentId: string, username: string) =>
+    mockGetEntregaDeUsuario(assignmentId, username),
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+}));
+
+vi.mock("./grupo-selector", () => ({
+  GrupoSelector: (props: { assignmentId: string; inscripcionesCerradas: boolean }) => (
+    <div
+      data-testid="grupo-selector"
+      data-assignment={props.assignmentId}
+      data-cerradas={String(props.inscripcionesCerradas)}
+    >
+      GrupoSelector
+    </div>
+  ),
+}));
+
+vi.mock("./mi-grupo", () => ({
+  MiGrupo: (props: { grupo: { nombre: string }; tieneEntrega: boolean }) => (
+    <div
+      data-testid="mi-grupo"
+      data-nombre={props.grupo.nombre}
+      data-tiene-entrega={String(props.tieneEntrega)}
+    >
+      MiGrupo
+    </div>
+  ),
+}));
+
+import GrupoPage from "./page";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeUser(overrides?: Partial<PdepUser>): PdepUser {
+  return {
+    githubUsername: "ana",
+    name: "Ana García",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+function makeGrupalAssignment(overrides = {}): GrupalAssignment {
+  const a = new GrupalAssignment();
+  a.id = "a1";
+  a.titulo = "TP Grupal";
+  a.paradigma = "objetos";
+  a.slug = "tp-grupal";
+  a.maxIntegrantes = 3;
+  a.inscripcionesCerradas = false;
+  return Object.assign(a, overrides);
+}
+
+function makeGrupo(
+  id: string,
+  miembros: string[],
+  maxIntegrantes = 3,
+  nombre = `grupo-${id}`
+) {
+  return {
+    id,
+    nombre,
+    paradigma: "objetos",
+    maxIntegrantes,
+    isOpen: () => miembros.length < maxIntegrantes,
+    alumnos: {
+      getItems: () => miembros.map((username) => ({ githubUsername: username })),
+    },
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("GrupoPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetAssignment.mockResolvedValue(makeGrupalAssignment());
+    mockGetGruposDeAssignment.mockResolvedValue([]);
+    mockGetEntregaDeUsuario.mockResolvedValue(null);
+  });
+
+  it("llama a notFound si el assignment no existe", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+    await expect(GrupoPage({ params: { id: "a1" } })).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("llama a notFound si el assignment es individual", async () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    mockGetAssignment.mockResolvedValue(individual);
+    await expect(GrupoPage({ params: { id: "a1" } })).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("muestra el título del assignment", async () => {
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("TP Grupal");
+  });
+
+  it("muestra maxIntegrantes y paradigma en el subtítulo", async () => {
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("3 integrantes");
+    expect(html).toContain("objetos");
+  });
+
+  it("muestra GrupoSelector cuando el alumno no está en ningún grupo", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([
+      makeGrupo("g1", ["bob", "cora"]),
+    ]);
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("data-testid=\"grupo-selector\"");
+    expect(html).not.toContain("data-testid=\"mi-grupo\"");
+  });
+
+  it("muestra MiGrupo cuando el alumno ya está en un grupo", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([
+      makeGrupo("g1", ["ana", "bob"], 3, "Los Lambdas"),
+    ]);
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("data-testid=\"mi-grupo\"");
+    expect(html).toContain("Los Lambdas");
+    expect(html).not.toContain("data-testid=\"grupo-selector\"");
+  });
+
+  it("pasa tieneEntrega=false a MiGrupo cuando no hay entrega", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([
+      makeGrupo("g1", ["ana"], 3, "Los Lambdas"),
+    ]);
+    mockGetEntregaDeUsuario.mockResolvedValue(null);
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("data-tiene-entrega=\"false\"");
+  });
+
+  it("pasa tieneEntrega=true a MiGrupo cuando ya aceptó el TP", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([
+      makeGrupo("g1", ["ana"], 3, "Los Lambdas"),
+    ]);
+    mockGetEntregaDeUsuario.mockResolvedValue({ id: "e1", repoUrl: "https://github.com/x" });
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("data-tiene-entrega=\"true\"");
+  });
+
+  it("pasa inscripcionesCerradas al GrupoSelector", async () => {
+    mockGetAssignment.mockResolvedValue(
+      makeGrupalAssignment({ inscripcionesCerradas: true })
+    );
+    const element = await GrupoPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element);
+    expect(html).toContain("data-cerradas=\"true\"");
+  });
+
+  it("no consulta entrega si el alumno no tiene grupo (optimización)", async () => {
+    mockGetGruposDeAssignment.mockResolvedValue([
+      makeGrupo("g1", ["bob", "cora"]),
+    ]);
+    await GrupoPage({ params: { id: "a1" } });
+    expect(mockGetEntregaDeUsuario).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/assignments/[id]/grupo/page.test.tsx
+++ b/src/app/assignments/[id]/grupo/page.test.tsx
@@ -65,14 +65,14 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
 }
 
 function makeGrupalAssignment(overrides = {}): GrupalAssignment {
-  const a = new GrupalAssignment();
-  a.id = "a1";
-  a.titulo = "TP Grupal";
-  a.paradigma = "objetos";
-  a.slug = "tp-grupal";
-  a.maxIntegrantes = 3;
-  a.inscripcionesCerradas = false;
-  return Object.assign(a, overrides);
+  const assignment = new GrupalAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "TP Grupal";
+  assignment.paradigma = "objetos";
+  assignment.slug = "tp-grupal";
+  assignment.maxIntegrantes = 3;
+  assignment.inscripcionesCerradas = false;
+  return Object.assign(assignment, overrides);
 }
 
 function makeGrupo(

--- a/src/app/assignments/[id]/grupo/page.test.tsx
+++ b/src/app/assignments/[id]/grupo/page.test.tsx
@@ -81,12 +81,19 @@ function makeGrupo(
   maxIntegrantes = 3,
   nombre = `grupo-${id}`
 ) {
+  const lleno = miembros.length >= maxIntegrantes;
   return {
     id,
     nombre,
     paradigma: "objetos",
     maxIntegrantes,
-    isOpen: () => miembros.length < maxIntegrantes,
+    isOpen: () => !lleno,
+    estaLleno: () => lleno,
+    etiquetaCupo: () => lleno
+      ? `Completo (${maxIntegrantes}/${maxIntegrantes})`
+      : `${miembros.length}/${maxIntegrantes} integrantes`,
+    contieneA: (username: string) => miembros.some((member) => member.toLowerCase() === username.toLowerCase()),
+    usernamesDeMiembros: () => miembros,
     alumnos: {
       getItems: () => miembros.map((username) => ({ githubUsername: username })),
     },

--- a/src/app/assignments/[id]/grupo/page.tsx
+++ b/src/app/assignments/[id]/grupo/page.tsx
@@ -1,0 +1,85 @@
+import { notFound } from "next/navigation";
+import { requireUser } from "@/lib/session";
+import {
+  getAssignment,
+  getGruposDeAssignment,
+  getEntregaDeUsuario,
+} from "@/lib/repositories";
+import { GrupalAssignment } from "@/domain/entities";
+import { GrupoSelector } from "./grupo-selector";
+import { MiGrupo } from "./mi-grupo";
+import type { GrupoResumen } from "./mi-grupo";
+
+export default async function GrupoPage({
+  params,
+}: {
+  params: { id: string };
+}) {
+  const user = await requireUser();
+
+  const [assignment, grupos] = await Promise.all([
+    getAssignment(params.id),
+    getGruposDeAssignment(params.id),
+  ]);
+
+  if (!assignment || !(assignment instanceof GrupalAssignment)) {
+    notFound();
+  }
+
+  const miGrupo = grupos.find((grupo) =>
+    grupo.alumnos
+      .getItems()
+      .some(
+        (alumno) =>
+          alumno.githubUsername.toLowerCase() ===
+          user.githubUsername.toLowerCase()
+      )
+  );
+
+  const entrega = miGrupo
+    ? await getEntregaDeUsuario(assignment.id, user.githubUsername)
+    : null;
+
+  function serializar(grupo: (typeof grupos)[number]): GrupoResumen {
+    return {
+      id: grupo.id,
+      nombre: grupo.nombre,
+      paradigma: grupo.paradigma,
+      maxIntegrantes: grupo.maxIntegrantes,
+      estaLleno: !grupo.isOpen(),
+      miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+    };
+  }
+
+  return (
+    <div>
+      <div className="mb-6">
+        <a
+          href="/dashboard"
+          className="text-sm text-gray-500 hover:text-gray-700 transition-colors"
+        >
+          ← Volver al dashboard
+        </a>
+        <h1 className="text-2xl font-bold mt-2">{assignment.titulo}</h1>
+        <p className="text-gray-500 text-sm mt-1">
+          TP grupal · hasta {assignment.maxIntegrantes} integrantes ·{" "}
+          {assignment.paradigma}
+        </p>
+      </div>
+
+      {miGrupo ? (
+        <MiGrupo
+          grupo={serializar(miGrupo)}
+          assignmentId={params.id}
+          tieneEntrega={!!entrega}
+        />
+      ) : (
+        <GrupoSelector
+          assignmentId={params.id}
+          grupos={grupos.map(serializar)}
+          inscripcionesCerradas={assignment.inscripcionesCerradas}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/app/assignments/[id]/grupo/page.tsx
+++ b/src/app/assignments/[id]/grupo/page.tsx
@@ -26,15 +26,7 @@ export default async function GrupoPage({
     notFound();
   }
 
-  const miGrupo = grupos.find((grupo) =>
-    grupo.alumnos
-      .getItems()
-      .some(
-        (alumno) =>
-          alumno.githubUsername.toLowerCase() ===
-          user.githubUsername.toLowerCase()
-      )
-  );
+  const miGrupo = grupos.find((grupo) => grupo.contieneA(user.githubUsername));
 
   const entrega = miGrupo
     ? await getEntregaDeUsuario(assignment.id, user.githubUsername)
@@ -46,8 +38,9 @@ export default async function GrupoPage({
       nombre: grupo.nombre,
       paradigma: grupo.paradigma,
       maxIntegrantes: grupo.maxIntegrantes,
-      estaLleno: !grupo.isOpen(),
-      miembros: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+      estaLleno: grupo.estaLleno(),
+      etiquetaCupo: grupo.etiquetaCupo(),
+      miembros: grupo.usernamesDeMiembros(),
     };
   }
 

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { useApiCall } from "@/app/hooks/useApiCall";
+import { ALUMNO_LEGAJO_PATTERN, ALUMNO_EMAIL_PATTERN } from "@/domain/entities/domain-constants";
 
 const INPUT_CLASS =
   "w-full border border-gray-300 rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-pdep-500 focus:border-pdep-500 outline-none";
@@ -142,7 +143,7 @@ export function AlumnoForm({
         <input
           name="legajo"
           required
-          pattern="\d{4,8}"
+          pattern={ALUMNO_LEGAJO_PATTERN}
           inputMode="numeric"
           placeholder="12345678"
           defaultValue={defaultValues.legajo}
@@ -187,7 +188,7 @@ export function AlumnoForm({
           name="email"
           type="email"
           required
-          pattern="[^\s@]+@[^\s@]+\.[^\s@]+"
+          pattern={ALUMNO_EMAIL_PATTERN}
           title="Ingresá un email con formato válido (usuario@dominio.com)"
           defaultValue={defaultValues.email}
           className={INPUT_CLASS}

--- a/src/app/components/AlumnoForm.tsx
+++ b/src/app/components/AlumnoForm.tsx
@@ -46,10 +46,10 @@ export function AlumnoForm({
   const [gruposSyncWarning, setGruposSyncWarning] = useState(false);
   const [fieldError, setFieldError] = useState<{ message: string; field: string } | null>(null);
 
-  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault();
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
     setFieldError(null);
-    const form = new FormData(e.currentTarget);
+    const form = new FormData(event.currentTarget);
     await call(async () => {
       const body = {
         legajo: form.get("legajo") as string,
@@ -58,13 +58,13 @@ export function AlumnoForm({
         email: form.get("email") as string,
         ...extraBody,
       };
-      const res = await fetch(apiEndpoint, {
+      const response = await fetch(apiEndpoint, {
         method,
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify(body),
       });
-      const json = await res.json();
-      if (!res.ok) {
+      const json = await response.json();
+      if (!response.ok) {
         if (typeof json.field === "string") {
           setFieldError({ message: json.error, field: json.field });
         }

--- a/src/app/components/PageSkeleton.tsx
+++ b/src/app/components/PageSkeleton.tsx
@@ -5,9 +5,9 @@ export function DashboardSkeleton() {
       <h1 className="text-2xl font-bold mb-1">Mis Trabajos Prácticos</h1>
       <div className="h-5 bg-gray-200 rounded w-72 mb-6 animate-pulse" />
       <div className="space-y-3">
-        {[...Array(3)].map((_, i) => (
+        {[...Array(3)].map((_, index) => (
           <div
-            key={i}
+            key={index}
             className="bg-white border border-gray-200 rounded-lg p-5 flex items-center justify-between animate-pulse"
           >
             <div className="flex-1 space-y-2">
@@ -42,13 +42,13 @@ export function AssignmentsTableSkeleton() {
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden animate-pulse">
         {/* Header */}
         <div className="bg-gray-50 border-b border-gray-200 px-4 py-3 flex gap-6">
-          {[140, 80, 60, 120, 60, 80, 80].map((w, i) => (
-            <div key={i} className="h-4 bg-gray-200 rounded" style={{ width: w }} />
+          {[140, 80, 60, 120, 60, 80, 80].map((width, index) => (
+            <div key={index} className="h-4 bg-gray-200 rounded" style={{ width }} />
           ))}
         </div>
         {/* Filas */}
-        {[...Array(4)].map((_, i) => (
-          <div key={i} className="px-4 py-3 border-b border-gray-100 flex gap-6 items-center">
+        {[...Array(4)].map((_, index) => (
+          <div key={index} className="px-4 py-3 border-b border-gray-100 flex gap-6 items-center">
             <div className="h-4 bg-gray-100 rounded w-36" />
             <div className="h-5 bg-gray-100 rounded-full w-20" />
             <div className="h-4 bg-gray-100 rounded w-16" />
@@ -73,12 +73,12 @@ export function ListSkeleton({ title, rows = 6 }: { title: string; rows?: number
       <h1 className="text-2xl font-bold mb-6">{title}</h1>
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden animate-pulse">
         <div className="bg-gray-50 border-b border-gray-200 px-4 py-3 flex gap-6">
-          {[120, 100, 140, 80].map((w, i) => (
-            <div key={i} className="h-4 bg-gray-200 rounded" style={{ width: w }} />
+          {[120, 100, 140, 80].map((width, index) => (
+            <div key={index} className="h-4 bg-gray-200 rounded" style={{ width }} />
           ))}
         </div>
-        {[...Array(rows)].map((_, i) => (
-          <div key={i} className="px-4 py-3 border-b border-gray-100 flex gap-6 items-center">
+        {[...Array(rows)].map((_, index) => (
+          <div key={index} className="px-4 py-3 border-b border-gray-100 flex gap-6 items-center">
             <div className="h-4 bg-gray-100 rounded w-28" />
             <div className="h-4 bg-gray-100 rounded w-24" />
             <div className="h-4 bg-gray-100 rounded w-36" />

--- a/src/app/components/SyncPendingBanner.test.tsx
+++ b/src/app/components/SyncPendingBanner.test.tsx
@@ -65,7 +65,7 @@ describe("SyncPendingBanner", () => {
     expect(el).toBeNull();
   });
 
-  it("no renderiza nada si el alumno no tiene el flag prendido", async () => {
+  it("no renderiza nada si ningún flag está prendido", async () => {
     mockGetCurrentUser.mockResolvedValue({
       githubUsername: "juangarcia",
       isAdmin: false,
@@ -75,7 +75,7 @@ describe("SyncPendingBanner", () => {
     expect(el).toBeNull();
   });
 
-  it("renderiza el banner cuando el alumno tiene el flag prendido", async () => {
+  it("renderiza el banner cuando gruposSyncFallidoEn está prendido", async () => {
     mockGetCurrentUser.mockResolvedValue({
       githubUsername: "juangarcia",
       isAdmin: false,
@@ -90,5 +90,39 @@ describe("SyncPendingBanner", () => {
     expect(html).toContain("No pudimos asignarte a tu grupo de TP");
     expect(html).toContain('href="/perfil"');
     expect(html).toContain("Reintentar");
+  });
+
+  it("renderiza el banner cuando alumnoSyncFallidoEn está prendido", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ alumnoSyncFallidoEn: new Date("2026-04-01") })
+    );
+
+    const el = await SyncPendingBanner();
+    const html = renderToStaticMarkup(el as React.ReactElement);
+
+    expect(html).toContain("No pudimos reflejar tus datos de alumno");
+  });
+
+  it("renderiza mensaje combinado cuando ambos flags están prendidos", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({
+        gruposSyncFallidoEn: new Date("2026-04-01"),
+        alumnoSyncFallidoEn: new Date("2026-04-01"),
+      })
+    );
+
+    const el = await SyncPendingBanner();
+    const html = renderToStaticMarkup(el as React.ReactElement);
+
+    expect(html).toContain("tus datos");
+    expect(html).toContain("grupo de TP");
   });
 });

--- a/src/app/components/SyncPendingBanner.test.tsx
+++ b/src/app/components/SyncPendingBanner.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import type { Alumno } from "@/domain/entities";
+import { Alumno } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -20,15 +20,17 @@ import { SyncPendingBanner } from "./SyncPendingBanner";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
-  return {
+  return Object.assign(new Alumno(), {
     id: "uuid-1",
     legajo: "12345",
     nombre: "Juan",
     apellido: "Garcia",
     githubUsername: "juangarcia",
     email: "juan@example.com",
+    gruposSyncFallidoEn: null,
+    alumnoSyncFallidoEn: null,
     ...overrides,
-  } as Alumno;
+  });
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/components/SyncPendingBanner.test.tsx
+++ b/src/app/components/SyncPendingBanner.test.tsx
@@ -40,8 +40,8 @@ describe("SyncPendingBanner", () => {
 
   it("no renderiza nada si no hay usuario logueado", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
-    const el = await SyncPendingBanner();
-    expect(el).toBeNull();
+    const banner = await SyncPendingBanner();
+    expect(banner).toBeNull();
     expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
   });
 
@@ -50,8 +50,8 @@ describe("SyncPendingBanner", () => {
       githubUsername: "juangarcia",
       isAdmin: true,
     });
-    const el = await SyncPendingBanner();
-    expect(el).toBeNull();
+    const banner = await SyncPendingBanner();
+    expect(banner).toBeNull();
     expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
   });
 
@@ -61,8 +61,8 @@ describe("SyncPendingBanner", () => {
       isAdmin: false,
     });
     mockGetAlumnoByGithub.mockResolvedValue(null);
-    const el = await SyncPendingBanner();
-    expect(el).toBeNull();
+    const banner = await SyncPendingBanner();
+    expect(banner).toBeNull();
   });
 
   it("no renderiza nada si ningún flag está prendido", async () => {
@@ -71,8 +71,8 @@ describe("SyncPendingBanner", () => {
       isAdmin: false,
     });
     mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
-    const el = await SyncPendingBanner();
-    expect(el).toBeNull();
+    const banner = await SyncPendingBanner();
+    expect(banner).toBeNull();
   });
 
   it("renderiza el banner cuando gruposSyncFallidoEn está prendido", async () => {
@@ -84,8 +84,8 @@ describe("SyncPendingBanner", () => {
       makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
     );
 
-    const el = await SyncPendingBanner();
-    const html = renderToStaticMarkup(el as React.ReactElement);
+    const banner = await SyncPendingBanner();
+    const html = renderToStaticMarkup(banner as React.ReactElement);
 
     expect(html).toContain("No pudimos asignarte a tu grupo de TP");
     expect(html).toContain('href="/perfil"');
@@ -101,8 +101,8 @@ describe("SyncPendingBanner", () => {
       makeAlumno({ alumnoSyncFallidoEn: new Date("2026-04-01") })
     );
 
-    const el = await SyncPendingBanner();
-    const html = renderToStaticMarkup(el as React.ReactElement);
+    const banner = await SyncPendingBanner();
+    const html = renderToStaticMarkup(banner as React.ReactElement);
 
     expect(html).toContain("No pudimos reflejar tus datos de alumno");
   });
@@ -119,8 +119,8 @@ describe("SyncPendingBanner", () => {
       })
     );
 
-    const el = await SyncPendingBanner();
-    const html = renderToStaticMarkup(el as React.ReactElement);
+    const banner = await SyncPendingBanner();
+    const html = renderToStaticMarkup(banner as React.ReactElement);
 
     expect(html).toContain("tus datos");
     expect(html).toContain("grupo de TP");

--- a/src/app/components/SyncPendingBanner.tsx
+++ b/src/app/components/SyncPendingBanner.tsx
@@ -3,20 +3,30 @@ import { getCurrentUser } from "@/lib/session";
 import { getAlumnoByGithub } from "@/lib/repositories";
 
 /**
- * Banner global que avisa al alumno que su sincronización con los grupos de
- * la planilla quedó en error. Es persistente: mientras `gruposSyncFallidoEn`
- * siga prendido en la DB, se muestra en todas las páginas logueadas.
+ * Banner global que avisa al alumno que algo en la sincronización con la
+ * planilla quedó en error. Es persistente: mientras `gruposSyncFallidoEn` o
+ * `alumnoSyncFallidoEn` estén prendidos, se muestra en todas las páginas
+ * logueadas.
  *
- * El flag se limpia solo cuando un reintento de sync funciona (ya sea al
- * entrar a `/perfil` o al guardar desde el form); cuando eso pasa, este
- * banner desaparece en el próximo render.
+ * Los flags se limpian cuando un reintento de sync funciona (events.signIn,
+ * /api/registro, /api/perfil, import admin, o reintento manual desde /perfil).
+ * Cuando eso pasa, este banner desaparece en el próximo render.
  */
 export async function SyncPendingBanner() {
   const user = await getCurrentUser();
   if (!user || user.isAdmin) return null;
 
   const alumno = await getAlumnoByGithub(user.githubUsername);
-  if (!alumno?.gruposSyncFallidoEn) return null;
+  if (!alumno) return null;
+
+  if (!alumno.gruposSyncFallidoEn && !alumno.alumnoSyncFallidoEn) return null;
+
+  const mensaje =
+    alumno.gruposSyncFallidoEn && alumno.alumnoSyncFallidoEn
+      ? "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla."
+      : alumno.gruposSyncFallidoEn
+        ? "No pudimos asignarte a tu grupo de TP desde la planilla."
+        : "No pudimos reflejar tus datos de alumno en la planilla.";
 
   return (
     <div
@@ -24,9 +34,7 @@ export async function SyncPendingBanner() {
       className="bg-amber-50 border-b border-amber-200 text-amber-900 text-sm"
     >
       <div className="max-w-5xl mx-auto px-4 py-2 flex flex-wrap items-center gap-x-3 gap-y-1">
-        <span>
-          No pudimos asignarte a tu grupo de TP desde la planilla.
-        </span>
+        <span>{mensaje}</span>
         <Link href="/perfil" className="underline font-medium hover:text-amber-950">
           Reintentar desde tu perfil
         </Link>

--- a/src/app/components/SyncPendingBanner.tsx
+++ b/src/app/components/SyncPendingBanner.tsx
@@ -19,14 +19,9 @@ export async function SyncPendingBanner() {
   const alumno = await getAlumnoByGithub(user.githubUsername);
   if (!alumno) return null;
 
-  if (!alumno.gruposSyncFallidoEn && !alumno.alumnoSyncFallidoEn) return null;
+  if (!alumno.tieneSyncPendiente()) return null;
 
-  const mensaje =
-    alumno.gruposSyncFallidoEn && alumno.alumnoSyncFallidoEn
-      ? "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla."
-      : alumno.gruposSyncFallidoEn
-        ? "No pudimos asignarte a tu grupo de TP desde la planilla."
-        : "No pudimos reflejar tus datos de alumno en la planilla.";
+  const mensaje = alumno.mensajeDeSyncPendiente();
 
   return (
     <div

--- a/src/app/dashboard/accept-button.tsx
+++ b/src/app/dashboard/accept-button.tsx
@@ -7,11 +7,11 @@ export function AcceptButton({ assignmentId }: { assignmentId: string }) {
 
   async function handleAccept() {
     await call(async () => {
-      const res = await fetch(`/api/assignments/${assignmentId}/accept`, {
+      const response = await fetch(`/api/assignments/${assignmentId}/accept`, {
         method: "POST",
       });
-      if (!res.ok) {
-        const data = await res.json();
+      if (!response.ok) {
+        const data = await response.json();
         throw new Error(data.error ?? "Error al crear el repo");
       }
       window.location.reload();

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { PdepUser } from "@/types";
-import { IndividualAssignment, GrupalAssignment, Entrega } from "@/domain/entities";
+import { Alumno, IndividualAssignment, GrupalAssignment, Entrega } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -42,6 +42,18 @@ vi.mock("./accept-button", () => ({
 import DashboardPage from "./page";
 
 // ── Helpers ──────────────────────────────────────────────────
+
+function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
+  const alumno = new Alumno();
+  alumno.githubUsername = "testuser";
+  alumno.legajo = "12345";
+  alumno.nombre = "Test";
+  alumno.apellido = "User";
+  alumno.email = "test@example.com";
+  alumno.gruposSyncFallidoEn = null;
+  alumno.alumnoSyncFallidoEn = null;
+  return Object.assign(alumno, overrides);
+}
 
 function makeUser(overrides?: Partial<PdepUser>): PdepUser {
   return {
@@ -117,42 +129,27 @@ describe("Dashboard page", () => {
     it("redirige a /registro si el alumno confirmó en otra comisión (recursante)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetComisionActiva.mockResolvedValue({ id: "c2" });
-      mockGetAlumnoByGithub.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Test",
-        apellido: "User",
-        githubUsername: "testuser",
-        email: "test@example.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
 
       await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
     });
 
     it("redirige a /registro si el alumno nunca confirmó (registroConfirmadoEn null)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
-      mockGetAlumnoByGithub.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Test",
-        apellido: "User",
-        githubUsername: "testuser",
-        email: "test@example.com",
-        registroConfirmadoEn: null,
-      });
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: undefined })
+      );
 
       await expect(DashboardPage()).rejects.toThrow("REDIRECT:/registro");
     });
 
     it("no redirige si el alumno confirmó para la comisión activa", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
-      mockGetAlumnoByGithub.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Test",
-        apellido: "User",
-        githubUsername: "testuser",
-        email: "test@example.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
 
       const element = await DashboardPage();
       expect(element).toBeDefined();
@@ -328,10 +325,9 @@ describe("Dashboard page", () => {
   describe("assignments grupales", () => {
     beforeEach(() => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
-      mockGetAlumnoByGithub.mockResolvedValue({
-        githubUsername: "testuser",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
     });
 
     it("muestra 'Elegir grupo' cuando es grupal y el alumno no tiene grupo", async () => {

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -54,40 +54,40 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
 }
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const a = new IndividualAssignment();
-  a.id = "a1";
-  a.titulo = "Kata Funcional";
-  a.descripcion = "";
-  a.templateRepo = "kata-template";
-  a.tipo = "individual";
-  a.paradigma = "funcional";
-  a.slug = "kata-funcional";
-  a.createdAt = new Date();
-  return Object.assign(a, overrides);
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "";
+  assignment.templateRepo = "kata-template";
+  assignment.tipo = "individual";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date();
+  return Object.assign(assignment, overrides);
 }
 
 function makeGrupalAssignment(overrides?: Partial<GrupalAssignment>): GrupalAssignment {
-  const a = new GrupalAssignment();
-  a.id = "a-grupal";
-  a.titulo = "TP Grupal";
-  a.descripcion = "";
-  a.templateRepo = "tp-template";
-  a.tipo = "grupal";
-  a.paradigma = "objetos";
-  a.slug = "tp-grupal";
-  a.maxIntegrantes = 3;
-  a.createdAt = new Date();
-  return Object.assign(a, overrides);
+  const assignment = new GrupalAssignment();
+  assignment.id = "a-grupal";
+  assignment.titulo = "TP Grupal";
+  assignment.descripcion = "";
+  assignment.templateRepo = "tp-template";
+  assignment.tipo = "grupal";
+  assignment.paradigma = "objetos";
+  assignment.slug = "tp-grupal";
+  assignment.maxIntegrantes = 3;
+  assignment.createdAt = new Date();
+  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
-  const e = new Entrega();
-  e.id = "e1";
-  e.repoName = "kata-funcional-testuser";
-  e.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-testuser";
-  e.githubUsernames = ["testuser"];
-  e.createdAt = new Date();
-  return Object.assign(e, overrides);
+  const entrega = new Entrega();
+  entrega.id = "e1";
+  entrega.repoName = "kata-funcional-testuser";
+  entrega.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-testuser";
+  entrega.githubUsernames = ["testuser"];
+  entrega.createdAt = new Date();
+  return Object.assign(entrega, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { PdepUser } from "@/types";
-import { IndividualAssignment, Entrega } from "@/domain/entities";
+import { IndividualAssignment, GrupalAssignment, Entrega } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -10,6 +10,7 @@ const mockGetAlumnoByGithub = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockGetAssignments = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
+const mockGetGruposDeAlumno = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -23,6 +24,7 @@ vi.mock("@/lib/repositories", () => ({
   getEntregasDeUsuario: (username: string) => mockGetEntregaDeUsuario(username),
   getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
   getComisionActiva: () => mockGetComisionActiva(),
+  getGruposDeAlumno: (username: string) => mockGetGruposDeAlumno(username),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -64,6 +66,20 @@ function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAs
   return Object.assign(a, overrides);
 }
 
+function makeGrupalAssignment(overrides?: Partial<GrupalAssignment>): GrupalAssignment {
+  const a = new GrupalAssignment();
+  a.id = "a-grupal";
+  a.titulo = "TP Grupal";
+  a.descripcion = "";
+  a.templateRepo = "tp-template";
+  a.tipo = "grupal";
+  a.paradigma = "objetos";
+  a.slug = "tp-grupal";
+  a.maxIntegrantes = 3;
+  a.createdAt = new Date();
+  return Object.assign(a, overrides);
+}
+
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
   const e = new Entrega();
   e.id = "e1";
@@ -86,6 +102,7 @@ describe("Dashboard page", () => {
     mockGetEntregaDeUsuario.mockResolvedValue(new Map());
     mockGetComisionActiva.mockResolvedValue({ id: "c1" });
     mockGetAlumnoByGithub.mockResolvedValue(null);
+    mockGetGruposDeAlumno.mockResolvedValue(new Map());
   });
 
   describe("redirecciones", () => {
@@ -305,6 +322,88 @@ describe("Dashboard page", () => {
 
       await DashboardPage();
       expect(mockGetEntregaDeUsuario).toHaveBeenCalledWith("miusuario");
+    });
+  });
+
+  describe("assignments grupales", () => {
+    beforeEach(() => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue({
+        githubUsername: "testuser",
+        registroConfirmadoEn: { id: "c1" },
+      });
+    });
+
+    it("muestra 'Elegir grupo' cuando es grupal y el alumno no tiene grupo", async () => {
+      mockGetAssignments.mockResolvedValue([makeGrupalAssignment()]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+      mockGetGruposDeAlumno.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("Elegir grupo");
+      expect(html).not.toContain("data-testid=\"accept-button\"");
+    });
+
+    it("el link 'Elegir grupo' apunta a la página del grupo del assignment", async () => {
+      mockGetAssignments.mockResolvedValue([makeGrupalAssignment({ id: "tp-g1" })]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+      mockGetGruposDeAlumno.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("/assignments/tp-g1/grupo");
+    });
+
+    it("muestra AcceptButton cuando es grupal y el alumno ya tiene grupo", async () => {
+      const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
+      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+      mockGetGruposDeAlumno.mockResolvedValue(
+        new Map([["tp-g1", { nombre: "Los Lambdas" }]])
+      );
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("data-testid=\"accept-button\"");
+      expect(html).not.toContain("Elegir grupo");
+    });
+
+    it("muestra el nombre del grupo cuando el alumno ya tiene grupo sin entrega", async () => {
+      const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
+      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+      mockGetGruposDeAlumno.mockResolvedValue(
+        new Map([["tp-g1", { nombre: "Los Lambdas" }]])
+      );
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("Los Lambdas");
+    });
+
+    it("muestra 'Ir al repo' cuando ya tiene entrega, aunque tenga grupo", async () => {
+      const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
+      const entrega = makeEntrega({ repoUrl: "https://github.com/pdep/tp-g1" });
+      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map([["tp-g1", entrega]]));
+      mockGetGruposDeAlumno.mockResolvedValue(
+        new Map([["tp-g1", { nombre: "Los Lambdas" }]])
+      );
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("Ir al repo");
+      expect(html).not.toContain("Elegir grupo");
+    });
+
+    it("no llama a getGruposDeAlumno si el usuario es admin", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: true }));
+      mockGetAssignments.mockResolvedValue([makeGrupalAssignment()]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+
+      await DashboardPage();
+      expect(mockGetGruposDeAlumno).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,21 +4,20 @@ import {
   getEntregasDeUsuario,
   getAlumnoByGithub,
   getComisionActiva,
+  getGruposDeAlumno,
 } from "@/lib/repositories";
 import { AcceptButton } from "./accept-button";
 import { redirect } from "next/navigation";
+import type { Grupo } from "@/domain/entities";
 
 export default async function DashboardPage() {
   const user = await requireUser();
 
-  // Los admins no pasan por el gate de registro; pueden entrar sin estar como alumnos.
   if (!user.isAdmin) {
     const [alumno, comisionActiva] = await Promise.all([
       getAlumnoByGithub(user.githubUsername),
       getComisionActiva(),
     ]);
-    // Sin comisión activa no podemos pedirle nada — se deja pasar.
-    // Con comisión activa, bloquear hasta que el alumno la haya confirmado.
     if (
       comisionActiva &&
       alumno?.registroConfirmadoEn?.id !== comisionActiva.id
@@ -27,10 +26,14 @@ export default async function DashboardPage() {
     }
   }
 
-  // Dos queries paralelas: assignments + todas las entregas del usuario
-  const [assignments, entregasMap] = await Promise.all([
+  const gruposPromise: Promise<Map<string, Grupo>> = user.isAdmin
+    ? Promise.resolve(new Map())
+    : getGruposDeAlumno(user.githubUsername);
+
+  const [assignments, entregasMap, gruposMap] = await Promise.all([
     getAssignments(),
     getEntregasDeUsuario(user.githubUsername),
+    gruposPromise,
   ]);
 
   const assignmentsConEntrega = assignments
@@ -38,6 +41,7 @@ export default async function DashboardPage() {
     .map((assignment) => ({
       assignment,
       entrega: entregasMap.get(assignment.id) ?? null,
+      grupo: gruposMap.get(assignment.id) ?? null,
     }));
 
   return (
@@ -54,7 +58,7 @@ export default async function DashboardPage() {
         </div>
       ) : (
         <div className="space-y-3">
-          {assignmentsConEntrega.map(({ assignment, entrega }) => (
+          {assignmentsConEntrega.map(({ assignment, entrega, grupo }) => (
             <div
               key={assignment.id}
               className="bg-white border border-gray-200 rounded-lg p-5 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4"
@@ -84,6 +88,11 @@ export default async function DashboardPage() {
                     })}
                   </p>
                 )}
+                {grupo && !entrega && (
+                  <p className="text-xs text-blue-600 mt-1">
+                    Grupo: <span className="font-medium">{grupo.nombre}</span>
+                  </p>
+                )}
               </div>
 
               <div className="flex-shrink-0 w-full sm:w-auto">
@@ -108,6 +117,14 @@ export default async function DashboardPage() {
                       />
                     </svg>
                     Ir al repo
+                  </a>
+                ) : assignment.tipo === "grupal" && !grupo ? (
+                  <a
+                    href={`/assignments/${assignment.id}/grupo`}
+                    className="inline-flex items-center justify-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors w-full sm:w-auto"
+                    data-testid="elegir-grupo-link"
+                  >
+                    Elegir grupo
                   </a>
                 ) : (
                   <AcceptButton assignmentId={assignment.id} />

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -37,7 +37,7 @@ export default async function DashboardPage() {
   ]);
 
   const assignmentsConEntrega = assignments
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .sort((prev, next) => new Date(next.createdAt).getTime() - new Date(prev.createdAt).getTime())
     .map((assignment) => ({
       assignment,
       entrega: entregasMap.get(assignment.id) ?? null,

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -118,7 +118,7 @@ export default async function DashboardPage() {
                     </svg>
                     Ir al repo
                   </a>
-                ) : assignment.tipo === "grupal" && !grupo ? (
+                ) : assignment.tipo === "grupal" && !grupo && !user.isAdmin ? (
                   <a
                     href={`/assignments/${assignment.id}/grupo`}
                     className="inline-flex items-center justify-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors w-full sm:w-auto"

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -18,10 +18,7 @@ export default async function DashboardPage() {
       getAlumnoByGithub(user.githubUsername),
       getComisionActiva(),
     ]);
-    if (
-      comisionActiva &&
-      alumno?.registroConfirmadoEn?.id !== comisionActiva.id
-    ) {
+    if (comisionActiva && (!alumno || alumno.necesitaConfirmarRegistroPara(comisionActiva))) {
       redirect("/registro");
     }
   }
@@ -118,7 +115,7 @@ export default async function DashboardPage() {
                     </svg>
                     Ir al repo
                   </a>
-                ) : assignment.tipo === "grupal" && !grupo && !user.isAdmin ? (
+                ) : assignment.requiereSeleccionDeGrupo(user, grupo) ? (
                   <a
                     href={`/assignments/${assignment.id}/grupo`}
                     className="inline-flex items-center justify-center gap-1.5 text-sm bg-pdep-600 text-white px-4 py-2 rounded-lg font-medium hover:bg-pdep-700 transition-colors w-full sm:w-auto"

--- a/src/app/error.test.tsx
+++ b/src/app/error.test.tsx
@@ -25,4 +25,31 @@ describe("GlobalError", () => {
     expect(msg).toHaveClass("font-mono");
     expect(msg).toHaveClass("text-red-500");
   });
+
+  it("muestra fallback cuando Next.js sanitiza el mensaje", () => {
+    const sanitized = Object.assign(
+      new Error(
+        "An error occurred in the Server Components render but no message was provided"
+      ),
+      { digest: "827364775" }
+    );
+    render(<GlobalError error={sanitized} />);
+    expect(
+      screen.getByText(/El servidor encontró un error/)
+    ).toBeInTheDocument();
+    expect(screen.getByText(/827364775/)).toBeInTheDocument();
+  });
+
+  it("muestra el digest como código de referencia cuando está presente", () => {
+    const errorWithDigest = Object.assign(new Error("falla"), {
+      digest: "123456789",
+    });
+    render(<GlobalError error={errorWithDigest} />);
+    expect(screen.getByText(/123456789/)).toBeInTheDocument();
+  });
+
+  it("no muestra sección de código si no hay digest", () => {
+    render(<GlobalError error={new Error("falla sin digest")} />);
+    expect(screen.queryByText(/código:/)).not.toBeInTheDocument();
+  });
 });

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -1,17 +1,32 @@
 "use client";
 
-export default function GlobalError({ error }: { error: Error }) {
+const SANITIZED_MESSAGE = "An error occurred in the Server Components render";
+
+export default function GlobalError({
+  error,
+}: {
+  error: Error & { digest?: string };
+}) {
+  const isSanitized =
+    !error.message || error.message.startsWith(SANITIZED_MESSAGE);
+  const displayMessage = isSanitized
+    ? "El servidor encontró un error. Revisá los logs para más detalles."
+    : error.message;
+
   return (
     <div className="max-w-lg mx-auto mt-16 text-center">
-      <h1 className="text-2xl font-bold mb-2 text-gray-800">
-        Algo salió mal
-      </h1>
+      <h1 className="text-2xl font-bold mb-2 text-gray-800">Algo salió mal</h1>
       <p className="text-gray-500 text-sm mb-4">
         Ocurrió un error inesperado. Podés intentar recargar la página.
       </p>
       <p className="text-red-500 font-mono text-xs bg-red-50 border border-red-100 rounded px-4 py-2 inline-block">
-        {error.message}
+        {displayMessage}
       </p>
+      {error.digest && (
+        <p className="text-gray-400 font-mono text-xs mt-2">
+          código: {error.digest}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/app/hooks/useApiCall.test.ts
+++ b/src/app/hooks/useApiCall.test.ts
@@ -22,7 +22,7 @@ describe("useApiCall", () => {
   it("pone loading=true mientras ejecuta y false al terminar", async () => {
     const { result } = renderHook(() => useApiCall());
     let resolveFn!: () => void;
-    const deferred = new Promise<void>((r) => { resolveFn = r; });
+    const deferred = new Promise<void>((resolve) => { resolveFn = resolve; });
 
     // inicia el call sin await
     act(() => { result.current.call(() => deferred); });

--- a/src/app/hooks/useApiCall.ts
+++ b/src/app/hooks/useApiCall.ts
@@ -6,13 +6,13 @@ export function useApiCall() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  async function call<T>(fn: () => Promise<T>): Promise<T | undefined> {
+  async function call<T>(apiCall: () => Promise<T>): Promise<T | undefined> {
     setLoading(true);
     setError(null);
     try {
-      return await fn();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Error desconocido");
+      return await apiCall();
+    } catch (caught) {
+      setError(caught instanceof Error ? caught.message : "Error desconocido");
     } finally {
       setLoading(false);
     }

--- a/src/app/logout-button.tsx
+++ b/src/app/logout-button.tsx
@@ -16,13 +16,13 @@ export function UserMenu({ username, image, isAdmin = false }: Props) {
 
   useEffect(() => {
     if (!open) return;
-    const onPointer = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
+    const onPointer = (event: MouseEvent) => {
+      if (ref.current && !ref.current.contains(event.target as Node)) {
         setOpen(false);
       }
     };
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
     };
     document.addEventListener("mousedown", onPointer);
     document.addEventListener("keydown", onKey);
@@ -39,7 +39,7 @@ export function UserMenu({ username, image, isAdmin = false }: Props) {
         className="flex items-center gap-2 cursor-pointer"
         aria-haspopup="menu"
         aria-expanded={open}
-        onClick={() => setOpen((o) => !o)}
+        onClick={() => setOpen((previous) => !previous)}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={image} alt="" className="w-7 h-7 rounded-full" />

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -2,7 +2,6 @@
 
 import Link from "next/link";
 import { useEffect, useState } from "react";
-import { usePathname } from "next/navigation";
 import { signOut } from "next-auth/react";
 import { UserMenu } from "./logout-button";
 
@@ -20,11 +19,6 @@ interface Props {
 
 export function NavMenu({ links, username, image, isAdmin }: Props) {
   const [open, setOpen] = useState(false);
-  const pathname = usePathname();
-
-  useEffect(() => {
-    setOpen(false);
-  }, [pathname]);
 
   useEffect(() => {
     if (!open) return;
@@ -39,22 +33,22 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
 
     getFocusables()[0]?.focus();
 
-    const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
         setOpen(false);
         return;
       }
-      if (e.key !== "Tab") return;
+      if (event.key !== "Tab") return;
       const items = getFocusables();
       if (items.length === 0) return;
       const first = items[0];
       const last = items[items.length - 1];
       const active = document.activeElement;
-      if (e.shiftKey && active === first) {
-        e.preventDefault();
+      if (event.shiftKey && active === first) {
+        event.preventDefault();
         last.focus();
-      } else if (!e.shiftKey && active === last) {
-        e.preventDefault();
+      } else if (!event.shiftKey && active === last) {
+        event.preventDefault();
         first.focus();
       }
     };
@@ -73,13 +67,13 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
   return (
     <>
       <div className="hidden md:flex items-center gap-6 text-sm">
-        {links.map((l) => (
+        {links.map((link) => (
           <Link
-            key={l.href}
-            href={l.href}
+            key={link.href}
+            href={link.href}
             className="hover:text-pdep-200 transition-colors"
           >
-            {l.label}
+            {link.label}
           </Link>
         ))}
         <UserMenu username={username} image={image} isAdmin={isAdmin} />
@@ -161,18 +155,20 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         </div>
 
         <nav className="flex flex-col py-2">
-          {links.map((l) => (
+          {links.map((link) => (
             <Link
-              key={l.href}
-              href={l.href}
+              key={link.href}
+              href={link.href}
+              onClick={() => setOpen(false)}
               className="px-4 py-3 text-white hover:bg-pdep-800 transition-colors"
             >
-              {l.label}
+              {link.label}
             </Link>
           ))}
           {!isAdmin && (
             <Link
               href="/perfil"
+              onClick={() => setOpen(false)}
               className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
             >
               Editar perfil

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -122,7 +122,7 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
         role="dialog"
         aria-modal="true"
         aria-label="Menú de navegación"
-        inert={!open}
+        inert={!open ? "" : undefined}
         className={`md:hidden fixed right-0 top-0 bottom-0 w-72 max-w-[85vw] bg-pdep-900 z-50 shadow-xl transform transition-transform ${
           open ? "translate-x-0" : "translate-x-full"
         }`}

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { PdepUser } from "@/types";
-import type { Alumno } from "@/domain/entities";
+import { Alumno } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -66,16 +66,16 @@ function makeSession(githubUsername: string) {
 }
 
 function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
-  return {
-    id: "uuid-1",
-    legajo: "12345",
-    nombre: "Juan",
-    apellido: "Garcia",
-    githubUsername: "juangarcia",
-    email: "juan@example.com",
-    comision: undefined,
-    ...overrides,
-  } as Alumno;
+  const alumno = new Alumno();
+  alumno.id = "uuid-1";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "Garcia";
+  alumno.githubUsername = "juangarcia";
+  alumno.email = "juan@example.com";
+  alumno.gruposSyncFallidoEn = null;
+  alumno.alumnoSyncFallidoEn = null;
+  return Object.assign(alumno, overrides);
 }
 
 const comisionActiva = { id: "c1", spreadsheetId: "sheet-xyz" };

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -8,6 +8,7 @@ import type { Alumno } from "@/domain/entities";
 const mockAuth = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
 const mockGetComisionActiva = vi.fn();
+const mockVerificarConsistenciaAlumno = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
@@ -20,6 +21,11 @@ vi.mock("@/lib/auth", () => ({
 vi.mock("@/lib/repositories", () => ({
   getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
   getComisionActiva: () => mockGetComisionActiva(),
+}));
+
+vi.mock("@/lib/services/verificarConsistenciaAlumno", () => ({
+  verificarConsistenciaAlumno: (...args: unknown[]) =>
+    mockVerificarConsistenciaAlumno(...args),
 }));
 
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
@@ -72,11 +78,16 @@ function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
   } as Alumno;
 }
 
+const comisionActiva = { id: "c1", spreadsheetId: "sheet-xyz" };
+
 // ── Tests ────────────────────────────────────────────────────
 
 describe("Perfil page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockVerificarConsistenciaAlumno.mockResolvedValue(undefined);
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
     mockRedirect.mockImplementation((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     });
@@ -103,8 +114,6 @@ describe("Perfil page", () => {
     beforeEach(() => {
       mockAuth.mockResolvedValue(makeSession("juangarcia"));
       mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
-      mockGetComisionActiva.mockResolvedValue({ id: "c1" });
-      mockIntentarSincronizarGrupos.mockResolvedValue(false);
     });
 
     it("muestra el título Mi perfil", async () => {
@@ -133,31 +142,61 @@ describe("Perfil page", () => {
     });
   });
 
-  describe("reintento de sincronización de grupos al montar", () => {
+  describe("reintento manual on-demand al montar", () => {
     beforeEach(() => {
       mockAuth.mockResolvedValue(makeSession("juangarcia"));
-      mockGetComisionActiva.mockResolvedValue({ id: "c1" });
-      mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
     });
 
-    it("no reintenta la sync si el alumno no tiene el flag prendido", async () => {
+    it("no dispara ninguna sync si ningún flag está prendido", async () => {
       mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
       await PerfilPage();
+      expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
       expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
     });
 
-    it("reintenta la sync al montar si el alumno tiene el flag prendido", async () => {
+    it("llama a verificarConsistenciaAlumno si alumnoSyncFallidoEn está prendido", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ alumnoSyncFallidoEn: new Date("2026-04-01") })
+      );
+      await PerfilPage();
+      expect(mockVerificarConsistenciaAlumno).toHaveBeenCalledWith(
+        "juangarcia",
+        comisionActiva
+      );
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    });
+
+    it("llama a intentarSincronizarGrupos si gruposSyncFallidoEn está prendido", async () => {
       mockGetAlumnoByGithub.mockResolvedValue(
         makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
       );
       await PerfilPage();
       expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
         "juangarcia",
-        { id: "c1" }
+        comisionActiva
+      );
+      expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
+    });
+
+    it("llama a ambas funciones si los dos flags están prendidos", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({
+          alumnoSyncFallidoEn: new Date("2026-04-01"),
+          gruposSyncFallidoEn: new Date("2026-04-01"),
+        })
+      );
+      await PerfilPage();
+      expect(mockVerificarConsistenciaAlumno).toHaveBeenCalledWith(
+        "juangarcia",
+        comisionActiva
+      );
+      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+        "juangarcia",
+        comisionActiva
       );
     });
 
-    it("no reintenta si tiene el flag pero no hay comisión activa (evita el crash)", async () => {
+    it("no dispara sync si no hay comisión activa", async () => {
       mockGetAlumnoByGithub.mockResolvedValue(
         makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
       );
@@ -166,7 +205,7 @@ describe("Perfil page", () => {
       expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
     });
 
-    it("no rompe el render si el wrapper throwea (el flag persistido en DB mantiene el banner)", async () => {
+    it("no rompe el render si alguna sync throwea", async () => {
       mockGetAlumnoByGithub.mockResolvedValue(
         makeAlumno({ gruposSyncFallidoEn: new Date("2026-04-01") })
       );

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -2,6 +2,7 @@ import { auth } from "@/lib/auth";
 import { getAlumnoByGithub, getComisionActiva } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
+import { verificarConsistenciaAlumno } from "@/lib/services/verificarConsistenciaAlumno";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import type { PdepUser } from "@/types";
 
@@ -15,19 +16,23 @@ export default async function PerfilPage() {
   const alumno = await getAlumnoByGithub(githubUsername);
   if (!alumno) redirect("/registro");
 
-  // Si el alumno tiene sync de grupos pendiente, reintentamos al montar
-  // el perfil. Si funciona, el flag se limpia acá mismo y el banner global
-  // desaparece en el próximo render. Si sigue fallando, el wrapper deja el
-  // flag prendido y el banner sigue visible — no queremos que la excepción
-  // rompa el render del perfil.
-  if (alumno.gruposSyncFallidoEn) {
-    const comisionActiva = await getComisionActiva();
-    if (comisionActiva) {
-      try {
-        await intentarSincronizarGrupos(githubUsername, comisionActiva);
-      } catch {
-        // Flag persistente en DB se encarga del banner en este render.
+  // Reintento on-demand: si alguno de los flags de sync está prendido,
+  // el alumno probablemente entró acá específicamente para resolverlo.
+  // Las dos llamadas son independientes y se invocan solo si su flag está activo.
+  // Protegemos defensivamente: una excepción inesperada no debe romper el render.
+  if (alumno.alumnoSyncFallidoEn || alumno.gruposSyncFallidoEn) {
+    try {
+      const comisionActiva = await getComisionActiva();
+      if (comisionActiva) {
+        if (alumno.alumnoSyncFallidoEn) {
+          await verificarConsistenciaAlumno(githubUsername, comisionActiva);
+        }
+        if (alumno.gruposSyncFallidoEn) {
+          await intentarSincronizarGrupos(githubUsername, comisionActiva);
+        }
       }
+    } catch {
+      // Flags persistentes en DB se encargan del banner.
     }
   }
 

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -20,13 +20,13 @@ export default async function PerfilPage() {
   // el alumno probablemente entró acá específicamente para resolverlo.
   // Las dos llamadas son independientes y se invocan solo si su flag está activo.
   // Protegemos defensivamente: una excepción inesperada no debe romper el render.
-  if (alumno.alumnoSyncFallidoEn || alumno.gruposSyncFallidoEn) {
+  if (alumno.tieneSyncPendiente()) {
     try {
       const comisionActiva = await getComisionActiva();
       if (comisionActiva) {
         const tareas: Promise<unknown>[] = [];
-        if (alumno.alumnoSyncFallidoEn) tareas.push(verificarConsistenciaAlumno(githubUsername, comisionActiva));
-        if (alumno.gruposSyncFallidoEn) tareas.push(intentarSincronizarGrupos(githubUsername, comisionActiva));
+        if (alumno.tieneSyncDeAlumnoFallido()) tareas.push(verificarConsistenciaAlumno(githubUsername, comisionActiva));
+        if (alumno.tieneSyncDeGruposFallido()) tareas.push(intentarSincronizarGrupos(githubUsername, comisionActiva));
         await Promise.allSettled(tareas);
       }
     } catch {

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -24,12 +24,10 @@ export default async function PerfilPage() {
     try {
       const comisionActiva = await getComisionActiva();
       if (comisionActiva) {
-        if (alumno.alumnoSyncFallidoEn) {
-          await verificarConsistenciaAlumno(githubUsername, comisionActiva);
-        }
-        if (alumno.gruposSyncFallidoEn) {
-          await intentarSincronizarGrupos(githubUsername, comisionActiva);
-        }
+        const tareas: Promise<unknown>[] = [];
+        if (alumno.alumnoSyncFallidoEn) tareas.push(verificarConsistenciaAlumno(githubUsername, comisionActiva));
+        if (alumno.gruposSyncFallidoEn) tareas.push(intentarSincronizarGrupos(githubUsername, comisionActiva));
+        await Promise.allSettled(tareas);
       }
     } catch {
       // Flags persistentes en DB se encargan del banner.

--- a/src/app/registro/page.test.tsx
+++ b/src/app/registro/page.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import type { PdepUser } from "@/types";
+import { Alumno } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -53,6 +54,18 @@ import RegistroPage from "./page";
 
 // ── Helpers ──────────────────────────────────────────────────
 
+function makeAlumnoDB(overrides: Partial<Alumno> = {}): Alumno {
+  const alumno = new Alumno();
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "G";
+  alumno.githubUsername = "juan";
+  alumno.email = "juan@mail.com";
+  alumno.gruposSyncFallidoEn = null;
+  alumno.alumnoSyncFallidoEn = null;
+  return Object.assign(alumno, overrides);
+}
+
 function makeSession(githubUsername: string, overrides?: Partial<PdepUser>) {
   const pdepUser: PdepUser = {
     githubUsername,
@@ -92,14 +105,9 @@ describe("Registro page", () => {
       const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Juan",
-        apellido: "G",
-        githubUsername: "juan",
-        email: "juan@mail.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(
+        makeAlumnoDB({ registroConfirmadoEn: { id: "c1" } as any })
+      );
 
       await expect(RegistroPage()).rejects.toThrow("REDIRECT:/dashboard");
     });
@@ -108,14 +116,9 @@ describe("Registro page", () => {
       const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Juan",
-        apellido: "G",
-        githubUsername: "juan",
-        email: "juan@mail.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(
+        makeAlumnoDB({ registroConfirmadoEn: { id: "c1" } as any })
+      );
 
       await RegistroPage();
       expect(mockRedirect).not.toHaveBeenCalled();
@@ -125,14 +128,9 @@ describe("Registro page", () => {
       const comision = { id: "c1", spreadsheetId: "s1", columnConfig: null };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Juan",
-        apellido: "G",
-        githubUsername: "juan",
-        email: "juan@mail.com",
-        registroConfirmadoEn: null,
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(
+        makeAlumnoDB({ registroConfirmadoEn: undefined })
+      );
 
       await RegistroPage();
       expect(mockRedirect).not.toHaveBeenCalled();
@@ -141,14 +139,7 @@ describe("Registro page", () => {
     it("NO redirige si no hay comisión activa aunque el alumno exista en DB", async () => {
       mockGetComisionActiva.mockResolvedValue(null);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Juan",
-        apellido: "G",
-        githubUsername: "juan",
-        email: "juan@mail.com",
-        registroConfirmadoEn: null,
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(makeAlumnoDB());
 
       await RegistroPage();
       expect(mockRedirect).not.toHaveBeenCalled();
@@ -160,14 +151,16 @@ describe("Registro page", () => {
       const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "99999",
-        nombre: "Juan Carlos",
-        apellido: "García",
-        githubUsername: "juan",
-        email: "personal@gmail.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(
+        makeAlumnoDB({
+          legajo: "99999",
+          nombre: "Juan Carlos",
+          apellido: "García",
+          githubUsername: "juan",
+          email: "personal@gmail.com",
+          registroConfirmadoEn: { id: "c1" } as any,
+        })
+      );
       // Sheets tiene otro email y otro legajo (el admin rearmó la planilla) — debe ganar DB
       mockGetAlumnoDeSheets.mockResolvedValue({
         legajo: "11111",
@@ -250,14 +243,9 @@ describe("Registro page", () => {
       const comision = { id: "c2", spreadsheetId: "s1", columnConfig: null };
       mockGetComisionActiva.mockResolvedValue(comision);
       mockAuth.mockResolvedValue(makeSession("juan"));
-      mockGetAlumnoDeDB.mockResolvedValue({
-        legajo: "12345",
-        nombre: "Juan",
-        apellido: "G",
-        githubUsername: "juan",
-        email: "juan@mail.com",
-        registroConfirmadoEn: { id: "c1" },
-      });
+      mockGetAlumnoDeDB.mockResolvedValue(
+        makeAlumnoDB({ registroConfirmadoEn: { id: "c1" } as any })
+      );
 
       const element = await RegistroPage();
       const html = renderToStaticMarkup(element);

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -19,11 +19,7 @@ export default async function RegistroPage() {
   const alumnoDB = await getAlumnoDeDB(githubUsername);
 
   // Si ya confirmó los datos para esta comisión, no tiene nada que hacer acá.
-  if (
-    alumnoDB &&
-    comisionActiva &&
-    alumnoDB.registroConfirmadoEn?.id === comisionActiva.id
-  ) {
+  if (alumnoDB && alumnoDB.confirmoRegistroEn(comisionActiva)) {
     redirect("/dashboard");
   }
 

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { Alumno } from "./Alumno";
+import type { Comision } from "./Comision";
+
+function nuevoAlumno(overrides: Partial<Alumno> = {}): Alumno {
+  const alumno = new Alumno();
+  alumno.legajo = "12345";
+  alumno.nombre = "Ana";
+  alumno.apellido = "García";
+  alumno.githubUsername = "ana-garcia";
+  alumno.email = "ana@example.com";
+  alumno.gruposSyncFallidoEn = null;
+  alumno.alumnoSyncFallidoEn = null;
+  return Object.assign(alumno, overrides);
+}
+
+function fakeComision(id: string): Comision {
+  return { id } as Comision;
+}
+
+describe("Alumno.normalizarUsername", () => {
+  it("pasa a minúsculas, quita @, y hace trim", () => {
+    expect(Alumno.normalizarUsername("@JuanGarcia ")).toBe("juangarcia");
+  });
+
+  it("es idempotente", () => {
+    const resultado = Alumno.normalizarUsername("@Ana-Garcia ");
+    expect(Alumno.normalizarUsername(resultado)).toBe(resultado);
+  });
+
+  it("devuelve string vacío para null/undefined", () => {
+    expect(Alumno.normalizarUsername(null)).toBe("");
+    expect(Alumno.normalizarUsername(undefined)).toBe("");
+  });
+});
+
+describe("Alumno.normalizarEmail", () => {
+  it("pasa a minúsculas y hace trim", () => {
+    expect(Alumno.normalizarEmail("  ANA@Example.COM  ")).toBe("ana@example.com");
+  });
+
+  it("es idempotente", () => {
+    const resultado = Alumno.normalizarEmail("  Ana@Example.COM ");
+    expect(Alumno.normalizarEmail(resultado)).toBe(resultado);
+  });
+
+  it("devuelve string vacío para null/undefined", () => {
+    expect(Alumno.normalizarEmail(null)).toBe("");
+    expect(Alumno.normalizarEmail(undefined)).toBe("");
+  });
+});
+
+describe("Alumno.usernameCanonico", () => {
+  it("devuelve el username normalizado del alumno", () => {
+    const alumno = nuevoAlumno({ githubUsername: "@AnaGarcia" });
+    expect(alumno.usernameCanonico).toBe("anagarcia");
+  });
+
+  it("coincide con normalizarUsername aplicado al mismo username", () => {
+    const alumno = nuevoAlumno({ githubUsername: "Juan-garcia" });
+    expect(alumno.usernameCanonico).toBe(Alumno.normalizarUsername("Juan-garcia"));
+  });
+});
+
+describe("Alumno.confirmoRegistroEn", () => {
+  it("devuelve true cuando registroConfirmadoEn apunta a la comision activa", () => {
+    const comision = fakeComision("c1");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: comision });
+
+    expect(alumno.confirmoRegistroEn(comision)).toBe(true);
+  });
+
+  it("devuelve false cuando registroConfirmadoEn apunta a otra comision", () => {
+    const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("c-antigua") });
+
+    expect(alumno.confirmoRegistroEn(fakeComision("c-nueva"))).toBe(false);
+  });
+
+  it("devuelve false cuando el alumno nunca confirmó", () => {
+    const alumno = nuevoAlumno({ registroConfirmadoEn: undefined });
+
+    expect(alumno.confirmoRegistroEn(fakeComision("c1"))).toBe(false);
+  });
+
+  it("devuelve false cuando la comision es null", () => {
+    const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("c1") });
+
+    expect(alumno.confirmoRegistroEn(null)).toBe(false);
+  });
+});
+
+describe("Alumno.necesitaConfirmarRegistroPara", () => {
+  it("devuelve true cuando el alumno no confirmó para la comision activa", () => {
+    const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("c-antigua") });
+
+    expect(alumno.necesitaConfirmarRegistroPara(fakeComision("c-nueva"))).toBe(true);
+  });
+
+  it("devuelve false cuando el alumno ya confirmó para la comision activa", () => {
+    const comision = fakeComision("c1");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: comision });
+
+    expect(alumno.necesitaConfirmarRegistroPara(comision)).toBe(false);
+  });
+});
+
+describe("Alumno — predicados de sync", () => {
+  describe("tieneSyncDeAlumnoFallido", () => {
+    it("devuelve false cuando el flag está limpio", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: null });
+      expect(alumno.tieneSyncDeAlumnoFallido()).toBe(false);
+    });
+
+    it("devuelve true cuando el flag está prendido", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: new Date() });
+      expect(alumno.tieneSyncDeAlumnoFallido()).toBe(true);
+    });
+  });
+
+  describe("tieneSyncDeGruposFallido", () => {
+    it("devuelve false cuando el flag está limpio", () => {
+      const alumno = nuevoAlumno({ gruposSyncFallidoEn: null });
+      expect(alumno.tieneSyncDeGruposFallido()).toBe(false);
+    });
+
+    it("devuelve true cuando el flag está prendido", () => {
+      const alumno = nuevoAlumno({ gruposSyncFallidoEn: new Date() });
+      expect(alumno.tieneSyncDeGruposFallido()).toBe(true);
+    });
+  });
+
+  describe("tieneSyncPendiente", () => {
+    it("devuelve false cuando ambos flags están limpios", () => {
+      const alumno = nuevoAlumno();
+      expect(alumno.tieneSyncPendiente()).toBe(false);
+    });
+
+    it("devuelve true cuando solo falló la sync del alumno", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: new Date() });
+      expect(alumno.tieneSyncPendiente()).toBe(true);
+    });
+
+    it("devuelve true cuando solo falló la sync de grupos", () => {
+      const alumno = nuevoAlumno({ gruposSyncFallidoEn: new Date() });
+      expect(alumno.tieneSyncPendiente()).toBe(true);
+    });
+
+    it("devuelve true cuando fallaron ambas syncs", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: new Date(), gruposSyncFallidoEn: new Date() });
+      expect(alumno.tieneSyncPendiente()).toBe(true);
+    });
+  });
+
+  describe("mensajeDeSyncPendiente", () => {
+    it("devuelve string vacío cuando no hay sync pendiente", () => {
+      const alumno = nuevoAlumno();
+      expect(alumno.mensajeDeSyncPendiente()).toBe("");
+    });
+
+    it("devuelve mensaje de alumno cuando solo falló esa sync", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: new Date() });
+      expect(alumno.mensajeDeSyncPendiente()).toBe(
+        "No pudimos reflejar tus datos de alumno en la planilla."
+      );
+    });
+
+    it("devuelve mensaje de grupos cuando solo falló esa sync", () => {
+      const alumno = nuevoAlumno({ gruposSyncFallidoEn: new Date() });
+      expect(alumno.mensajeDeSyncPendiente()).toBe(
+        "No pudimos asignarte a tu grupo de TP desde la planilla."
+      );
+    });
+
+    it("devuelve mensaje combinado cuando fallaron ambas syncs", () => {
+      const alumno = nuevoAlumno({ alumnoSyncFallidoEn: new Date(), gruposSyncFallidoEn: new Date() });
+      expect(alumno.mensajeDeSyncPendiente()).toBe(
+        "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla."
+      );
+    });
+  });
+});

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -1,9 +1,20 @@
 import { Entity, ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
 import { randomUUID } from "crypto";
 import { Comision } from "./Comision";
+import { ALUMNO_LEGAJO_PATTERN, ALUMNO_EMAIL_PATTERN, normalizarGithubUsername } from "./domain-constants";
 
 @Entity()
 export class Alumno {
+  static readonly LEGAJO_PATTERN = ALUMNO_LEGAJO_PATTERN;
+  static readonly EMAIL_PATTERN = ALUMNO_EMAIL_PATTERN;
+
+  static normalizarUsername(raw: unknown): string {
+    return normalizarGithubUsername(raw);
+  }
+
+  static normalizarEmail(raw: unknown): string {
+    return String(raw ?? "").trim().toLowerCase();
+  }
   @PrimaryKey({ type: "uuid" })
   id: string = randomUUID();
 
@@ -42,7 +53,45 @@ export class Alumno {
   @Property({ type: 'datetime', nullable: true })
   alumnoSyncFallidoEn: Date | null = null;
 
+  get usernameCanonico(): string {
+    return Alumno.normalizarUsername(this.githubUsername);
+  }
+
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;
+  }
+
+  confirmoRegistroEn(comision: Comision | null): boolean {
+    if (!comision) return false;
+    return this.registroConfirmadoEn?.id === comision.id;
+  }
+
+  necesitaConfirmarRegistroPara(comision: Comision | null): boolean {
+    return !this.confirmoRegistroEn(comision);
+  }
+
+  tieneSyncDeAlumnoFallido(): boolean {
+    return this.alumnoSyncFallidoEn !== null;
+  }
+
+  tieneSyncDeGruposFallido(): boolean {
+    return this.gruposSyncFallidoEn !== null;
+  }
+
+  tieneSyncPendiente(): boolean {
+    return this.tieneSyncDeAlumnoFallido() || this.tieneSyncDeGruposFallido();
+  }
+
+  mensajeDeSyncPendiente(): string {
+    if (this.tieneSyncDeGruposFallido() && this.tieneSyncDeAlumnoFallido()) {
+      return "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla.";
+    }
+    if (this.tieneSyncDeGruposFallido()) {
+      return "No pudimos asignarte a tu grupo de TP desde la planilla.";
+    }
+    if (this.tieneSyncDeAlumnoFallido()) {
+      return "No pudimos reflejar tus datos de alumno en la planilla.";
+    }
+    return "";
   }
 }

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -37,6 +37,11 @@ export class Alumno {
   @Property({ type: 'datetime', nullable: true })
   gruposSyncFallidoEn: Date | null = null;
 
+  // Análogo a gruposSyncFallidoEn pero para la dirección DB → planilla del
+  // alta del alumno: se prende si re-upsertar la fila en Sheets falla.
+  @Property({ type: 'datetime', nullable: true })
+  alumnoSyncFallidoEn: Date | null = null;
+
   get nombreCompleto(): string {
     return `${this.apellido}, ${this.nombre}`;
   }

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -1,17 +1,19 @@
 import { describe, it, expect, vi } from "vitest";
 import { IndividualAssignment } from "./IndividualAssignment";
 import { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
-import type { Alumno } from "./Alumno";
+import { Alumno } from "./Alumno";
 import type { Grupo } from "./Grupo";
 
 function fakeAlumno(github: string): Alumno {
-  return { githubUsername: github } as Alumno;
+  return Object.assign(new Alumno(), { githubUsername: github });
 }
 
 function fakeGrupo(id: string, usernames: string[]): Grupo {
   return {
     id,
     alumnos: { getItems: () => usernames.map(fakeAlumno) },
+    usernamesDeMiembros: () => usernames,
+    usernamesCanonicos: () => usernames.map(Alumno.normalizarUsername),
   } as unknown as Grupo;
 }
 
@@ -55,6 +57,22 @@ describe("IndividualAssignment", () => {
     const buscar = vi.fn();
     await individual.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
     expect(buscar).not.toHaveBeenCalled();
+  });
+
+  it("requiereSeleccionDeGrupo siempre devuelve false", () => {
+    const individual = new IndividualAssignment();
+    expect(individual.requiereSeleccionDeGrupo({ isAdmin: false }, null)).toBe(false);
+    expect(individual.requiereSeleccionDeGrupo({ isAdmin: false }, fakeGrupo("g1", []))).toBe(false);
+    expect(individual.requiereSeleccionDeGrupo({ isAdmin: true }, null)).toBe(false);
+  });
+
+  it("alumnosSinGrupo siempre devuelve arreglo vacío", () => {
+    const individual = new IndividualAssignment();
+    expect(individual.alumnosSinGrupo([fakeAlumno("ana")], [])).toEqual([]);
+  });
+
+  it("extraFormDefaults devuelve objeto vacío", () => {
+    expect(new IndividualAssignment().extraFormDefaults()).toEqual({});
   });
 });
 
@@ -122,5 +140,74 @@ describe("GrupalAssignment", () => {
       expect(err.assignmentId).toBe("a1");
       expect(err.githubUsername).toBe("forastero");
     }
+  });
+
+  it("requiereSeleccionDeGrupo devuelve true cuando no es admin y no tiene grupo", () => {
+    expect(nuevoGrupal().requiereSeleccionDeGrupo({ isAdmin: false }, null)).toBe(true);
+  });
+
+  it("requiereSeleccionDeGrupo devuelve false cuando ya tiene grupo", () => {
+    expect(nuevoGrupal().requiereSeleccionDeGrupo({ isAdmin: false }, fakeGrupo("g1", []))).toBe(false);
+  });
+
+  it("requiereSeleccionDeGrupo devuelve false cuando es admin", () => {
+    expect(nuevoGrupal().requiereSeleccionDeGrupo({ isAdmin: true }, null)).toBe(false);
+  });
+
+  it("alumnosSinGrupo devuelve los alumnos no asignados a ningún grupo", () => {
+    const alumnos = [fakeAlumno("ana"), fakeAlumno("bob"), fakeAlumno("carol")];
+    const grupos = [fakeGrupo("g1", ["ana"])];
+    const sinGrupo = nuevoGrupal().alumnosSinGrupo(alumnos, grupos);
+    expect(sinGrupo.map((alumno) => alumno.githubUsername)).toEqual(["bob", "carol"]);
+  });
+
+  it("alumnosSinGrupo devuelve vacío cuando todos tienen grupo", () => {
+    const alumnos = [fakeAlumno("ANA"), fakeAlumno("BOB")];
+    const grupos = [fakeGrupo("g1", ["ana", "bob"])];
+    expect(nuevoGrupal().alumnosSinGrupo(alumnos, grupos)).toHaveLength(0);
+  });
+
+  it("alumnosSinGrupo es case-insensitive", () => {
+    const alumnos = [fakeAlumno("AnaGarcia")];
+    const grupos = [fakeGrupo("g1", ["anagarcia"])];
+    expect(nuevoGrupal().alumnosSinGrupo(alumnos, grupos)).toHaveLength(0);
+  });
+
+  it("extraFormDefaults incluye maxIntegrantes", () => {
+    expect(nuevoGrupal().extraFormDefaults()).toEqual({ maxIntegrantes: 4 });
+  });
+});
+
+describe("Assignment.nombreDelTemplate", () => {
+  it("devuelve solo el nombre cuando el templateRepo incluye organización", () => {
+    const individual = new IndividualAssignment();
+    individual.templateRepo = "pdep-unahur/kata-funcional";
+    expect(individual.nombreDelTemplate()).toBe("kata-funcional");
+  });
+
+  it("devuelve el templateRepo completo cuando no hay slash", () => {
+    const individual = new IndividualAssignment();
+    individual.templateRepo = "kata-funcional";
+    expect(individual.nombreDelTemplate()).toBe("kata-funcional");
+  });
+});
+
+describe("Assignment.cargarGruposCon", () => {
+  it("IndividualAssignment devuelve [] sin llamar al loader", async () => {
+    const loader = vi.fn();
+    const individual = new IndividualAssignment();
+    const result = await individual.cargarGruposCon(loader);
+    expect(result).toEqual([]);
+    expect(loader).not.toHaveBeenCalled();
+  });
+
+  it("GrupalAssignment llama al loader con su id y devuelve el resultado", async () => {
+    const grupal = new GrupalAssignment();
+    grupal.id = "a1";
+    const grupos = [fakeGrupo("g1", ["ana"])];
+    const loader = vi.fn().mockResolvedValue(grupos);
+    const result = await grupal.cargarGruposCon(loader);
+    expect(loader).toHaveBeenCalledWith("a1");
+    expect(result).toBe(grupos);
   });
 });

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -88,4 +88,37 @@ export abstract class Assignment {
     user: { githubUsername: string },
     buscarGrupoDelAlumno: BuscadorDeGrupoDelAlumno
   ): Promise<ParticipantesResueltos>;
+
+  /**
+   * `true` cuando el alumno debe elegir un grupo antes de poder aceptar el TP.
+   * Individual: siempre `false`. Grupal: `true` cuando no es admin y no tiene grupo.
+   */
+  abstract requiereSeleccionDeGrupo(user: { isAdmin: boolean }, grupo: Grupo | null): boolean;
+
+  /**
+   * Alumnos del curso que todavía no están en ningún grupo de este assignment.
+   * Individual: siempre `[]`. Grupal: filtra `alumnos` excluyendo los que aparecen en algún grupo.
+   */
+  abstract alumnosSinGrupo(alumnos: Alumno[], grupos: Grupo[]): Alumno[];
+
+  /**
+   * Campos extra del formulario de assignment específicos del subtipo.
+   * Individual: `{}`. Grupal: `{ maxIntegrantes }`.
+   */
+  abstract extraFormDefaults(): Partial<{ maxIntegrantes: number }>;
+
+  /** Nombre del repo template sin el prefijo de organización (ej. "org/repo" → "repo"). */
+  nombreDelTemplate(): string {
+    return this.templateRepo.includes("/")
+      ? this.templateRepo.split("/").pop()!
+      : this.templateRepo;
+  }
+
+  /**
+   * Carga los grupos asociados delegando en `loader`. Individual devuelve `[]`;
+   * Grupal invoca `loader(this.id)`. Evita `instanceof GrupalAssignment` en las pages.
+   */
+  abstract cargarGruposCon(
+    loader: (assignmentId: string) => Promise<Grupo[]>
+  ): Promise<Grupo[]>;
 }

--- a/src/domain/entities/Comision.ts
+++ b/src/domain/entities/Comision.ts
@@ -7,10 +7,13 @@ import {
 } from "@mikro-orm/core";
 import { randomUUID } from "crypto";
 import type { Assignment } from "./Assignment";
-import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
+import { type ColumnConfig, type GruposColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
+import { COMISION_ANIO_MIN, COMISION_ANIO_MAX } from "./domain-constants";
 
 @Entity()
 export class Comision {
+  static readonly ANIO_MIN = COMISION_ANIO_MIN;
+  static readonly ANIO_MAX = COMISION_ANIO_MAX;
   @PrimaryKey({ type: "uuid" })
   id: string = randomUUID();
 
@@ -32,5 +35,9 @@ export class Comision {
   constructor(anio: number, spreadsheetId: string) {
     this.anio = anio;
     this.spreadsheetId = spreadsheetId;
+  }
+
+  gruposConfig(): GruposColumnConfig | undefined {
+    return this.columnConfig?.grupos;
   }
 }

--- a/src/domain/entities/Entrega.test.ts
+++ b/src/domain/entities/Entrega.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { Entrega } from "./Entrega";
+
+function nuevaEntrega(overrides: Partial<Entrega> = {}): Entrega {
+  const entrega = new Entrega();
+  entrega.githubUsernames = ["ana-garcia"];
+  entrega.repoDeleted = false;
+  return Object.assign(entrega, overrides);
+}
+
+describe("Entrega.hasRepo", () => {
+  it("devuelve true cuando hay repoUrl y no fue borrado", () => {
+    const entrega = nuevaEntrega({ repoUrl: "https://github.com/org/repo", repoDeleted: false });
+    expect(entrega.hasRepo()).toBe(true);
+  });
+
+  it("devuelve false cuando no hay repoUrl", () => {
+    const entrega = nuevaEntrega({ repoUrl: undefined });
+    expect(entrega.hasRepo()).toBe(false);
+  });
+
+  it("devuelve false cuando el repo fue borrado", () => {
+    const entrega = nuevaEntrega({ repoUrl: "https://github.com/org/repo", repoDeleted: true });
+    expect(entrega.hasRepo()).toBe(false);
+  });
+});
+
+describe("Entrega.repoFueBorrado", () => {
+  it("devuelve true cuando hay repoName y repoDeleted es true", () => {
+    const entrega = nuevaEntrega({ repoName: "org-repo", repoDeleted: true });
+    expect(entrega.repoFueBorrado()).toBe(true);
+  });
+
+  it("devuelve false cuando repoDeleted es false", () => {
+    const entrega = nuevaEntrega({ repoName: "org-repo", repoDeleted: false });
+    expect(entrega.repoFueBorrado()).toBe(false);
+  });
+
+  it("devuelve false cuando no hay repoName", () => {
+    const entrega = nuevaEntrega({ repoName: undefined, repoDeleted: true });
+    expect(entrega.repoFueBorrado()).toBe(false);
+  });
+});
+
+describe("Entrega.estadoRepo", () => {
+  it("devuelve 'activo' cuando tiene repo y no fue borrado", () => {
+    const entrega = nuevaEntrega({
+      repoName: "repo",
+      repoUrl: "https://github.com/org/repo",
+      repoDeleted: false,
+    });
+    expect(entrega.estadoRepo()).toBe("activo");
+  });
+
+  it("devuelve 'borrado' cuando el repo fue borrado", () => {
+    const entrega = nuevaEntrega({ repoName: "repo", repoUrl: "https://github.com/org/repo", repoDeleted: true });
+    expect(entrega.estadoRepo()).toBe("borrado");
+  });
+
+  it("devuelve 'sin-repo' cuando nunca tuvo repo", () => {
+    const entrega = nuevaEntrega({ repoName: undefined, repoUrl: undefined });
+    expect(entrega.estadoRepo()).toBe("sin-repo");
+  });
+});
+
+describe("Entrega.matcheaQuery", () => {
+  it("devuelve true para query vacía (no filtra nada)", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["ana"] });
+    expect(entrega.matcheaQuery("")).toBe(true);
+    expect(entrega.matcheaQuery("   ")).toBe(true);
+  });
+
+  it("devuelve true cuando la query coincide con un username", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia", "bob"] });
+    expect(entrega.matcheaQuery("ana")).toBe(true);
+  });
+
+  it("es case-insensitive en usernames", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia"] });
+    expect(entrega.matcheaQuery("anagarcia")).toBe(true);
+    expect(entrega.matcheaQuery("ANAGARCIA")).toBe(true);
+  });
+
+  it("devuelve true cuando la query coincide con el repoName", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
+    expect(entrega.matcheaQuery("funcional")).toBe(true);
+  });
+
+  it("devuelve false cuando la query no coincide con ningún campo", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
+    expect(entrega.matcheaQuery("logico")).toBe(false);
+  });
+
+  it("tolera repoName undefined sin explotar", () => {
+    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: undefined });
+    expect(entrega.matcheaQuery("algo")).toBe(false);
+  });
+});

--- a/src/domain/entities/Entrega.ts
+++ b/src/domain/entities/Entrega.ts
@@ -8,6 +8,7 @@ import { randomUUID } from "crypto";
 import { Alumno } from "./Alumno";
 import { Assignment } from "./Assignment";
 import { Grupo } from "./Grupo";
+import { matcheaEntregaQuery } from "@/lib/entrega-query";
 
 @Entity()
 export class Entrega {
@@ -43,5 +44,23 @@ export class Entrega {
 
   hasRepo(): boolean {
     return !!this.repoUrl && !this.repoDeleted;
+  }
+
+  repoFueBorrado(): boolean {
+    return !!this.repoName && this.repoDeleted;
+  }
+
+  noTieneRepo(): boolean {
+    return !this.repoName;
+  }
+
+  estadoRepo(): "borrado" | "activo" | "sin-repo" {
+    if (this.repoFueBorrado()) return "borrado";
+    if (this.hasRepo()) return "activo";
+    return "sin-repo";
+  }
+
+  matcheaQuery(rawQuery: string): boolean {
+    return matcheaEntregaQuery(this, rawQuery);
   }
 }

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -25,11 +25,22 @@ export class GrupalAssignment extends Assignment {
   @Property({ type: 'integer' })
   maxIntegrantes!: number;
 
+  // Cerrado por el docente cuando los grupos ya están trabajando y no quiere
+  // que se sumen alumnos despistados. Independiente de si los grupos están
+  // llenos o no — un grupo con cupo libre tampoco recibe nuevos miembros si
+  // este flag está prendido.
+  @Property({ type: 'boolean', default: false })
+  inscripcionesCerradas: boolean = false;
+
   @OneToMany("Grupo", "assignment")
   grupos = new Collection<Grupo>(this);
 
   etiquetaTotales(): string {
     return "Grupos";
+  }
+
+  aceptaNuevasInscripciones(): boolean {
+    return !this.inscripcionesCerradas;
   }
 
   async totalEsperado(fuentes: FuentesDeConteo): Promise<number> {

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -5,7 +5,9 @@ import {
   type ParticipantesResueltos,
   type FuentesDeConteo,
 } from "./Assignment";
+import type { Alumno } from "./Alumno";
 import type { Grupo } from "./Grupo";
+import { GRUPAL_MIN_MAX_INTEGRANTES } from "./domain-constants";
 
 // Lanzado cuando un alumno intenta aceptar un TP grupal y no figura en
 // ningún grupo del assignment. El handler de accept lo traduce a 400 con
@@ -22,6 +24,8 @@ export class GrupoNoAsignadoError extends Error {
 
 @Entity({ discriminatorValue: "grupal" })
 export class GrupalAssignment extends Assignment {
+  static readonly MIN_MAX_INTEGRANTES = GRUPAL_MIN_MAX_INTEGRANTES;
+
   @Property({ type: 'integer' })
   maxIntegrantes!: number;
 
@@ -56,8 +60,27 @@ export class GrupalAssignment extends Assignment {
       throw new GrupoNoAsignadoError(this.id, user.githubUsername);
     }
     return {
-      usernames: grupo.alumnos.getItems().map((alumno) => alumno.githubUsername),
+      usernames: grupo.usernamesDeMiembros(),
       grupoId: grupo.id,
     };
+  }
+
+  requiereSeleccionDeGrupo(user: { isAdmin: boolean }, grupo: Grupo | null): boolean {
+    return !user.isAdmin && !grupo;
+  }
+
+  alumnosSinGrupo(alumnos: Alumno[], grupos: Grupo[]): Alumno[] {
+    const alumnosConGrupo = new Set(
+      grupos.flatMap((grupo) => grupo.usernamesCanonicos())
+    );
+    return alumnos.filter((alumno) => !alumnosConGrupo.has(alumno.usernameCanonico));
+  }
+
+  extraFormDefaults(): Partial<{ maxIntegrantes: number }> {
+    return { maxIntegrantes: this.maxIntegrantes };
+  }
+
+  cargarGruposCon(loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
+    return loader(this.id);
   }
 }

--- a/src/domain/entities/Grupo.test.ts
+++ b/src/domain/entities/Grupo.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from "vitest";
+import { Collection } from "@mikro-orm/core";
+import {
+  Grupo,
+  GrupoLlenoError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  InscripcionesCerradasError,
+  AssignmentNoGrupalError,
+} from "./Grupo";
+import { GrupalAssignment } from "./GrupalAssignment";
+import type { Alumno } from "./Alumno";
+
+function fakeAlumno(github: string): Alumno {
+  return {
+    id: `id-${github}`,
+    githubUsername: github,
+  } as Alumno;
+}
+
+function nuevoGrupo(maxIntegrantes: number, miembros: Alumno[] = []): Grupo {
+  const grupo = new Grupo();
+  grupo.id = "g1";
+  grupo.nombre = "Los Lambdas";
+  grupo.paradigma = "funcional";
+  grupo.maxIntegrantes = maxIntegrantes;
+  grupo.creadoPor = miembros[0]?.githubUsername ?? "alguien";
+  // Reemplazo la Collection real por una mínima testeable: contains() y add().
+  // Evita arrastrar el ORM en tests puros de la entidad.
+  const items: Alumno[] = [...miembros];
+  grupo.alumnos = {
+    contains: (alumno: Alumno) => items.some((member) => member.id === alumno.id),
+    add: (alumno: Alumno) => items.push(alumno),
+    get length() {
+      return items.length;
+    },
+  } as unknown as Collection<Alumno>;
+  return grupo;
+}
+
+describe("Grupo", () => {
+  describe("isOpen", () => {
+    it("es true cuando hay menos miembros que el max", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      expect(grupo.isOpen()).toBe(true);
+    });
+
+    it("es false cuando se alcanza el max", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.isOpen()).toBe(false);
+    });
+  });
+
+  describe("canJoin", () => {
+    it("permite unirse si hay cupo y el alumno no es miembro", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      expect(grupo.canJoin(fakeAlumno("bob"))).toBe(true);
+    });
+
+    it("rechaza si el alumno ya es miembro", () => {
+      const ana = fakeAlumno("ana");
+      const grupo = nuevoGrupo(3, [ana]);
+      expect(grupo.canJoin(ana)).toBe(false);
+    });
+
+    it("rechaza si el grupo está lleno", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.canJoin(fakeAlumno("cora"))).toBe(false);
+    });
+  });
+
+  describe("addMember", () => {
+    it("suma al alumno cuando hay cupo y no es miembro", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      const bob = fakeAlumno("bob");
+      grupo.addMember(bob);
+      expect(grupo.alumnos.contains(bob)).toBe(true);
+    });
+
+    it("lanza GrupoLlenoError cuando ya alcanzó el max", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(() => grupo.addMember(fakeAlumno("cora"))).toThrow(GrupoLlenoError);
+    });
+
+    it("el GrupoLlenoError lleva el grupoId y maxIntegrantes para diagnóstico", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      try {
+        grupo.addMember(fakeAlumno("cora"));
+        expect.fail("debería haber lanzado GrupoLlenoError");
+      } catch (error) {
+        expect(error).toBeInstanceOf(GrupoLlenoError);
+        const lleno = error as GrupoLlenoError;
+        expect(lleno.grupoId).toBe("g1");
+        expect(lleno.maxIntegrantes).toBe(2);
+      }
+    });
+
+    it("lanza Error genérico si el alumno ya es miembro (programmer error: el caller debió validar antes)", () => {
+      const ana = fakeAlumno("ana");
+      const grupo = nuevoGrupo(3, [ana]);
+      expect(() => grupo.addMember(ana)).toThrow(/ya es miembro/);
+    });
+  });
+});
+
+describe("GrupalAssignment.aceptaNuevasInscripciones", () => {
+  function nuevoGrupal(): GrupalAssignment {
+    const grupal = new GrupalAssignment();
+    grupal.id = "a1";
+    grupal.maxIntegrantes = 3;
+    return grupal;
+  }
+
+  it("acepta inscripciones por default (flag inicializa false)", () => {
+    expect(nuevoGrupal().aceptaNuevasInscripciones()).toBe(true);
+  });
+
+  it("rechaza cuando el docente cerró las inscripciones", () => {
+    const grupal = nuevoGrupal();
+    grupal.inscripcionesCerradas = true;
+    expect(grupal.aceptaNuevasInscripciones()).toBe(false);
+  });
+});
+
+// Smoke test: los errores tipados llevan los datos de diagnóstico esperados
+// y el handler HTTP los puede discriminar por `instanceof` o por `name`.
+describe("Errores de negocio de inscripción a grupos", () => {
+  it("InscripcionesCerradasError lleva el assignmentId", () => {
+    const error = new InscripcionesCerradasError("a1");
+    expect(error.assignmentId).toBe("a1");
+    expect(error.name).toBe("InscripcionesCerradasError");
+  });
+
+  it("AlumnoYaEnGrupoDelAssignmentError lleva assignmentId y githubUsername", () => {
+    const error = new AlumnoYaEnGrupoDelAssignmentError("a1", "ana");
+    expect(error.assignmentId).toBe("a1");
+    expect(error.githubUsername).toBe("ana");
+    expect(error.name).toBe("AlumnoYaEnGrupoDelAssignmentError");
+  });
+
+  it("AssignmentNoGrupalError lleva el assignmentId", () => {
+    const error = new AssignmentNoGrupalError("a1");
+    expect(error.assignmentId).toBe("a1");
+    expect(error.name).toBe("AssignmentNoGrupalError");
+  });
+});

--- a/src/domain/entities/Grupo.test.ts
+++ b/src/domain/entities/Grupo.test.ts
@@ -8,13 +8,13 @@ import {
   AssignmentNoGrupalError,
 } from "./Grupo";
 import { GrupalAssignment } from "./GrupalAssignment";
-import type { Alumno } from "./Alumno";
+import { Alumno } from "./Alumno";
 
 function fakeAlumno(github: string): Alumno {
-  return {
+  return Object.assign(new Alumno(), {
     id: `id-${github}`,
     githubUsername: github,
-  } as Alumno;
+  });
 }
 
 function nuevoGrupo(maxIntegrantes: number, miembros: Alumno[] = []): Grupo {
@@ -24,15 +24,12 @@ function nuevoGrupo(maxIntegrantes: number, miembros: Alumno[] = []): Grupo {
   grupo.paradigma = "funcional";
   grupo.maxIntegrantes = maxIntegrantes;
   grupo.creadoPor = miembros[0]?.githubUsername ?? "alguien";
-  // Reemplazo la Collection real por una mínima testeable: contains() y add().
-  // Evita arrastrar el ORM en tests puros de la entidad.
   const items: Alumno[] = [...miembros];
   grupo.alumnos = {
     contains: (alumno: Alumno) => items.some((member) => member.id === alumno.id),
-    add: (alumno: Alumno) => items.push(alumno),
-    get length() {
-      return items.length;
-    },
+    add: (alumno: Alumno) => { items.push(alumno); },
+    getItems: () => items,
+    get length() { return items.length; },
   } as unknown as Collection<Alumno>;
   return grupo;
 }
@@ -98,6 +95,98 @@ describe("Grupo", () => {
       const ana = fakeAlumno("ana");
       const grupo = nuevoGrupo(3, [ana]);
       expect(() => grupo.addMember(ana)).toThrow(/ya es miembro/);
+    });
+  });
+});
+
+describe("Grupo — predicados de cupo", () => {
+  describe("estaLleno", () => {
+    it("devuelve false cuando hay cupo disponible", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      expect(grupo.estaLleno()).toBe(false);
+    });
+
+    it("devuelve true cuando el grupo alcanzó el máximo", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.estaLleno()).toBe(true);
+    });
+  });
+
+  describe("cantidadMiembros", () => {
+    it("devuelve 0 para un grupo vacío", () => {
+      const grupo = nuevoGrupo(3);
+      expect(grupo.cantidadMiembros()).toBe(0);
+    });
+
+    it("devuelve la cantidad de miembros actuales", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.cantidadMiembros()).toBe(2);
+    });
+  });
+
+  describe("etiquetaCupo", () => {
+    it("muestra 'Completo' cuando está lleno", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.etiquetaCupo()).toBe("Completo (2/2)");
+    });
+
+    it("muestra 'X/N integrantes' cuando hay cupo", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      expect(grupo.etiquetaCupo()).toBe("1/3 integrantes");
+    });
+  });
+});
+
+describe("Grupo — pertenencia", () => {
+  describe("contieneA", () => {
+    it("devuelve true cuando el username coincide (exacto)", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("AnaGarcia")]);
+      expect(grupo.contieneA("AnaGarcia")).toBe(true);
+    });
+
+    it("es case-insensitive", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("AnaGarcia")]);
+      expect(grupo.contieneA("anagarcia")).toBe(true);
+      expect(grupo.contieneA("ANAGARCIA")).toBe(true);
+    });
+
+    it("devuelve false cuando el username no está en el grupo", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana")]);
+      expect(grupo.contieneA("bob")).toBe(false);
+    });
+
+    it("devuelve false para un grupo vacío", () => {
+      const grupo = nuevoGrupo(3);
+      expect(grupo.contieneA("ana")).toBe(false);
+    });
+  });
+
+  describe("usernamesDeMiembros", () => {
+    it("devuelve lista vacía para grupo sin miembros", () => {
+      const grupo = nuevoGrupo(3);
+      expect(grupo.usernamesDeMiembros()).toEqual([]);
+    });
+
+    it("devuelve los githubUsernames de todos los miembros", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("ana"), fakeAlumno("bob")]);
+      expect(grupo.usernamesDeMiembros()).toEqual(["ana", "bob"]);
+    });
+
+    it("preserva el casing original almacenado en DB", () => {
+      const grupo = nuevoGrupo(2, [fakeAlumno("AnaGarcia")]);
+      expect(grupo.usernamesDeMiembros()).toEqual(["AnaGarcia"]);
+    });
+  });
+
+  describe("usernamesCanonicos", () => {
+    it("devuelve lista vacía para grupo sin miembros", () => {
+      const grupo = nuevoGrupo(3);
+      expect(grupo.usernamesCanonicos()).toEqual([]);
+    });
+
+    it("normaliza todos los usernames a minúsculas y sin @", () => {
+      const grupo = nuevoGrupo(3, [fakeAlumno("@AnaGarcia"), fakeAlumno("BOB")]);
+      expect(grupo.usernamesCanonicos()).toEqual(["anagarcia", "bob"]);
     });
   });
 });

--- a/src/domain/entities/Grupo.ts
+++ b/src/domain/entities/Grupo.ts
@@ -12,6 +12,44 @@ import { Alumno } from "./Alumno";
 import type { GrupalAssignment } from "./GrupalAssignment";
 import type { Paradigma } from "@/types";
 
+// Errores de negocio del flujo self-serve de inscripción a grupos. El handler
+// HTTP los traduce a 400/409 con mensajes amigables. Análogos a
+// `GrupoNoAsignadoError`: tipados para que el caller pueda discriminar.
+
+export class InscripcionesCerradasError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Las inscripciones a grupos están cerradas para este TP.");
+    this.name = "InscripcionesCerradasError";
+  }
+}
+
+export class AlumnoYaEnGrupoDelAssignmentError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly githubUsername: string
+  ) {
+    super("Ya estás en un grupo para este TP.");
+    this.name = "AlumnoYaEnGrupoDelAssignmentError";
+  }
+}
+
+export class GrupoLlenoError extends Error {
+  constructor(
+    public readonly grupoId: string,
+    public readonly maxIntegrantes: number
+  ) {
+    super(`El grupo está completo (${maxIntegrantes} integrantes).`);
+    this.name = "GrupoLlenoError";
+  }
+}
+
+export class AssignmentNoGrupalError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Este TP no es grupal.");
+    this.name = "AssignmentNoGrupalError";
+  }
+}
+
 @Entity()
 export class Grupo {
   @PrimaryKey({ type: "uuid" })
@@ -44,12 +82,11 @@ export class Grupo {
   }
 
   addMember(alumno: Alumno): void {
-    if (!this.canJoin(alumno)) {
-      throw new Error(
-        this.alumnos.contains(alumno)
-          ? `${alumno.githubUsername} ya es miembro del grupo`
-          : `El grupo está completo (${this.maxIntegrantes} integrantes)`
-      );
+    if (this.alumnos.contains(alumno)) {
+      throw new Error(`${alumno.githubUsername} ya es miembro del grupo`);
+    }
+    if (!this.isOpen()) {
+      throw new GrupoLlenoError(this.id, this.maxIntegrantes);
     }
     this.alumnos.add(alumno);
   }

--- a/src/domain/entities/Grupo.ts
+++ b/src/domain/entities/Grupo.ts
@@ -77,6 +77,36 @@ export class Grupo {
     return this.alumnos.length < this.maxIntegrantes;
   }
 
+  estaLleno(): boolean {
+    return !this.isOpen();
+  }
+
+  cantidadMiembros(): number {
+    return this.alumnos.length;
+  }
+
+  etiquetaCupo(): string {
+    if (this.estaLleno()) {
+      return `Completo (${this.maxIntegrantes}/${this.maxIntegrantes})`;
+    }
+    return `${this.cantidadMiembros()}/${this.maxIntegrantes} integrantes`;
+  }
+
+  contieneA(githubUsername: string): boolean {
+    const canonico = Alumno.normalizarUsername(githubUsername);
+    return this.alumnos
+      .getItems()
+      .some((alumno) => alumno.usernameCanonico === canonico);
+  }
+
+  usernamesDeMiembros(): string[] {
+    return this.alumnos.getItems().map((alumno) => alumno.githubUsername);
+  }
+
+  usernamesCanonicos(): string[] {
+    return this.alumnos.getItems().map((alumno) => alumno.usernameCanonico);
+  }
+
   canJoin(alumno: Alumno): boolean {
     return this.isOpen() && !this.alumnos.contains(alumno);
   }

--- a/src/domain/entities/IndividualAssignment.ts
+++ b/src/domain/entities/IndividualAssignment.ts
@@ -1,5 +1,6 @@
 import { Collection, Entity, ManyToMany } from "@mikro-orm/core";
 import { Alumno } from "./Alumno";
+import type { Grupo } from "./Grupo";
 import {
   Assignment,
   type ParticipantesResueltos,
@@ -24,5 +25,21 @@ export class IndividualAssignment extends Assignment {
     githubUsername: string;
   }): Promise<ParticipantesResueltos> {
     return { usernames: [user.githubUsername] };
+  }
+
+  requiereSeleccionDeGrupo(_user: { isAdmin: boolean }, _grupo: Grupo | null): boolean {
+    return false;
+  }
+
+  alumnosSinGrupo(_alumnos: Alumno[], _grupos: Grupo[]): Alumno[] {
+    return [];
+  }
+
+  extraFormDefaults(): Partial<{ maxIntegrantes: number }> {
+    return {};
+  }
+
+  cargarGruposCon(_loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
+    return Promise.resolve([]);
   }
 }

--- a/src/domain/entities/domain-constants.test.ts
+++ b/src/domain/entities/domain-constants.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { normalizarGithubUsername } from "./domain-constants";
+
+describe("normalizarGithubUsername", () => {
+  it("elimina un @ inicial", () => {
+    expect(normalizarGithubUsername("@juancete")).toBe("juancete");
+  });
+
+  it("elimina múltiples @ iniciales", () => {
+    expect(normalizarGithubUsername("@@juancete")).toBe("juancete");
+  });
+
+  it("no toca @ en medio del nombre", () => {
+    expect(normalizarGithubUsername("juan@cete")).toBe("juan@cete");
+  });
+
+  it("normaliza a minúsculas", () => {
+    expect(normalizarGithubUsername("@JuanCete")).toBe("juancete");
+  });
+
+  it("elimina espacios en los extremos", () => {
+    expect(normalizarGithubUsername("  @juancete  ")).toBe("juancete");
+  });
+
+  it("devuelve string vacío para null", () => {
+    expect(normalizarGithubUsername(null)).toBe("");
+  });
+
+  it("devuelve string vacío para undefined", () => {
+    expect(normalizarGithubUsername(undefined)).toBe("");
+  });
+});

--- a/src/domain/entities/domain-constants.ts
+++ b/src/domain/entities/domain-constants.ts
@@ -5,5 +5,5 @@ export const COMISION_ANIO_MAX = 2100;
 export const GRUPAL_MIN_MAX_INTEGRANTES = 2;
 
 export function normalizarGithubUsername(raw: unknown): string {
-  return String(raw ?? "").trim().replace("@", "").toLowerCase();
+  return String(raw ?? "").trim().replace(/^@+/, "").toLowerCase();
 }

--- a/src/domain/entities/domain-constants.ts
+++ b/src/domain/entities/domain-constants.ts
@@ -1,0 +1,9 @@
+export const ALUMNO_LEGAJO_PATTERN = "\\d{4,8}";
+export const ALUMNO_EMAIL_PATTERN = "[^\\s@]+@[^\\s@]+\\.[^\\s@]+";
+export const COMISION_ANIO_MIN = 2020;
+export const COMISION_ANIO_MAX = 2100;
+export const GRUPAL_MIN_MAX_INTEGRANTES = 2;
+
+export function normalizarGithubUsername(raw: unknown): string {
+  return String(raw ?? "").trim().replace("@", "").toLowerCase();
+}

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -8,5 +8,11 @@ export type {
 } from "./Assignment";
 export { IndividualAssignment } from "./IndividualAssignment";
 export { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
-export { Grupo } from "./Grupo";
+export {
+  Grupo,
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  GrupoLlenoError,
+  AssignmentNoGrupalError,
+} from "./Grupo";
 export { Entrega } from "./Entrega";

--- a/src/lib/assignment-schema.ts
+++ b/src/lib/assignment-schema.ts
@@ -17,7 +17,7 @@ export const AssignmentBaseSchema = z.object({
   maxIntegrantes: z.coerce
     .number()
     .int()
-    .min(GRUPAL_MIN_MAX_INTEGRANTES, "Mínimo 2 integrantes")
+    .min(GRUPAL_MIN_MAX_INTEGRANTES, `Mínimo ${GRUPAL_MIN_MAX_INTEGRANTES} integrantes`)
     .optional(),
 });
 

--- a/src/lib/assignment-schema.ts
+++ b/src/lib/assignment-schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { PARADIGMAS } from "@/types";
+import { GRUPAL_MIN_MAX_INTEGRANTES } from "@/domain/entities/domain-constants";
 
 export const AssignmentBaseSchema = z.object({
   titulo: z.string().min(1, "El título es obligatorio"),
@@ -16,7 +17,7 @@ export const AssignmentBaseSchema = z.object({
   maxIntegrantes: z.coerce
     .number()
     .int()
-    .min(2, "Mínimo 2 integrantes")
+    .min(GRUPAL_MIN_MAX_INTEGRANTES, "Mínimo 2 integrantes")
     .optional(),
 });
 

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -4,7 +4,7 @@ import type { PdepUser } from "@/types";
 
 const adminUsernames = (process.env.ADMIN_GITHUB_USERNAMES ?? "")
   .split(",")
-  .map((u) => u.trim().toLowerCase())
+  .map((username) => username.trim().toLowerCase())
   .filter(Boolean);
 
 export const authConfig: NextAuthConfig = {

--- a/src/lib/auth.events.test.ts
+++ b/src/lib/auth.events.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetComisionActiva = vi.fn();
+const mockVerificarConsistenciaAlumno = vi.fn();
+
+vi.mock("./repositories", () => ({
+  getComisionActiva: () => mockGetComisionActiva(),
+}));
+
+vi.mock("./services/verificarConsistenciaAlumno", () => ({
+  verificarConsistenciaAlumno: (...args: unknown[]) =>
+    mockVerificarConsistenciaAlumno(...args),
+}));
+
+import { onSignIn } from "./auth.events";
+
+const comision = { id: "c1", spreadsheetId: "sheet-xyz" };
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("auth events — onSignIn", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetComisionActiva.mockResolvedValue(comision);
+    mockVerificarConsistenciaAlumno.mockResolvedValue(undefined);
+  });
+
+  it("no hace nada si el profile no trae login", async () => {
+    await onSignIn({ name: "Sin login" });
+
+    expect(mockGetComisionActiva).not.toHaveBeenCalled();
+    expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
+  });
+
+  it("no hace nada si profile es null/undefined", async () => {
+    await onSignIn(null);
+    await onSignIn(undefined);
+
+    expect(mockGetComisionActiva).not.toHaveBeenCalled();
+    expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
+  });
+
+  it("no dispara verificarConsistenciaAlumno si no hay comisión activa", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+
+    await onSignIn({ login: "juangarcia" });
+
+    expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
+  });
+
+  it("dispara verificarConsistenciaAlumno con el login y la comisión activa", async () => {
+    await onSignIn({ login: "juangarcia" });
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(mockVerificarConsistenciaAlumno).toHaveBeenCalledWith(
+      "juangarcia",
+      comision
+    );
+  });
+
+  it("no throwea ni bloquea si verificarConsistenciaAlumno rejecta (fire-and-forget)", async () => {
+    mockVerificarConsistenciaAlumno.mockRejectedValue(new Error("Sheets caído"));
+
+    await expect(onSignIn({ login: "juangarcia" })).resolves.toBeUndefined();
+  });
+
+  it("no throwea si getComisionActiva falla", async () => {
+    mockGetComisionActiva.mockRejectedValue(new Error("DB hipada"));
+
+    await expect(onSignIn({ login: "juangarcia" })).resolves.toBeUndefined();
+    expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/auth.events.ts
+++ b/src/lib/auth.events.ts
@@ -1,0 +1,33 @@
+import { logger } from "./logger";
+import { getComisionActiva } from "./repositories";
+import { verificarConsistenciaAlumno } from "./services/verificarConsistenciaAlumno";
+
+/**
+ * Handler de `events.signIn` de NextAuth: corre server-side tras un OAuth
+ * flow exitoso (no en revalidación de JWT). Lanza DB→Sheets fire-and-forget
+ * para no bloquear el redirect post-OAuth.
+ *
+ * Vive en su propio módulo para que sea testeable sin necesidad de simular
+ * el setup completo de NextAuth.
+ */
+export async function onSignIn(profile: unknown): Promise<void> {
+  const githubUsername = (profile as { login?: string } | null | undefined)
+    ?.login;
+  if (!githubUsername) return;
+
+  const comisionActiva = await getComisionActiva().catch((error) => {
+    logger.error(
+      { err: error, githubUsername },
+      "getComisionActiva falló en events.signIn"
+    );
+    return null;
+  });
+  if (!comisionActiva) return;
+
+  verificarConsistenciaAlumno(githubUsername, comisionActiva).catch((error) => {
+    logger.error(
+      { err: error, githubUsername },
+      "verificarConsistenciaAlumno lanzó excepción inesperada tras login"
+    );
+  });
+}

--- a/src/lib/auth.events.ts
+++ b/src/lib/auth.events.ts
@@ -11,9 +11,9 @@ import { verificarConsistenciaAlumno } from "./services/verificarConsistenciaAlu
  * el setup completo de NextAuth.
  */
 export async function onSignIn(profile: unknown): Promise<void> {
-  const githubUsername = (profile as { login?: string } | null | undefined)
+  const githubUsername = (profile as { login?: unknown } | null | undefined)
     ?.login;
-  if (!githubUsername) return;
+  if (typeof githubUsername !== "string" || !githubUsername) return;
 
   const comisionActiva = await getComisionActiva().catch((error) => {
     logger.error(

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,15 @@
 import NextAuth from "next-auth";
 import { authConfig } from "./auth.config";
+import { onSignIn } from "./auth.events";
 
-export const { handlers, signIn, signOut, auth } = NextAuth(authConfig);
+// Los `events` viven en `auth.events.ts` (no en `auth.config.ts`) porque
+// importan servicios que tocan MikroORM. El middleware instancia NextAuth
+// con `authConfig` directamente y corre en edge runtime — separar los
+// eventos garantiza que ese grafo de imports no se acople al bundle del
+// middleware.
+export const { handlers, signIn, signOut, auth } = NextAuth({
+  ...authConfig,
+  events: {
+    signIn: ({ profile }) => onSignIn(profile),
+  },
+});

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -65,10 +65,10 @@ export async function deleteEntity<T extends object>(
   EntityClass: abstract new (...args: never[]) => T,
   id: string
 ): Promise<void> {
-  const em = await getEM();
-  const entity = await em.findOne(EntityClass, { id } as never);
+  const entityManager = await getEM();
+  const entity = await entityManager.findOne(EntityClass, { id } as never);
   if (entity) {
-    em.remove(entity);
-    await em.flush();
+    entityManager.remove(entity);
+    await entityManager.flush();
   }
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -27,11 +27,27 @@ export async function getOrm(): Promise<MikroORM> {
 
   // Evita que múltiples requests simultáneos en dev inicien varias conexiones
   if (!global.__mikro_orm_init__) {
-    global.__mikro_orm_init__ = MikroORM.init(config).then((orm) => {
-      global.__mikro_orm__ = orm;
-      global.__mikro_orm_init__ = undefined;
-      return orm;
-    });
+    global.__mikro_orm_init__ = MikroORM.init(config)
+      .then((orm) => {
+        global.__mikro_orm__ = orm;
+        global.__mikro_orm_init__ = undefined;
+        return orm;
+      })
+      .catch((cause: unknown) => {
+        global.__mikro_orm_init__ = undefined;
+        const isConnectionError =
+          cause instanceof Error &&
+          (cause.message.includes("ECONNREFUSED") ||
+            cause.message.includes("ENOTFOUND") ||
+            (cause as NodeJS.ErrnoException).code === "ECONNREFUSED");
+        if (isConnectionError || (cause instanceof AggregateError)) {
+          throw new Error(
+            `No se pudo conectar a la base de datos (${process.env.DATABASE_URL?.replace(/:[^:@]+@/, ":***@") ?? "sin URL configurada"}). Verificá que el servidor esté disponible.`,
+            { cause }
+          );
+        }
+        throw cause;
+      });
   }
 
   return global.__mikro_orm_init__;

--- a/src/lib/entrega-query.test.ts
+++ b/src/lib/entrega-query.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { matcheaEntregaQuery } from "./entrega-query";
+
+describe("matcheaEntregaQuery", () => {
+  it("devuelve true con query vacío", () => {
+    expect(matcheaEntregaQuery({ githubUsernames: [], repoName: null }, "")).toBe(true);
+    expect(matcheaEntregaQuery({ githubUsernames: [], repoName: null }, "   ")).toBe(true);
+  });
+
+  it("matchea por username (case-insensitive)", () => {
+    const row = { githubUsernames: ["JuanGarcia", "MariaLopez"], repoName: undefined };
+    expect(matcheaEntregaQuery(row, "juan")).toBe(true);
+    expect(matcheaEntregaQuery(row, "MARIA")).toBe(true);
+    expect(matcheaEntregaQuery(row, "garcia")).toBe(true);
+  });
+
+  it("matchea por nombre de repo (case-insensitive)", () => {
+    const row = { githubUsernames: [], repoName: "tp-funcional-2024" };
+    expect(matcheaEntregaQuery(row, "funcional")).toBe(true);
+    expect(matcheaEntregaQuery(row, "FUNCIONAL")).toBe(true);
+  });
+
+  it("no matchea cuando no hay coincidencia", () => {
+    const row = { githubUsernames: ["ana"], repoName: "tp-logico" };
+    expect(matcheaEntregaQuery(row, "juan")).toBe(false);
+  });
+
+  it("trata repoName null como string vacío", () => {
+    const row = { githubUsernames: ["ana"], repoName: null };
+    expect(matcheaEntregaQuery(row, "logico")).toBe(false);
+  });
+
+  it("trata repoName undefined como string vacío", () => {
+    const row = { githubUsernames: ["ana"], repoName: undefined };
+    expect(matcheaEntregaQuery(row, "logico")).toBe(false);
+  });
+
+  it("matchea parcialmente (substring)", () => {
+    const row = { githubUsernames: ["juanperez"], repoName: "tp-objetos-2024" };
+    expect(matcheaEntregaQuery(row, "perez")).toBe(true);
+    expect(matcheaEntregaQuery(row, "objetos")).toBe(true);
+  });
+});

--- a/src/lib/entrega-query.ts
+++ b/src/lib/entrega-query.ts
@@ -1,0 +1,11 @@
+export function matcheaEntregaQuery(
+  row: { githubUsernames: string[]; repoName?: string | null },
+  rawQuery: string
+): boolean {
+  const query = rawQuery.toLowerCase().trim();
+  if (!query) return true;
+  return (
+    row.githubUsernames.some((username) => username.toLowerCase().includes(query)) ||
+    (row.repoName ?? "").toLowerCase().includes(query)
+  );
+}

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -33,8 +33,8 @@ function getOctokit(): Octokit {
       // Fallback: PAT clásico (para desarrollo rápido)
       _octokit = new Octokit({ auth: process.env.GITHUB_PAT });
     }
-  } catch (e) {
-    handleOctokitError(e);
+  } catch (error) {
+    handleOctokitError(error);
   }
 
   return _octokit!;
@@ -69,8 +69,8 @@ export async function createRepoFromTemplate(
       repoUrl: data.html_url,
       repoFullName: data.full_name,
     };
-  } catch (e) {
-    handleOctokitError(e);
+  } catch (error) {
+    handleOctokitError(error);
   }
 }
 
@@ -94,8 +94,8 @@ export async function addCollaborators(
         })
       )
     );
-  } catch (e) {
-    handleOctokitError(e);
+  } catch (error) {
+    handleOctokitError(error);
   }
 }
 
@@ -125,7 +125,7 @@ export async function crearEntrega(opts: {
   });
 
   // Pequeña pausa para que GitHub procese la creación
-  await new Promise((r) => setTimeout(r, 1500));
+  await new Promise((resolve) => setTimeout(resolve, 1500));
 
   await addCollaborators(repoName, opts.usernames);
 
@@ -148,14 +148,14 @@ export async function listarReposDeAssignment(
     });
 
     return data
-      .filter((r) => r.name.startsWith(`${slug}-`))
-      .map((r) => ({
-        name: r.name,
-        url: r.html_url,
-        updatedAt: r.updated_at ?? "",
+      .filter((repo) => repo.name.startsWith(`${slug}-`))
+      .map((repo) => ({
+        name: repo.name,
+        url: repo.html_url,
+        updatedAt: repo.updated_at ?? "",
       }));
-  } catch (e) {
-    handleOctokitError(e);
+  } catch (error) {
+    handleOctokitError(error);
   }
 }
 
@@ -165,10 +165,9 @@ export async function deleteRepo(repoName: string): Promise<void> {
   const octokit = getOctokit();
   try {
     await octokit.repos.delete({ owner: ORG, repo: repoName });
-  } catch (e) {
-    // 404 = el repo ya no existe → resultado idempotente, no es un error
-    if (isRequestError(e) && e.status === 404) return;
-    handleOctokitError(e);
+  } catch (error) {
+    if (isRequestError(error) && error.status === 404) return;
+    handleOctokitError(error);
   }
 }
 
@@ -199,13 +198,13 @@ export async function listarTemplates(): Promise<
     });
 
     return data
-      .filter((r) => r.is_template)
-      .map((r) => ({
-        name: r.name,
-        fullName: r.full_name,
-        description: r.description ?? "",
+      .filter((repo) => repo.is_template)
+      .map((repo) => ({
+        name: repo.name,
+        fullName: repo.full_name,
+        description: repo.description ?? "",
       }));
-  } catch (e) {
-    handleOctokitError(e);
+  } catch (error) {
+    handleOctokitError(error);
   }
 }

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -82,21 +82,36 @@ export async function addCollaborators(
   permission: "push" | "admin" = "push"
 ): Promise<void> {
   const octokit = getOctokit();
+  const MAX_ATTEMPTS = 4;
+  const INITIAL_DELAY_MS = 500;
+  const MAX_DELAY_MS = 8000;
+  let lastError: unknown;
 
-  try {
-    await Promise.all(
-      usernames.map((username) =>
-        octokit.repos.addCollaborator({
-          owner: ORG,
-          repo: repoName,
-          username,
-          permission,
-        })
-      )
-    );
-  } catch (error) {
-    handleOctokitError(error);
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt++) {
+    try {
+      await Promise.all(
+        usernames.map((username) =>
+          octokit.repos.addCollaborator({
+            owner: ORG,
+            repo: repoName,
+            username,
+            permission,
+          })
+        )
+      );
+      return;
+    } catch (error) {
+      lastError = error;
+      const isTransient = isRequestError(error) && (error.status === 404 || error.status === 422);
+      if (!isTransient || attempt >= MAX_ATTEMPTS - 1) break;
+      const delay = Math.min(
+        INITIAL_DELAY_MS * 2 ** attempt + Math.random() * INITIAL_DELAY_MS,
+        MAX_DELAY_MS
+      );
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   }
+  handleOctokitError(lastError);
 }
 
 // ── Crear repo + dar acceso en una sola operación ───────────
@@ -123,9 +138,6 @@ export async function crearEntrega(opts: {
     description: opts.descripcion,
     isPrivate: true,
   });
-
-  // Pequeña pausa para que GitHub procese la creación
-  await new Promise((resolve) => setTimeout(resolve, 1500));
 
   await addCollaborators(repoName, opts.usernames);
 

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -48,19 +48,19 @@ export type AgregarMiembroResult =
 // de la API. Google devuelve 409 + reason "duplicate" para este caso, pero
 // googleapis expone el status por varias rutas (err.code, err.status) y los
 // errores detallados pueden venir top-level o anidados en response.data.error.
-function isDuplicateError(e: unknown): boolean {
-  const err = e as {
+function isDuplicateError(error: unknown): boolean {
+  const apiError = error as {
     code?: number;
     status?: number;
     errors?: { reason?: string }[];
     response?: { data?: { error?: { errors?: { reason?: string }[] } } };
   };
-  if (err.code === 409 || err.status === 409) return true;
+  if (apiError.code === 409 || apiError.status === 409) return true;
   const hasDuplicateReason = (errors?: { reason?: string }[]) =>
-    Boolean(errors?.some((x) => x.reason === "duplicate"));
+    Boolean(errors?.some((errorEntry) => errorEntry.reason === "duplicate"));
   return (
-    hasDuplicateReason(err.errors) ||
-    hasDuplicateReason(err.response?.data?.error?.errors)
+    hasDuplicateReason(apiError.errors) ||
+    hasDuplicateReason(apiError.response?.data?.error?.errors)
   );
 }
 
@@ -80,9 +80,9 @@ export async function agregarMiembroAGrupo(
       { signal: AbortSignal.timeout(10_000) }
     );
     return { status: "added" };
-  } catch (e) {
-    if (isDuplicateError(e)) return { status: "already_member" };
-    const msg = e instanceof Error ? e.message : "Error al suscribir al grupo";
-    return { status: "error", error: msg };
+  } catch (error) {
+    if (isDuplicateError(error)) return { status: "already_member" };
+    const message = error instanceof Error ? error.message : "Error al suscribir al grupo";
+    return { status: "error", error: message };
   }
 }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -141,6 +141,37 @@ export async function marcarGruposSyncOk(githubUsername: string): Promise<void> 
   await em.flush();
 }
 
+export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<void> {
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, {
+    githubUsername: githubUsername.toLowerCase().trim(),
+  });
+  if (!alumno) return;
+  alumno.alumnoSyncFallidoEn = new Date();
+  await em.flush();
+}
+
+export async function marcarAlumnoSyncOk(githubUsername: string): Promise<void> {
+  const em = await getEM();
+  const alumno = await em.findOne(Alumno, {
+    githubUsername: githubUsername.toLowerCase().trim(),
+  });
+  if (!alumno || !alumno.alumnoSyncFallidoEn) return;
+  alumno.alumnoSyncFallidoEn = null;
+  await em.flush();
+}
+
+export async function getAlumnosByComision(
+  comisionId: string
+): Promise<Alumno[]> {
+  const em = await getEM();
+  return em.find(
+    Alumno,
+    { comision: { id: comisionId } },
+    { orderBy: { apellido: "ASC", nombre: "ASC" } }
+  );
+}
+
 export async function getAlumnosConGruposSyncPendiente(
   comisionId: string
 ): Promise<Alumno[]> {

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -22,23 +22,23 @@ async function assertLegajoLibreOPropio(
   legajo: string,
   githubUsername: string
 ): Promise<void> {
-  const em = await getEM();
-  const otro = await em.findOne(Alumno, { legajo: legajo.trim() });
+  const entityManager = await getEM();
+  const otro = await entityManager.findOne(Alumno, { legajo: legajo.trim() });
   if (otro && otro.githubUsername.toLowerCase() !== githubUsername.toLowerCase().trim()) {
     throw new LegajoConflictError(legajo.trim(), otro.githubUsername);
   }
 }
 
 export async function getAlumnos(): Promise<Alumno[]> {
-  const em = await getEM();
-  return em.find(Alumno, {}, { orderBy: { apellido: "ASC", nombre: "ASC" } });
+  const entityManager = await getEM();
+  return entityManager.find(Alumno, {}, { orderBy: { apellido: "ASC", nombre: "ASC" } });
 }
 
 export async function getAlumnoByGithub(
   githubUsername: string
 ): Promise<Alumno | null> {
-  const em = await getEM();
-  return em.findOne(Alumno, {
+  const entityManager = await getEM();
+  return entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase(),
   });
 }
@@ -46,8 +46,8 @@ export async function getAlumnoByGithub(
 export async function getAlumnoByLegajo(
   legajo: string
 ): Promise<Alumno | null> {
-  const em = await getEM();
-  return em.findOne(Alumno, { legajo: legajo.trim() });
+  const entityManager = await getEM();
+  return entityManager.findOne(Alumno, { legajo: legajo.trim() });
 }
 
 export interface AlumnoData {
@@ -77,25 +77,25 @@ function applyAlumnoData(alumno: Alumno, data: AlumnoData): void {
 
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
   await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
-  const em = await getEM();
+  const entityManager = await getEM();
   const alumno = new Alumno();
   applyAlumnoData(alumno, data);
-  em.persist(alumno);
-  await em.flush();
+  entityManager.persist(alumno);
+  await entityManager.flush();
   return alumno;
 }
 
 /** Crea o actualiza el Alumno en la DB a partir de los datos de la planilla. */
 export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
-  const em = await getEM();
-  const existing = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const existing = await entityManager.findOne(Alumno, {
     githubUsername: data.githubUsername.toLowerCase().trim(),
   });
 
   if (existing) {
     applyAlumnoData(existing, data);
-    await em.flush();
+    await entityManager.flush();
     return existing;
   }
 
@@ -110,62 +110,62 @@ export async function marcarRegistroConfirmado(
   githubUsername: string,
   comision: Comision
 ): Promise<void> {
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase().trim(),
   });
   if (!alumno) return;
   alumno.registroConfirmadoEn = comision;
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function marcarGruposSyncFallido(githubUsername: string): Promise<void> {
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase().trim(),
   });
   if (!alumno) return;
   alumno.gruposSyncFallidoEn = new Date();
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function marcarGruposSyncOk(githubUsername: string): Promise<void> {
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase().trim(),
   });
   // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
   // exitosa del happy path.
   if (!alumno || !alumno.gruposSyncFallidoEn) return;
   alumno.gruposSyncFallidoEn = null;
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<void> {
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase().trim(),
   });
   if (!alumno) return;
   alumno.alumnoSyncFallidoEn = new Date();
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function marcarAlumnoSyncOk(githubUsername: string): Promise<void> {
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
     githubUsername: githubUsername.toLowerCase().trim(),
   });
   if (!alumno || !alumno.alumnoSyncFallidoEn) return;
   alumno.alumnoSyncFallidoEn = null;
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function getAlumnosByComision(
   comisionId: string
 ): Promise<Alumno[]> {
-  const em = await getEM();
-  return em.find(
+  const entityManager = await getEM();
+  return entityManager.find(
     Alumno,
     { comision: { id: comisionId } },
     { orderBy: { apellido: "ASC", nombre: "ASC" } }
@@ -175,8 +175,8 @@ export async function getAlumnosByComision(
 export async function getAlumnosConGruposSyncPendiente(
   comisionId: string
 ): Promise<Alumno[]> {
-  const em = await getEM();
-  return em.find(
+  const entityManager = await getEM();
+  return entityManager.find(
     Alumno,
     { comision: { id: comisionId }, gruposSyncFallidoEn: { $ne: null } },
     { orderBy: { apellido: "ASC", nombre: "ASC" } }
@@ -187,7 +187,7 @@ export async function getAlumnosConGruposSyncPendiente(
 export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   if (dataList.length === 0) return 0;
 
-  const em = await getEM();
+  const entityManager = await getEM();
 
   // Validar coherencia legajo↔github antes de persistir: el UNIQUE de la DB
   // dispararía un error genérico del driver. Así surfaceamos LegajoConflictError
@@ -203,7 +203,7 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     githubPorLegajo.set(legajo, github);
   }
   const legajos = [...githubPorLegajo.keys()];
-  const alumnosConLegajoTomado = await em.find(Alumno, { legajo: { $in: legajos } });
+  const alumnosConLegajoTomado = await entityManager.find(Alumno, { legajo: { $in: legajos } });
   for (const alumno of alumnosConLegajoTomado) {
     const incomingGithub = githubPorLegajo.get(alumno.legajo)!;
     if (alumno.githubUsername.toLowerCase() !== incomingGithub) {
@@ -212,8 +212,8 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   }
 
   const githubUsernames = [...githubPorLegajo.values()];
-  const existentes = await em.find(Alumno, { githubUsername: { $in: githubUsernames } });
-  const existentesPorGithub = new Map(existentes.map((a) => [a.githubUsername, a]));
+  const existentes = await entityManager.find(Alumno, { githubUsername: { $in: githubUsernames } });
+  const existentesPorGithub = new Map(existentes.map((alumno) => [alumno.githubUsername, alumno]));
 
   for (const data of dataList) {
     const key = data.githubUsername.toLowerCase().trim();
@@ -223,7 +223,7 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     } else {
       const alumno = new Alumno();
       applyAlumnoData(alumno, data);
-      em.persist(alumno);
+      entityManager.persist(alumno);
       // Si el batch trae otra fila con el mismo github (typo o fila duplicada
       // en la planilla), debe reutilizar esta instancia — sin esto, el UNIQUE
       // de githubUsername explota en el flush con un error genérico.
@@ -231,11 +231,11 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     }
   }
 
-  await em.flush();
+  await entityManager.flush();
   return dataList.length;
 }
 
 export async function countAlumnos(): Promise<number> {
-  const em = await getEM();
-  return em.count(Alumno, {});
+  const entityManager = await getEM();
+  return entityManager.count(Alumno, {});
 }

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -24,7 +24,7 @@ async function assertLegajoLibreOPropio(
 ): Promise<void> {
   const entityManager = await getEM();
   const otro = await entityManager.findOne(Alumno, { legajo: legajo.trim() });
-  if (otro && otro.githubUsername.toLowerCase() !== githubUsername.toLowerCase().trim()) {
+  if (otro && otro.usernameCanonico !== Alumno.normalizarUsername(githubUsername)) {
     throw new LegajoConflictError(legajo.trim(), otro.githubUsername);
   }
 }
@@ -39,7 +39,7 @@ export async function getAlumnoByGithub(
 ): Promise<Alumno | null> {
   const entityManager = await getEM();
   return entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
 }
 
@@ -67,8 +67,8 @@ function applyAlumnoData(alumno: Alumno, data: AlumnoData): void {
   alumno.legajo = data.legajo.trim();
   alumno.nombre = data.nombre.trim();
   alumno.apellido = data.apellido.trim();
-  alumno.githubUsername = data.githubUsername.toLowerCase().trim();
-  alumno.email = data.email.toLowerCase().trim();
+  alumno.githubUsername = Alumno.normalizarUsername(data.githubUsername);
+  alumno.email = Alumno.normalizarEmail(data.email);
   alumno.comision = data.comision;
   if (data.registroConfirmadoEn !== undefined) {
     alumno.registroConfirmadoEn = data.registroConfirmadoEn;
@@ -90,7 +90,7 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
   const entityManager = await getEM();
   const existing = await entityManager.findOne(Alumno, {
-    githubUsername: data.githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(data.githubUsername),
   });
 
   if (existing) {
@@ -112,7 +112,7 @@ export async function marcarRegistroConfirmado(
 ): Promise<void> {
   const entityManager = await getEM();
   const alumno = await entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
   alumno.registroConfirmadoEn = comision;
@@ -122,7 +122,7 @@ export async function marcarRegistroConfirmado(
 export async function marcarGruposSyncFallido(githubUsername: string): Promise<void> {
   const entityManager = await getEM();
   const alumno = await entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
   alumno.gruposSyncFallidoEn = new Date();
@@ -132,7 +132,7 @@ export async function marcarGruposSyncFallido(githubUsername: string): Promise<v
 export async function marcarGruposSyncOk(githubUsername: string): Promise<void> {
   const entityManager = await getEM();
   const alumno = await entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
   // exitosa del happy path.
@@ -144,7 +144,7 @@ export async function marcarGruposSyncOk(githubUsername: string): Promise<void> 
 export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<void> {
   const entityManager = await getEM();
   const alumno = await entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
   alumno.alumnoSyncFallidoEn = new Date();
@@ -154,7 +154,7 @@ export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<v
 export async function marcarAlumnoSyncOk(githubUsername: string): Promise<void> {
   const entityManager = await getEM();
   const alumno = await entityManager.findOne(Alumno, {
-    githubUsername: githubUsername.toLowerCase().trim(),
+    githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno || !alumno.alumnoSyncFallidoEn) return;
   alumno.alumnoSyncFallidoEn = null;
@@ -195,7 +195,7 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   const githubPorLegajo = new Map<string, string>();
   for (const data of dataList) {
     const legajo = data.legajo.trim();
-    const github = data.githubUsername.toLowerCase().trim();
+    const github = Alumno.normalizarUsername(data.githubUsername);
     const prev = githubPorLegajo.get(legajo);
     if (prev && prev !== github) {
       throw new LegajoConflictError(legajo, prev);
@@ -206,7 +206,7 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   const alumnosConLegajoTomado = await entityManager.find(Alumno, { legajo: { $in: legajos } });
   for (const alumno of alumnosConLegajoTomado) {
     const incomingGithub = githubPorLegajo.get(alumno.legajo)!;
-    if (alumno.githubUsername.toLowerCase() !== incomingGithub) {
+    if (alumno.usernameCanonico !== incomingGithub) {
       throw new LegajoConflictError(alumno.legajo, alumno.githubUsername);
     }
   }
@@ -216,7 +216,7 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
   const existentesPorGithub = new Map(existentes.map((alumno) => [alumno.githubUsername, alumno]));
 
   for (const data of dataList) {
-    const key = data.githubUsername.toLowerCase().trim();
+    const key = Alumno.normalizarUsername(data.githubUsername);
     const existing = existentesPorGithub.get(key);
     if (existing) {
       applyAlumnoData(existing, data);

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -75,3 +75,15 @@ export async function updateAssignment(
 export async function deleteAssignment(id: string): Promise<void> {
   await deleteEntity(Assignment, id);
 }
+
+export async function setInscripcionesCerradas(
+  assignmentId: string,
+  cerradas: boolean
+): Promise<GrupalAssignment | null> {
+  const em = await getEM();
+  const assignment = await em.findOne(GrupalAssignment, { id: assignmentId });
+  if (!assignment) return null;
+  assignment.inscripcionesCerradas = cerradas;
+  await em.flush();
+  return assignment;
+}

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -9,19 +9,19 @@ import { slugify } from "@/lib/naming";
 import type { Paradigma } from "@/types";
 
 export async function getAssignments(): Promise<Assignment[]> {
-  const em = await getEM();
-  return em.find(Assignment, {}, { orderBy: { createdAt: "DESC" } });
+  const entityManager = await getEM();
+  return entityManager.find(Assignment, {}, { orderBy: { createdAt: "DESC" } });
 }
 
 export async function getAssignment(id: string): Promise<Assignment | null> {
-  const em = await getEM();
-  return em.findOne(Assignment, { id });
+  const entityManager = await getEM();
+  return entityManager.findOne(Assignment, { id });
 }
 
 export async function createAssignment(
   data: AssignmentFormData
 ): Promise<Assignment> {
-  const em = await getEM();
+  const entityManager = await getEM();
   const slug = data.slug || slugify(data.titulo);
 
   let assignment: Assignment;
@@ -41,8 +41,8 @@ export async function createAssignment(
   assignment.paradigma = data.paradigma as Paradigma;
   if (data.deadline) assignment.deadline = new Date(data.deadline);
 
-  em.persist(assignment);
-  await em.flush();
+  entityManager.persist(assignment);
+  await entityManager.flush();
   return assignment;
 }
 
@@ -50,8 +50,8 @@ export async function updateAssignment(
   id: string,
   data: Partial<AssignmentFormData>
 ): Promise<Assignment | null> {
-  const em = await getEM();
-  const assignment = await em.findOne(Assignment, { id });
+  const entityManager = await getEM();
+  const assignment = await entityManager.findOne(Assignment, { id });
   if (!assignment) return null;
 
   if (data.titulo !== undefined) assignment.titulo = data.titulo;
@@ -68,7 +68,7 @@ export async function updateAssignment(
     assignment.maxIntegrantes = data.maxIntegrantes;
   }
 
-  await em.flush();
+  await entityManager.flush();
   return assignment;
 }
 
@@ -80,10 +80,10 @@ export async function setInscripcionesCerradas(
   assignmentId: string,
   cerradas: boolean
 ): Promise<GrupalAssignment | null> {
-  const em = await getEM();
-  const assignment = await em.findOne(GrupalAssignment, { id: assignmentId });
+  const entityManager = await getEM();
+  const assignment = await entityManager.findOne(GrupalAssignment, { id: assignmentId });
   if (!assignment) return null;
   assignment.inscripcionesCerradas = cerradas;
-  await em.flush();
+  await entityManager.flush();
   return assignment;
 }

--- a/src/lib/repositories/ComisionRepository.ts
+++ b/src/lib/repositories/ComisionRepository.ts
@@ -10,33 +10,33 @@ export interface ComisionFormData {
 }
 
 export async function getComisiones(): Promise<Comision[]> {
-  const em = await getEM();
-  return em.find(Comision, {}, { orderBy: { anio: "DESC" } });
+  const entityManager = await getEM();
+  return entityManager.find(Comision, {}, { orderBy: { anio: "DESC" } });
 }
 
 export async function getComision(id: string): Promise<Comision | null> {
-  const em = await getEM();
-  return em.findOne(Comision, { id });
+  const entityManager = await getEM();
+  return entityManager.findOne(Comision, { id });
 }
 
 export async function getComisionActiva(): Promise<Comision | null> {
-  const em = await getEM();
-  return em.findOne(Comision, { activa: true });
+  const entityManager = await getEM();
+  return entityManager.findOne(Comision, { activa: true });
 }
 
 export async function createComision(data: ComisionFormData): Promise<Comision> {
-  const em = await getEM();
+  const entityManager = await getEM();
 
   if (data.activa) {
-    await em.nativeUpdate(Comision, {}, { activa: false });
+    await entityManager.nativeUpdate(Comision, {}, { activa: false });
   }
 
   const comision = new Comision(data.anio, data.spreadsheetId);
   comision.activa = data.activa;
   comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
 
-  em.persist(comision);
-  await em.flush();
+  entityManager.persist(comision);
+  await entityManager.flush();
   return comision;
 }
 
@@ -44,12 +44,12 @@ export async function updateComision(
   id: string,
   data: Partial<ComisionFormData>
 ): Promise<Comision | null> {
-  const em = await getEM();
-  const comision = await em.findOne(Comision, { id });
+  const entityManager = await getEM();
+  const comision = await entityManager.findOne(Comision, { id });
   if (!comision) return null;
 
   if (data.activa) {
-    await em.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
+    await entityManager.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
   }
 
   if (data.anio !== undefined) comision.anio = data.anio;
@@ -57,7 +57,7 @@ export async function updateComision(
   if (data.activa !== undefined) comision.activa = data.activa;
   if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
 
-  await em.flush();
+  await entityManager.flush();
   return comision;
 }
 

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -2,9 +2,9 @@ import { getEM } from "@/lib/db";
 import { Assignment, Grupo, Entrega } from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
-  const em = await getEM();
+  const entityManager = await getEM();
   const where = assignmentId ? { assignment: { id: assignmentId } } : {};
-  return em.find(Entrega, where, { populate: ["assignment", "grupo"] });
+  return entityManager.find(Entrega, where, { populate: ["assignment", "grupo"] });
 }
 
 // Devuelve todas las entregas de un usuario de una sola query,
@@ -12,13 +12,13 @@ export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
 export async function getEntregasDeUsuario(
   githubUsername: string
 ): Promise<Map<string, Entrega>> {
-  const em = await getEM();
-  const entregas = await em.find(Entrega, {});
+  const entityManager = await getEM();
+  const entregas = await entityManager.find(Entrega, {});
   const map = new Map<string, Entrega>();
   const normalized = githubUsername.toLowerCase();
-  for (const e of entregas) {
-    if (e.githubUsernames.some((u) => u.toLowerCase() === normalized)) {
-      map.set(e.assignment.id, e);
+  for (const entrega of entregas) {
+    if (entrega.githubUsernames.some((username) => username.toLowerCase() === normalized)) {
+      map.set(entrega.assignment.id, entrega);
     }
   }
   return map;
@@ -28,12 +28,12 @@ export async function getEntregaDeUsuario(
   assignmentId: string,
   githubUsername: string
 ): Promise<Entrega | null> {
-  const em = await getEM();
-  const entregas = await em.find(Entrega, { assignment: { id: assignmentId } });
+  const entityManager = await getEM();
+  const entregas = await entityManager.find(Entrega, { assignment: { id: assignmentId } });
   return (
-    entregas.find((e) =>
-      e.githubUsernames.some(
-        (u) => u.toLowerCase() === githubUsername.toLowerCase()
+    entregas.find((entrega) =>
+      entrega.githubUsernames.some(
+        (username) => username.toLowerCase() === githubUsername.toLowerCase()
       )
     ) ?? null
   );
@@ -41,39 +41,39 @@ export async function getEntregaDeUsuario(
 
 // Devuelve el conteo de entregas por assignmentId en una sola query.
 export async function getEntregaCountsByAssignment(): Promise<Map<string, number>> {
-  const em = await getEM();
-  const entregas = await em.find(Entrega, {}, { fields: ["assignment"] });
+  const entityManager = await getEM();
+  const entregas = await entityManager.find(Entrega, {}, { fields: ["assignment"] });
   const map = new Map<string, number>();
-  for (const e of entregas) {
-    const id = e.assignment.id;
-    map.set(id, (map.get(id) ?? 0) + 1);
+  for (const entrega of entregas) {
+    const assignmentId = entrega.assignment.id;
+    map.set(assignmentId, (map.get(assignmentId) ?? 0) + 1);
   }
   return map;
 }
 
 export async function getActiveRepoCountsByAssignment(): Promise<Map<string, number>> {
-  const em = await getEM();
-  const entregas = await em.find(
+  const entityManager = await getEM();
+  const entregas = await entityManager.find(
     Entrega,
     { repoDeleted: false },
     { fields: ["assignment", "repoName"] }
   );
   const map = new Map<string, number>();
-  for (const e of entregas) {
-    if (!e.repoName) continue;
-    const id = e.assignment.id;
-    map.set(id, (map.get(id) ?? 0) + 1);
+  for (const entrega of entregas) {
+    if (!entrega.repoName) continue;
+    const assignmentId = entrega.assignment.id;
+    map.set(assignmentId, (map.get(assignmentId) ?? 0) + 1);
   }
   return map;
 }
 
 export async function clearReposDeAssignment(assignmentId: string): Promise<void> {
-  const em = await getEM();
-  const entregas = await em.find(Entrega, { assignment: { id: assignmentId } });
-  for (const e of entregas) {
-    e.repoDeleted = true;
+  const entityManager = await getEM();
+  const entregas = await entityManager.find(Entrega, { assignment: { id: assignmentId } });
+  for (const entrega of entregas) {
+    entrega.repoDeleted = true;
   }
-  await em.flush();
+  await entityManager.flush();
 }
 
 export async function createEntrega(data: {
@@ -83,9 +83,9 @@ export async function createEntrega(data: {
   githubUsernames: string[];
   grupoId?: string;
 }): Promise<Entrega> {
-  const em = await getEM();
+  const entityManager = await getEM();
 
-  const assignment = await em.findOneOrFail(Assignment, { id: data.assignmentId });
+  const assignment = await entityManager.findOneOrFail(Assignment, { id: data.assignmentId });
 
   const entrega = new Entrega();
   entrega.assignment = assignment;
@@ -94,10 +94,10 @@ export async function createEntrega(data: {
   entrega.githubUsernames = data.githubUsernames;
 
   if (data.grupoId) {
-    entrega.grupo = em.getReference(Grupo, data.grupoId);
+    entrega.grupo = entityManager.getReference(Grupo, data.grupoId);
   }
 
-  em.persist(entrega);
-  await em.flush();
+  entityManager.persist(entrega);
+  await entityManager.flush();
   return entrega;
 }

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -1,0 +1,281 @@
+import { describe, it, expect, vi, beforeEach, beforeAll, afterAll } from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import { TsMorphMetadataProvider } from "@mikro-orm/reflection";
+import config from "../../../mikro-orm.config";
+
+// ── Mocks ────────────────────────────────────────────────────
+//
+// Mockeo el EM completo: cada test arma respuestas de findOne/findOneOrFail
+// según el caso. `transactional(cb)` simplemente invoca el callback con el
+// mismo mock — el lock de transacción es responsabilidad de Postgres, acá
+// solo se valida la lógica de validación + persistencia.
+//
+// Para que `new Grupo()` y `grupo.alumnos.add(...)` funcionen sin BD, el ORM
+// se inicializa una sola vez con `connect: false` para que descubra los
+// metadata de las entidades (mismo truco que `orm.test.ts`).
+
+type MockTx = {
+  findOne: ReturnType<typeof vi.fn>;
+  findOneOrFail: ReturnType<typeof vi.fn>;
+  persist: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+};
+
+const mockTx: MockTx = {
+  findOne: vi.fn(),
+  findOneOrFail: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+const mockEm = {
+  ...mockTx,
+  transactional: vi.fn(async (cb: (tx: MockTx) => Promise<unknown>) => cb(mockTx)),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+// ── Imports después del mock ─────────────────────────────────
+
+import { crearGrupo, unirseAGrupo } from "./GrupoRepository";
+import {
+  Grupo,
+  Alumno,
+  GrupalAssignment,
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  GrupoLlenoError,
+  AssignmentNoGrupalError,
+} from "@/domain/entities";
+import { IndividualAssignment } from "@/domain/entities/IndividualAssignment";
+import type { Collection } from "@mikro-orm/core";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function fakeAlumno(id: string, githubUsername: string): Alumno {
+  // Instancia real para que Collection<Alumno>.add() pase el `instanceof` check.
+  const alumno = new Alumno();
+  alumno.id = id;
+  alumno.githubUsername = githubUsername;
+  alumno.legajo = `leg-${id}`;
+  alumno.nombre = githubUsername;
+  alumno.apellido = "Test";
+  alumno.email = `${githubUsername}@test`;
+  return alumno;
+}
+
+function fakeGrupal(overrides: Partial<GrupalAssignment> = {}): GrupalAssignment {
+  const grupal = new GrupalAssignment();
+  grupal.id = "a1";
+  grupal.paradigma = "funcional";
+  grupal.maxIntegrantes = 3;
+  grupal.inscripcionesCerradas = false;
+  Object.assign(grupal, overrides);
+  return grupal;
+}
+
+function fakeGrupo(
+  id: string,
+  assignment: GrupalAssignment,
+  miembros: Alumno[],
+  maxIntegrantes = assignment.maxIntegrantes
+): Grupo {
+  const grupo = new Grupo();
+  grupo.id = id;
+  grupo.nombre = `grupo-${id}`;
+  grupo.paradigma = assignment.paradigma;
+  grupo.assignment = assignment;
+  grupo.maxIntegrantes = maxIntegrantes;
+  grupo.creadoPor = miembros[0]?.githubUsername ?? "alguien";
+  const items: Alumno[] = [...miembros];
+  grupo.alumnos = {
+    contains: (alumno: Alumno) => items.some((member) => member.id === alumno.id),
+    add: (alumno: Alumno) => items.push(alumno),
+    get length() {
+      return items.length;
+    },
+  } as unknown as Collection<Alumno>;
+  return grupo;
+}
+
+let orm: MikroORM;
+
+beforeAll(async () => {
+  orm = await MikroORM.init({
+    ...config,
+    metadataProvider: TsMorphMetadataProvider,
+    connect: false,
+  });
+});
+
+afterAll(async () => {
+  await orm.close(true);
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockEm.transactional.mockImplementation(
+    async (cb: (tx: MockTx) => Promise<unknown>) => cb(mockTx)
+  );
+});
+
+// ── crearGrupo ──────────────────────────────────────────────
+
+describe("crearGrupo", () => {
+  it("crea el grupo con paradigma y maxIntegrantes del assignment, agrega al creador y persiste", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    mockTx.findOne
+      .mockResolvedValueOnce(assignment) // Assignment lookup
+      .mockResolvedValueOnce(null); // yaEnGrupo check
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    const grupo = await crearGrupo({
+      assignmentId: "a1",
+      alumnoId: "alumno-ana",
+      nombre: "Los Lambdas",
+    });
+
+    expect(grupo.nombre).toBe("Los Lambdas");
+    expect(grupo.paradigma).toBe("funcional");
+    expect(grupo.maxIntegrantes).toBe(3);
+    expect(grupo.assignment).toBe(assignment);
+    expect(grupo.creadoPor).toBe("ana");
+    expect(grupo.alumnos.contains(ana)).toBe(true);
+    expect(mockTx.persist).toHaveBeenCalledWith(grupo);
+    expect(mockTx.flush).toHaveBeenCalled();
+  });
+
+  it("lanza AssignmentNoGrupalError si el assignment no existe", async () => {
+    mockTx.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+    ).rejects.toBeInstanceOf(AssignmentNoGrupalError);
+  });
+
+  it("lanza AssignmentNoGrupalError si el assignment es individual", async () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    mockTx.findOne.mockResolvedValueOnce(individual);
+
+    await expect(
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+    ).rejects.toBeInstanceOf(AssignmentNoGrupalError);
+  });
+
+  it("lanza InscripcionesCerradasError si el docente cerró las inscripciones", async () => {
+    mockTx.findOne.mockResolvedValueOnce(fakeGrupal({ inscripcionesCerradas: true }));
+
+    await expect(
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+    ).rejects.toBeInstanceOf(InscripcionesCerradasError);
+  });
+
+  it("lanza AlumnoYaEnGrupoDelAssignmentError si el alumno ya está en otro grupo del mismo assignment", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupoExistente = fakeGrupo("g-otro", assignment, [ana]);
+    mockTx.findOne
+      .mockResolvedValueOnce(assignment)
+      .mockResolvedValueOnce(grupoExistente);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+    expect(mockTx.persist).not.toHaveBeenCalled();
+  });
+});
+
+// ── unirseAGrupo ────────────────────────────────────────────
+
+describe("unirseAGrupo", () => {
+  it("happy path: suma al alumno y flushea", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOneOrFail
+      .mockResolvedValueOnce(grupo) // Grupo
+      .mockResolvedValueOnce(ana); // Alumno
+    mockTx.findOne.mockResolvedValueOnce(null); // enOtroGrupo
+
+    const resultado = await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+
+    expect(resultado).toBe(grupo);
+    expect(grupo.alumnos.contains(ana)).toBe(true);
+    expect(mockTx.flush).toHaveBeenCalled();
+  });
+
+  it("idempotente: si el alumno ya es miembro del grupo, retorna el grupo sin error y sin flush", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, [ana]);
+    mockTx.findOneOrFail
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(ana);
+
+    const resultado = await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+
+    expect(resultado).toBe(grupo);
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("lanza InscripcionesCerradasError cuando el docente cerró el assignment", async () => {
+    const assignment = fakeGrupal({ inscripcionesCerradas: true });
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOneOrFail.mockResolvedValueOnce(grupo);
+
+    await expect(
+      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" })
+    ).rejects.toBeInstanceOf(InscripcionesCerradasError);
+  });
+
+  it("lanza AlumnoYaEnGrupoDelAssignmentError si el alumno ya está en otro grupo", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupoDestino = fakeGrupo("g1", assignment, []);
+    const grupoOtro = fakeGrupo("g-otro", assignment, [ana]);
+    mockTx.findOneOrFail
+      .mockResolvedValueOnce(grupoDestino)
+      .mockResolvedValueOnce(ana);
+    mockTx.findOne.mockResolvedValueOnce(grupoOtro);
+
+    await expect(
+      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("propaga GrupoLlenoError cuando el grupo está al máximo (race del último cupo)", async () => {
+    const assignment = fakeGrupal({ maxIntegrantes: 2 });
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const bob = fakeAlumno("alumno-bob", "bob");
+    const cora = fakeAlumno("alumno-cora", "cora");
+    const grupoLleno = fakeGrupo("g1", assignment, [ana, bob]);
+    mockTx.findOneOrFail
+      .mockResolvedValueOnce(grupoLleno)
+      .mockResolvedValueOnce(cora);
+    mockTx.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-cora" })
+    ).rejects.toBeInstanceOf(GrupoLlenoError);
+  });
+
+  it("toda la operación corre dentro de em.transactional para resolver races", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOneOrFail
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(ana);
+    mockTx.findOne.mockResolvedValueOnce(null);
+
+    await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+
+    expect(mockEm.transactional).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -30,7 +30,7 @@ const mockTx: MockTx = {
 
 const mockEm = {
   ...mockTx,
-  transactional: vi.fn(async (cb: (tx: MockTx) => Promise<unknown>) => cb(mockTx)),
+  transactional: vi.fn(async (callback: (transaction: MockTx) => Promise<unknown>) => callback(mockTx)),
 };
 
 vi.mock("@/lib/db", () => ({
@@ -117,7 +117,7 @@ afterAll(async () => {
 beforeEach(() => {
   vi.clearAllMocks();
   mockEm.transactional.mockImplementation(
-    async (cb: (tx: MockTx) => Promise<unknown>) => cb(mockTx)
+    async (callback: (transaction: MockTx) => Promise<unknown>) => callback(mockTx)
   );
 });
 

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -13,8 +13,8 @@ import type { Paradigma } from "@/types";
 export async function getGruposDeAlumno(
   githubUsername: string
 ): Promise<Map<string, Grupo>> {
-  const em = await getEM();
-  const grupos = await em.find(
+  const entityManager = await getEM();
+  const grupos = await entityManager.find(
     Grupo,
     { alumnos: { githubUsername: { $ilike: githubUsername } } },
     { populate: ["assignment", "alumnos"] }
@@ -23,14 +23,14 @@ export async function getGruposDeAlumno(
 }
 
 export async function getGrupos(paradigma?: Paradigma): Promise<Grupo[]> {
-  const em = await getEM();
+  const entityManager = await getEM();
   const where = paradigma ? { paradigma } : {};
-  return em.find(Grupo, where, { populate: ["assignment", "alumnos"] });
+  return entityManager.find(Grupo, where, { populate: ["assignment", "alumnos"] });
 }
 
 export async function getGruposDeAssignment(assignmentId: string): Promise<Grupo[]> {
-  const em = await getEM();
-  return em.find(
+  const entityManager = await getEM();
+  return entityManager.find(
     Grupo,
     { assignment: { id: assignmentId } },
     { populate: ["alumnos"] }
@@ -41,8 +41,8 @@ export async function getGrupoDeAlumnoEnAssignment(
   assignmentId: string,
   githubUsername: string
 ): Promise<Grupo | null> {
-  const em = await getEM();
-  return em.findOne(
+  const entityManager = await getEM();
+  return entityManager.findOne(
     Grupo,
     {
       assignment: { id: assignmentId },
@@ -63,10 +63,10 @@ export async function crearGrupo(params: {
   nombre: string;
 }): Promise<Grupo> {
   const { assignmentId, alumnoId, nombre } = params;
-  const em = await getEM();
+  const entityManager = await getEM();
 
-  return em.transactional(async (tx) => {
-    const assignment = await tx.findOne(Assignment, { id: assignmentId });
+  return entityManager.transactional(async (transaction) => {
+    const assignment = await transaction.findOne(Assignment, { id: assignmentId });
     if (!assignment || !(assignment instanceof GrupalAssignment)) {
       throw new AssignmentNoGrupalError(assignmentId);
     }
@@ -74,9 +74,9 @@ export async function crearGrupo(params: {
       throw new InscripcionesCerradasError(assignmentId);
     }
 
-    const alumno = await tx.findOneOrFail(Alumno, { id: alumnoId });
+    const alumno = await transaction.findOneOrFail(Alumno, { id: alumnoId });
 
-    const yaEnGrupo = await tx.findOne(Grupo, {
+    const yaEnGrupo = await transaction.findOne(Grupo, {
       assignment: { id: assignmentId },
       alumnos: { id: alumno.id },
     });
@@ -91,9 +91,9 @@ export async function crearGrupo(params: {
     grupo.maxIntegrantes = assignment.maxIntegrantes;
     grupo.creadoPor = alumno.githubUsername;
     grupo.alumnos.add(alumno);
-    tx.persist(grupo);
+    transaction.persist(grupo);
 
-    await tx.flush();
+    await transaction.flush();
     return grupo;
   });
 }
@@ -107,10 +107,10 @@ export async function unirseAGrupo(params: {
   alumnoId: string;
 }): Promise<Grupo> {
   const { grupoId, alumnoId } = params;
-  const em = await getEM();
+  const entityManager = await getEM();
 
-  return em.transactional(async (tx) => {
-    const grupo = await tx.findOneOrFail(
+  return entityManager.transactional(async (transaction) => {
+    const grupo = await transaction.findOneOrFail(
       Grupo,
       { id: grupoId },
       { populate: ["alumnos", "assignment"] }
@@ -120,13 +120,13 @@ export async function unirseAGrupo(params: {
       throw new InscripcionesCerradasError(assignment.id);
     }
 
-    const alumno = await tx.findOneOrFail(Alumno, { id: alumnoId });
+    const alumno = await transaction.findOneOrFail(Alumno, { id: alumnoId });
 
     if (grupo.alumnos.contains(alumno)) {
       return grupo;
     }
 
-    const enOtroGrupo = await tx.findOne(Grupo, {
+    const enOtroGrupo = await transaction.findOne(Grupo, {
       assignment: { id: assignment.id },
       alumnos: { id: alumno.id },
     });
@@ -139,7 +139,7 @@ export async function unirseAGrupo(params: {
 
     grupo.addMember(alumno);
 
-    await tx.flush();
+    await transaction.flush();
     return grupo;
   });
 }
@@ -154,9 +154,9 @@ export async function upsertGrupoConMiembro(params: {
   alumno: Alumno;
 }): Promise<Grupo> {
   const { nombreGrupo, paradigma, assignment, alumno } = params;
-  const em = await getEM();
+  const entityManager = await getEM();
 
-  const existente = await em.findOne(
+  const existente = await entityManager.findOne(
     Grupo,
     {
       nombre: nombreGrupo,
@@ -176,13 +176,13 @@ export async function upsertGrupoConMiembro(params: {
     grupo.assignment = assignment;
     grupo.maxIntegrantes = assignment.maxIntegrantes;
     grupo.creadoPor = "sheets-sync";
-    em.persist(grupo);
+    entityManager.persist(grupo);
   }
 
   if (!grupo.alumnos.contains(alumno)) {
     grupo.alumnos.add(alumno);
   }
 
-  await em.flush();
+  await entityManager.flush();
   return grupo;
 }

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -1,7 +1,26 @@
 import { getEM } from "@/lib/db";
-import { Grupo } from "@/domain/entities";
-import type { Alumno, GrupalAssignment } from "@/domain/entities";
+import {
+  Grupo,
+  Alumno,
+  GrupalAssignment,
+  Assignment,
+  InscripcionesCerradasError,
+  AlumnoYaEnGrupoDelAssignmentError,
+  AssignmentNoGrupalError,
+} from "@/domain/entities";
 import type { Paradigma } from "@/types";
+
+export async function getGruposDeAlumno(
+  githubUsername: string
+): Promise<Map<string, Grupo>> {
+  const em = await getEM();
+  const grupos = await em.find(
+    Grupo,
+    { alumnos: { githubUsername: { $ilike: githubUsername } } },
+    { populate: ["assignment", "alumnos"] }
+  );
+  return new Map(grupos.map((grupo) => [grupo.assignment.id, grupo]));
+}
 
 export async function getGrupos(paradigma?: Paradigma): Promise<Grupo[]> {
   const em = await getEM();
@@ -31,6 +50,98 @@ export async function getGrupoDeAlumnoEnAssignment(
     },
     { populate: ["alumnos"] }
   );
+}
+
+// Crea un grupo nuevo en un assignment grupal y suma al alumno creador como
+// primer miembro. Atómico: la lectura del assignment, la verificación de que
+// el alumno no esté ya en otro grupo, y la creación se hacen en una única
+// transacción para evitar carreras (dos creaciones simultáneas, o crear
+// mientras un join concurrente está en curso).
+export async function crearGrupo(params: {
+  assignmentId: string;
+  alumnoId: string;
+  nombre: string;
+}): Promise<Grupo> {
+  const { assignmentId, alumnoId, nombre } = params;
+  const em = await getEM();
+
+  return em.transactional(async (tx) => {
+    const assignment = await tx.findOne(Assignment, { id: assignmentId });
+    if (!assignment || !(assignment instanceof GrupalAssignment)) {
+      throw new AssignmentNoGrupalError(assignmentId);
+    }
+    if (!assignment.aceptaNuevasInscripciones()) {
+      throw new InscripcionesCerradasError(assignmentId);
+    }
+
+    const alumno = await tx.findOneOrFail(Alumno, { id: alumnoId });
+
+    const yaEnGrupo = await tx.findOne(Grupo, {
+      assignment: { id: assignmentId },
+      alumnos: { id: alumno.id },
+    });
+    if (yaEnGrupo) {
+      throw new AlumnoYaEnGrupoDelAssignmentError(assignmentId, alumno.githubUsername);
+    }
+
+    const grupo = new Grupo();
+    grupo.nombre = nombre;
+    grupo.paradigma = assignment.paradigma;
+    grupo.assignment = assignment;
+    grupo.maxIntegrantes = assignment.maxIntegrantes;
+    grupo.creadoPor = alumno.githubUsername;
+    grupo.alumnos.add(alumno);
+    tx.persist(grupo);
+
+    await tx.flush();
+    return grupo;
+  });
+}
+
+// Suma al alumno como miembro de un grupo existente. Atómico: re-checa cupo
+// y "no está en otro grupo del mismo assignment" dentro de la transacción
+// para resolver el race del último cupo (dos joins simultáneos al mismo
+// grupo cuando queda un solo lugar).
+export async function unirseAGrupo(params: {
+  grupoId: string;
+  alumnoId: string;
+}): Promise<Grupo> {
+  const { grupoId, alumnoId } = params;
+  const em = await getEM();
+
+  return em.transactional(async (tx) => {
+    const grupo = await tx.findOneOrFail(
+      Grupo,
+      { id: grupoId },
+      { populate: ["alumnos", "assignment"] }
+    );
+    const assignment = grupo.assignment;
+    if (!assignment.aceptaNuevasInscripciones()) {
+      throw new InscripcionesCerradasError(assignment.id);
+    }
+
+    const alumno = await tx.findOneOrFail(Alumno, { id: alumnoId });
+
+    if (grupo.alumnos.contains(alumno)) {
+      return grupo;
+    }
+
+    const enOtroGrupo = await tx.findOne(Grupo, {
+      assignment: { id: assignment.id },
+      alumnos: { id: alumno.id },
+    });
+    if (enOtroGrupo) {
+      throw new AlumnoYaEnGrupoDelAssignmentError(
+        assignment.id,
+        alumno.githubUsername
+      );
+    }
+
+    grupo.addMember(alumno);
+
+    await tx.flush();
+    return grupo;
+  });
 }
 
 // Usado por la sincronización desde la planilla: crea el Grupo (nombre +

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -116,14 +116,14 @@ export async function unirseAGrupo(params: {
       { populate: ["alumnos", "assignment"] }
     );
     const assignment = grupo.assignment;
-    if (!assignment.aceptaNuevasInscripciones()) {
-      throw new InscripcionesCerradasError(assignment.id);
-    }
-
     const alumno = await transaction.findOneOrFail(Alumno, { id: alumnoId });
 
     if (grupo.alumnos.contains(alumno)) {
       return grupo;
+    }
+
+    if (!assignment.aceptaNuevasInscripciones()) {
+      throw new InscripcionesCerradasError(assignment.id);
     }
 
     const enOtroGrupo = await transaction.findOne(Grupo, {

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -8,6 +8,9 @@ export {
   marcarRegistroConfirmado,
   marcarGruposSyncFallido,
   marcarGruposSyncOk,
+  marcarAlumnoSyncFallido,
+  marcarAlumnoSyncOk,
+  getAlumnosByComision,
   getAlumnosConGruposSyncPendiente,
   countAlumnos,
   LegajoConflictError,
@@ -20,6 +23,7 @@ export {
   createAssignment,
   updateAssignment,
   deleteAssignment,
+  setInscripcionesCerradas,
 } from "./AssignmentRepository";
 
 export {
@@ -34,8 +38,11 @@ export {
 
 export {
   getGrupos,
+  getGruposDeAlumno,
   getGruposDeAssignment,
   getGrupoDeAlumnoEnAssignment,
+  crearGrupo,
+  unirseAGrupo,
   upsertGrupoConMiembro,
 } from "./GrupoRepository";
 

--- a/src/lib/services/grupoSync.test.ts
+++ b/src/lib/services/grupoSync.test.ts
@@ -51,6 +51,7 @@ const comisionConGrupos = {
     email: 4,
     grupos: gruposConfig,
   },
+  gruposConfig: () => gruposConfig,
 } as unknown as Parameters<typeof sincronizarGruposDelAlumno>[1];
 
 const comisionSinGrupos = {
@@ -65,6 +66,7 @@ const comisionSinGrupos = {
     githubUsername: 3,
     email: 4,
   },
+  gruposConfig: () => undefined,
 } as unknown as Parameters<typeof sincronizarGruposDelAlumno>[1];
 
 const alumnoFake = { id: "a1", githubUsername: "juangarcia" };

--- a/src/lib/services/grupoSync.ts
+++ b/src/lib/services/grupoSync.ts
@@ -33,15 +33,15 @@ export async function sincronizarGruposDelAlumno(
     asignacionesPrefetched ??
     (await getAsignacionesGrupos(comision.spreadsheetId, gruposConfig));
 
-  const deEsteAlumno = asignaciones.filter((a) => a.githubUsername === ghNorm);
+  const deEsteAlumno = asignaciones.filter((asignacion) => asignacion.githubUsername === ghNorm);
   if (deEsteAlumno.length === 0) return;
 
-  const em = await getEM();
-  const alumno = await em.findOne(Alumno, { githubUsername: ghNorm });
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, { githubUsername: ghNorm });
   if (!alumno) return;
 
   for (const asig of deEsteAlumno) {
-    const grupales = await em.find(GrupalAssignment, {
+    const grupales = await entityManager.find(GrupalAssignment, {
       comision: { id: comision.id },
       paradigma: asig.paradigma,
     });

--- a/src/lib/services/grupoSync.ts
+++ b/src/lib/services/grupoSync.ts
@@ -24,10 +24,10 @@ export async function sincronizarGruposDelAlumno(
   comision: Comision,
   asignacionesPrefetched?: AsignacionGrupoRow[]
 ): Promise<void> {
-  const gruposConfig = comision.columnConfig?.grupos;
+  const gruposConfig = comision.gruposConfig();
   if (!gruposConfig) return;
 
-  const ghNorm = githubUsername.toLowerCase().trim();
+  const ghNorm = Alumno.normalizarUsername(githubUsername);
 
   const asignaciones =
     asignacionesPrefetched ??

--- a/src/lib/services/verificarConsistenciaAlumno.test.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Alumno } from "@/domain/entities";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetAlumnoByGithub = vi.fn();
+const mockMarcarAlumnoSyncFallido = vi.fn();
+const mockMarcarAlumnoSyncOk = vi.fn();
+const mockUpsertarAlumnoEnSheets = vi.fn();
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+  marcarAlumnoSyncFallido: (...args: unknown[]) =>
+    mockMarcarAlumnoSyncFallido(...args),
+  marcarAlumnoSyncOk: (...args: unknown[]) => mockMarcarAlumnoSyncOk(...args),
+}));
+
+vi.mock("@/lib/sheets", () => ({
+  upsertarAlumnoEnSheets: (...args: unknown[]) =>
+    mockUpsertarAlumnoEnSheets(...args),
+}));
+
+import { verificarConsistenciaAlumno } from "./verificarConsistenciaAlumno";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+const comision = {
+  id: "c1",
+  spreadsheetId: "sheet-xyz",
+  columnConfig: {},
+} as unknown as Parameters<typeof verificarConsistenciaAlumno>[1];
+
+function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
+  return {
+    id: "uuid-1",
+    legajo: "12345",
+    nombre: "Juan",
+    apellido: "Garcia",
+    githubUsername: "juangarcia",
+    email: "juan@example.com",
+    ...overrides,
+  } as Alumno;
+}
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe("verificarConsistenciaAlumno", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMarcarAlumnoSyncFallido.mockResolvedValue(undefined);
+    mockMarcarAlumnoSyncOk.mockResolvedValue(undefined);
+  });
+
+  it("no hace nada si el alumno no existe en DB", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+
+    await expect(
+      verificarConsistenciaAlumno("juangarcia", comision)
+    ).resolves.toBeUndefined();
+
+    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockMarcarAlumnoSyncFallido).not.toHaveBeenCalled();
+    expect(mockMarcarAlumnoSyncOk).not.toHaveBeenCalled();
+  });
+
+  it("re-upsertea en Sheets con los datos del alumno y limpia el flag cuando funciona", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+
+    await verificarConsistenciaAlumno("juangarcia", comision);
+
+    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
+      {
+        legajo: "12345",
+        apellido: "Garcia",
+        nombre: "Juan",
+        githubUsername: "juangarcia",
+        email: "juan@example.com",
+      },
+      "sheet-xyz",
+      {}
+    );
+    expect(mockMarcarAlumnoSyncOk).toHaveBeenCalledWith("juangarcia");
+    expect(mockMarcarAlumnoSyncFallido).not.toHaveBeenCalled();
+  });
+
+  it("prende el flag y propaga cuando el resultado de Sheets es no-ok", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({
+      ok: false,
+      error: "Email inválido en planilla",
+    });
+
+    await expect(
+      verificarConsistenciaAlumno("juangarcia", comision)
+    ).rejects.toThrow("Email inválido en planilla");
+
+    expect(mockMarcarAlumnoSyncFallido).toHaveBeenCalledWith("juangarcia");
+    expect(mockMarcarAlumnoSyncOk).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("prende el flag y propaga cuando upsertarAlumnoEnSheets throwea", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const sheetsError = new Error("Sheets caído");
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(sheetsError);
+
+    await expect(
+      verificarConsistenciaAlumno("juangarcia", comision)
+    ).rejects.toBe(sheetsError);
+
+    expect(mockMarcarAlumnoSyncFallido).toHaveBeenCalledWith("juangarcia");
+    expect(mockMarcarAlumnoSyncOk).not.toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("si marcarAlumnoSyncFallido también falla, propaga el error original (no enmascara)", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    const sheetsError = new Error("Sheets caído");
+    const flagError = new Error("DB hipada");
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockUpsertarAlumnoEnSheets.mockRejectedValue(sheetsError);
+    mockMarcarAlumnoSyncFallido.mockRejectedValue(flagError);
+
+    await expect(
+      verificarConsistenciaAlumno("juangarcia", comision)
+    ).rejects.toBe(sheetsError);
+
+    expect(errorSpy).toHaveBeenCalledTimes(2);
+    errorSpy.mockRestore();
+  });
+});

--- a/src/lib/services/verificarConsistenciaAlumno.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.ts
@@ -1,0 +1,67 @@
+import { logger } from "@/lib/logger";
+import type { Comision } from "@/domain/entities";
+import {
+  getAlumnoByGithub,
+  marcarAlumnoSyncFallido,
+  marcarAlumnoSyncOk,
+} from "@/lib/repositories";
+import { upsertarAlumnoEnSheets } from "@/lib/sheets";
+
+/**
+ * Re-refleja en la planilla los datos del alumno guardados en la DB.
+ *
+ * Source-of-truth para el alta del alumno: la DB (lo que el alumno completó
+ * en el form). Si alguien editó la fila en Sheets a mano, este comando la
+ * vuelve a alinear escribiendo los datos canónicos.
+ *
+ * Es idempotente: `upsertarAlumnoEnSheets` ya respeta columnas desconocidas
+ * y hace find-or-append por githubUsername. Llamarlo cuando los datos ya
+ * coinciden es un write innecesario pero seguro.
+ *
+ * Persiste el resultado en `alumnoSyncFallidoEn` (análogo al flag de grupos):
+ * se prende ante cualquier falla y se limpia cuando un reintento exitoso lo
+ * resuelve. La persistencia del flag es best-effort: si escribir el flag
+ * también falla, se loguea pero se propaga el error original.
+ */
+export async function verificarConsistenciaAlumno(
+  githubUsername: string,
+  comision: Comision
+): Promise<void> {
+  const alumno = await getAlumnoByGithub(githubUsername);
+  if (!alumno) return;
+
+  try {
+    const resultado = await upsertarAlumnoEnSheets(
+      {
+        legajo: alumno.legajo,
+        apellido: alumno.apellido,
+        nombre: alumno.nombre,
+        githubUsername: alumno.githubUsername,
+        email: alumno.email,
+      },
+      comision.spreadsheetId,
+      comision.columnConfig
+    );
+    if (!resultado.ok) throw new Error(resultado.error);
+  } catch (error) {
+    logger.error(
+      {
+        err: error,
+        githubUsername: alumno.githubUsername,
+        comisionId: comision.id,
+      },
+      "Falló re-upsert del alumno en planilla"
+    );
+    try {
+      await marcarAlumnoSyncFallido(alumno.githubUsername);
+    } catch (flagError) {
+      logger.error(
+        { err: flagError, githubUsername: alumno.githubUsername },
+        "Falló al persistir alumnoSyncFallidoEn (banner no aparecerá)"
+      );
+    }
+    throw error;
+  }
+
+  await marcarAlumnoSyncOk(alumno.githubUsername);
+}

--- a/src/lib/sheets.test.ts
+++ b/src/lib/sheets.test.ts
@@ -6,6 +6,7 @@ import {
   colLetter,
   isValidEmail,
   upsertarAlumnoEnSheets,
+  getSheetNames,
 } from "./sheets";
 import type { GruposColumnConfig } from "@/types";
 
@@ -357,5 +358,13 @@ describe("upsertarAlumnoEnSheets – validaciones", () => {
     await expect(upsertarAlumnoEnSheets(valid, undefined)).rejects.toThrow(
       "No hay una comisión activa"
     );
+  });
+});
+
+// ── getSheetNames – validación de spreadsheetId ──────────────
+
+describe("getSheetNames – validación de spreadsheetId", () => {
+  it("lanza error de dominio si el spreadsheetId está vacío", async () => {
+    await expect(getSheetNames("")).rejects.toThrow("No hay una comisión activa");
   });
 });

--- a/src/lib/sheets.test.ts
+++ b/src/lib/sheets.test.ts
@@ -309,48 +309,48 @@ describe("upsertarAlumnoEnSheets – validaciones", () => {
   };
 
   it("rechaza apellido vacío", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "" });
-    expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, apellido: "" });
+    expect(result).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza apellido con solo espacios", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, apellido: "   " });
-    expect(r).toEqual({ ok: false, error: "El apellido es obligatorio" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, apellido: "   " });
+    expect(result).toEqual({ ok: false, error: "El apellido es obligatorio" });
   });
 
   it("rechaza nombre vacío", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, nombre: "" });
-    expect(r).toEqual({ ok: false, error: "El nombre es obligatorio" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, nombre: "" });
+    expect(result).toEqual({ ok: false, error: "El nombre es obligatorio" });
   });
 
   it("rechaza legajo vacío", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, legajo: "" });
+    expect(result).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza legajo con letras", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, legajo: "abc12" });
-    expect(r).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, legajo: "abc12" });
+    expect(result).toEqual({ ok: false, error: "El legajo debe tener entre 4 y 8 dígitos" });
   });
 
   it("rechaza email sin @", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juangmail.com" });
-    expect(r).toEqual({ ok: false, error: "El email no es válido" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, email: "juangmail.com" });
+    expect(result).toEqual({ ok: false, error: "El email no es válido" });
   });
 
   it("rechaza email sin punto en el dominio", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, email: "juan@gmail" });
-    expect(r).toEqual({ ok: false, error: "El email no es válido" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, email: "juan@gmail" });
+    expect(result).toEqual({ ok: false, error: "El email no es válido" });
   });
 
   it("rechaza email vacío", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, email: "" });
-    expect(r).toEqual({ ok: false, error: "El email no es válido" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, email: "" });
+    expect(result).toEqual({ ok: false, error: "El email no es válido" });
   });
 
   it("rechaza github vacío", async () => {
-    const r = await upsertarAlumnoEnSheets({ ...valid, githubUsername: "" });
-    expect(r).toEqual({ ok: false, error: "El usuario de GitHub es obligatorio" });
+    const result = await upsertarAlumnoEnSheets({ ...valid, githubUsername: "" });
+    expect(result).toEqual({ ok: false, error: "El usuario de GitHub es obligatorio" });
   });
 
   it("lanza error si no hay spreadsheetId configurado (input válido)", async () => {

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -52,11 +52,11 @@ function buildReadRange(config: ColumnConfig): string {
 // Convierte índice 0-based a letra de columna (0→A, 25→Z, 26→AA…)
 export function colLetter(index: number): string {
   let result = "";
-  let n = index;
+  let remaining = index;
   do {
-    result = String.fromCharCode(65 + (n % 26)) + result;
-    n = Math.floor(n / 26) - 1;
-  } while (n >= 0);
+    result = String.fromCharCode(65 + (remaining % 26)) + result;
+    remaining = Math.floor(remaining / 26) - 1;
+  } while (remaining >= 0);
   return result;
 }
 
@@ -69,14 +69,13 @@ export function parseAlumnosRows(
   return rows
     .filter((row) => row[config.legajo] && row[config.githubUsername])
     .map((row) => {
-      const a = new Alumno();
-      a.legajo = norm(row[config.legajo]);
-      a.apellido = norm(row[config.apellido]);
-      a.nombre = norm(row[config.nombre]);
-      a.githubUsername = norm(row[config.githubUsername]).replace("@", "").toLowerCase();
-      a.email = norm(row[config.email]);
-      // comision es una relación ManyToOne — no se puede resolver desde la planilla
-      return a;
+      const alumno = new Alumno();
+      alumno.legajo = norm(row[config.legajo]);
+      alumno.apellido = norm(row[config.apellido]);
+      alumno.nombre = norm(row[config.nombre]);
+      alumno.githubUsername = norm(row[config.githubUsername]).replace("@", "").toLowerCase();
+      alumno.email = norm(row[config.email]);
+      return alumno;
     });
 }
 
@@ -87,17 +86,17 @@ export async function getAlumnos(
   config?: Partial<ColumnConfig>
 ): Promise<Alumno[]> {
   const id = resolveSpreadsheetId(spreadsheetId);
-  const cfg = resolveConfig(config);
+  const columnConfig = resolveConfig(config);
 
   try {
     const sheets = getSheetsClient();
     const { data } = await sheets.spreadsheets.values.get({
       spreadsheetId: id,
-      range: buildReadRange(cfg),
+      range: buildReadRange(columnConfig),
     });
-    return parseAlumnosRows(data.values ?? [], cfg);
-  } catch (e) {
-    throw new Error(`No se pudo leer la planilla de alumnos: ${(e as Error).message}`);
+    return parseAlumnosRows(data.values ?? [], columnConfig);
+  } catch (error) {
+    throw new Error(`No se pudo leer la planilla de alumnos: ${(error as Error).message}`);
   }
 }
 
@@ -108,7 +107,7 @@ export async function getAlumnoByGithub(
 ): Promise<Alumno | undefined> {
   const all = await getAlumnos(spreadsheetId, config);
   return all.find(
-    (a) => a.githubUsername.toLowerCase() === username.toLowerCase()
+    (alumno) => alumno.githubUsername.toLowerCase() === username.toLowerCase()
   );
 }
 
@@ -118,7 +117,7 @@ export async function getAlumnoByLegajo(
   config?: Partial<ColumnConfig>
 ): Promise<Alumno | undefined> {
   const all = await getAlumnos(spreadsheetId, config);
-  return all.find((a) => a.legajo === legajo.trim());
+  return all.find((alumno) => alumno.legajo === legajo.trim());
 }
 
 // ── Encontrar el número de fila de un alumno (1-based, incluyendo header) ──
@@ -134,14 +133,13 @@ async function findAlumnoRowIndex(
     range: buildReadRange(config),
   });
   const rows = data.values ?? [];
-  const idx = rows.findIndex(
+  const rowIndex = rows.findIndex(
     (row) =>
       norm(row[config.githubUsername]).replace("@", "").toLowerCase() ===
       githubUsername.toLowerCase()
   );
-  if (idx === -1) return null;
-  // idx es 0-based dentro de los datos; la fila real = headerRows + 1 + idx
-  return config.headerRows + 1 + idx;
+  if (rowIndex === -1) return null;
+  return config.headerRows + 1 + rowIndex;
 }
 
 // ── Registro de alumno ──────────────────────────────────────
@@ -200,36 +198,34 @@ export async function upsertarAlumnoEnSheets(
   if (validationError) return { ok: false, error: validationError };
 
   const id = resolveSpreadsheetId(spreadsheetId);
-  const cfg = resolveConfig(config);
+  const columnConfig = resolveConfig(config);
   const githubNormalizado = input.githubUsername.trim().toLowerCase();
 
-  const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, cfg);
+  const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, columnConfig);
   const sheets = getSheetsClient(false);
   const maxCol = Math.max(
-    cfg.legajo, cfg.apellido, cfg.nombre,
-    cfg.githubUsername, cfg.email
+    columnConfig.legajo, columnConfig.apellido, columnConfig.nombre,
+    columnConfig.githubUsername, columnConfig.email
   );
 
   if (rowNumber === null) {
     const row = new Array(maxCol + 1).fill("");
-    row[cfg.legajo] = input.legajo.trim();
-    row[cfg.apellido] = input.apellido.trim();
-    row[cfg.nombre] = input.nombre.trim();
-    row[cfg.githubUsername] = githubNormalizado;
-    row[cfg.email] = input.email.trim().toLowerCase();
+    row[columnConfig.legajo] = input.legajo.trim();
+    row[columnConfig.apellido] = input.apellido.trim();
+    row[columnConfig.nombre] = input.nombre.trim();
+    row[columnConfig.githubUsername] = githubNormalizado;
+    row[columnConfig.email] = input.email.trim().toLowerCase();
 
     await sheets.spreadsheets.values.append({
       spreadsheetId: id,
-      range: `${cfg.sheetName}!A:${colLetter(maxCol)}`,
+      range: `${columnConfig.sheetName}!A:${colLetter(maxCol)}`,
       valueInputOption: "USER_ENTERED",
       requestBody: { values: [row] },
     });
     return { ok: true };
   }
 
-  // Leemos la fila completa para no pisar columnas desconocidas que el admin
-  // pueda tener (notas, observaciones, etc).
-  const range = `${cfg.sheetName}!A${rowNumber}:${colLetter(maxCol)}${rowNumber}`;
+  const range = `${columnConfig.sheetName}!A${rowNumber}:${colLetter(maxCol)}${rowNumber}`;
   const { data: existing } = await sheets.spreadsheets.values.get({
     spreadsheetId: id,
     range,
@@ -237,11 +233,10 @@ export async function upsertarAlumnoEnSheets(
   const existingRow: unknown[] = existing.values?.[0] ?? [];
   while (existingRow.length <= maxCol) existingRow.push("");
 
-  existingRow[cfg.legajo] = input.legajo.trim();
-  existingRow[cfg.apellido] = input.apellido.trim();
-  existingRow[cfg.nombre] = input.nombre.trim();
-  existingRow[cfg.email] = input.email.trim().toLowerCase();
-  // githubUsername NO se sobrescribe: la fila se identifica por él.
+  existingRow[columnConfig.legajo] = input.legajo.trim();
+  existingRow[columnConfig.apellido] = input.apellido.trim();
+  existingRow[columnConfig.nombre] = input.nombre.trim();
+  existingRow[columnConfig.email] = input.email.trim().toLowerCase();
 
   await sheets.spreadsheets.values.update({
     spreadsheetId: id,
@@ -264,8 +259,8 @@ export interface AsignacionGrupoRow {
 
 function buildGruposReadRange(config: GruposColumnConfig): string {
   const gruposCols = PARADIGMAS
-    .map((p) => config.nombreGrupoPorParadigma[p])
-    .filter((v): v is number => typeof v === "number");
+    .map((paradigma) => config.nombreGrupoPorParadigma[paradigma])
+    .filter((value): value is number => typeof value === "number");
   const maxCol = Math.max(config.githubUsername, ...gruposCols);
   const startRow = config.headerRows + 1;
   return `${config.sheetName}!A${startRow}:${colLetter(maxCol)}500`;
@@ -302,8 +297,8 @@ export async function getAsignacionesGrupos(
       range: buildGruposReadRange(config),
     });
     return parseAsignacionesGrupos(data.values ?? [], config);
-  } catch (e) {
-    throw new Error(`No se pudo leer la hoja de grupos: ${(e as Error).message}`);
+  } catch (error) {
+    throw new Error(`No se pudo leer la hoja de grupos: ${(error as Error).message}`);
   }
 }
 

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -307,6 +307,19 @@ export async function getAsignacionesGrupos(
   }
 }
 
+// ── Nombres de hojas del spreadsheet ────────────────────────
+
+export async function getSheetNames(spreadsheetId: string): Promise<string[]> {
+  const sheets = getSheetsClient();
+  const { data } = await sheets.spreadsheets.get({
+    spreadsheetId,
+    fields: "sheets.properties.title",
+  });
+  return (data.sheets ?? [])
+    .map((sheet) => sheet.properties?.title ?? "")
+    .filter(Boolean);
+}
+
 // ── Helpers ─────────────────────────────────────────────────
 
 function norm(value: unknown): string {

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -73,7 +73,7 @@ export function parseAlumnosRows(
       alumno.legajo = norm(row[config.legajo]);
       alumno.apellido = norm(row[config.apellido]);
       alumno.nombre = norm(row[config.nombre]);
-      alumno.githubUsername = norm(row[config.githubUsername]).replace("@", "").toLowerCase();
+      alumno.githubUsername = Alumno.normalizarUsername(row[config.githubUsername]);
       alumno.email = norm(row[config.email]);
       return alumno;
     });
@@ -107,7 +107,7 @@ export async function getAlumnoByGithub(
 ): Promise<Alumno | undefined> {
   const all = await getAlumnos(spreadsheetId, config);
   return all.find(
-    (alumno) => alumno.githubUsername.toLowerCase() === username.toLowerCase()
+    (alumno) => alumno.usernameCanonico === Alumno.normalizarUsername(username)
   );
 }
 
@@ -135,8 +135,8 @@ async function findAlumnoRowIndex(
   const rows = data.values ?? [];
   const rowIndex = rows.findIndex(
     (row) =>
-      norm(row[config.githubUsername]).replace("@", "").toLowerCase() ===
-      githubUsername.toLowerCase()
+      Alumno.normalizarUsername(row[config.githubUsername]) ===
+      Alumno.normalizarUsername(githubUsername)
   );
   if (rowIndex === -1) return null;
   return config.headerRows + 1 + rowIndex;
@@ -163,7 +163,7 @@ export function isValidEmail(email: string): boolean {
 export function validateRegistro(input: RegistroInput): string | null {
   const { legajo, apellido, nombre, githubUsername, email } = input;
 
-  if (!legajo || !/^\d{4,8}$/.test(legajo.trim()))
+  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
     return "El legajo debe tener entre 4 y 8 dígitos";
   if (!apellido.trim()) return "El apellido es obligatorio";
   if (!nombre.trim()) return "El nombre es obligatorio";
@@ -199,7 +199,7 @@ export async function upsertarAlumnoEnSheets(
 
   const id = resolveSpreadsheetId(spreadsheetId);
   const columnConfig = resolveConfig(config);
-  const githubNormalizado = input.githubUsername.trim().toLowerCase();
+  const githubNormalizado = Alumno.normalizarUsername(input.githubUsername);
 
   const rowNumber = await findAlumnoRowIndex(githubNormalizado, id, columnConfig);
   const sheets = getSheetsClient(false);
@@ -214,7 +214,7 @@ export async function upsertarAlumnoEnSheets(
     row[columnConfig.apellido] = input.apellido.trim();
     row[columnConfig.nombre] = input.nombre.trim();
     row[columnConfig.githubUsername] = githubNormalizado;
-    row[columnConfig.email] = input.email.trim().toLowerCase();
+    row[columnConfig.email] = Alumno.normalizarEmail(input.email);
 
     await sheets.spreadsheets.values.append({
       spreadsheetId: id,
@@ -236,7 +236,7 @@ export async function upsertarAlumnoEnSheets(
   existingRow[columnConfig.legajo] = input.legajo.trim();
   existingRow[columnConfig.apellido] = input.apellido.trim();
   existingRow[columnConfig.nombre] = input.nombre.trim();
-  existingRow[columnConfig.email] = input.email.trim().toLowerCase();
+  existingRow[columnConfig.email] = Alumno.normalizarEmail(input.email);
 
   await sheets.spreadsheets.values.update({
     spreadsheetId: id,
@@ -272,7 +272,7 @@ export function parseAsignacionesGrupos(
 ): AsignacionGrupoRow[] {
   const result: AsignacionGrupoRow[] = [];
   for (const row of rows) {
-    const github = norm(row[config.githubUsername]).replace("@", "").toLowerCase();
+    const github = Alumno.normalizarUsername(row[config.githubUsername]);
     if (!github) continue;
     for (const paradigma of PARADIGMAS) {
       const colIndex = config.nombreGrupoPorParadigma[paradigma];

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -305,9 +305,10 @@ export async function getAsignacionesGrupos(
 // ── Nombres de hojas del spreadsheet ────────────────────────
 
 export async function getSheetNames(spreadsheetId: string): Promise<string[]> {
+  const id = resolveSpreadsheetId(spreadsheetId);
   const sheets = getSheetsClient();
   const { data } = await sheets.spreadsheets.get({
-    spreadsheetId,
+    spreadsheetId: id,
     fields: "sheets.properties.title",
   });
   return (data.sheets ?? [])

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,3 +1,6 @@
+import { normalizarGithubUsername } from "@/domain/entities/domain-constants";
+export { normalizarGithubUsername };
+
 // ── Paradigmas ──────────────────────────────────────────────
 export type Paradigma = "funcional" | "logico" | "objetos";
 
@@ -48,4 +51,8 @@ export interface PdepUser {
   name: string;
   image: string;
   isAdmin: boolean;
+}
+
+export function usernameCanonicoDe(user: PdepUser): string {
+  return normalizarGithubUsername(user.githubUsername);
 }


### PR DESCRIPTION
## Resumen

- Servicio `verificarConsistenciaAlumno` ejecutado tras login: valida coherencia entre DB y planilla, con manejo de fallos sin interrumpir el flujo
- 3 migraciones nuevas: campos de consistencia en `Alumno`, flag `inscripcionesCerradas` en `Assignment`, limpieza de campo obsoleto
- Panel admin de grupos en `/admin/assignments/[id]`: vista por grupo con integrantes y acciones por alumno
- Nuevas rutas REST: `GET/POST /api/assignments/[id]/grupos`, `POST /api/assignments/[id]/grupos/[grupoId]/join`, `PATCH /api/assignments/[id]/inscripciones`
- Páginas de alumno para selección/vista de grupo: `/assignments/[id]/grupo`
- Extracción de lógica de eventos de auth a `auth.events.ts`
- Actualización de versión de Node en CI y mejoras de expresividad en sheets/github/repositories

## Cierra

Closes #21

## Test plan

- [ ] Correr migraciones: `npm run db:migration:up`
- [ ] Login de alumno: verificar que `verificarConsistenciaAlumno` se ejecuta sin romper el flujo si la planilla falla
- [ ] `/admin/assignments/[id]` — panel de grupos lista grupos con integrantes
- [ ] Como alumno, navegar a `/assignments/[id]/grupo` y unirse a un grupo
- [ ] Inscripciones cerradas: endpoint responde con error apropiado
- [ ] Alumnos con inconsistencia en planilla ven el banner de sync pendiente