### PR TITLE
Remove Entrega dependency on lib query helper

### DIFF
--- a/src/domain/entities/Entrega.test.ts
+++ b/src/domain/entities/Entrega.test.ts
@@ -62,37 +62,3 @@ describe("Entrega.estadoRepo", () => {
     expect(entrega.estadoRepo()).toBe("sin-repo");
   });
 });
-
-describe("Entrega.matcheaQuery", () => {
-  it("devuelve true para query vacía (no filtra nada)", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"] });
-    expect(entrega.matcheaQuery("")).toBe(true);
-    expect(entrega.matcheaQuery("   ")).toBe(true);
-  });
-
-  it("devuelve true cuando la query coincide con un username", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia", "bob"] });
-    expect(entrega.matcheaQuery("ana")).toBe(true);
-  });
-
-  it("es case-insensitive en usernames", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia"] });
-    expect(entrega.matcheaQuery("anagarcia")).toBe(true);
-    expect(entrega.matcheaQuery("ANAGARCIA")).toBe(true);
-  });
-
-  it("devuelve true cuando la query coincide con el repoName", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
-    expect(entrega.matcheaQuery("funcional")).toBe(true);
-  });
-
-  it("devuelve false cuando la query no coincide con ningún campo", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
-    expect(entrega.matcheaQuery("logico")).toBe(false);
-  });
-
-  it("tolera repoName undefined sin explotar", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: undefined });
-    expect(entrega.matcheaQuery("algo")).toBe(false);
-  });
-});

--- a/src/domain/entities/Entrega.ts
+++ b/src/domain/entities/Entrega.ts
@@ -8,7 +8,6 @@ import { randomUUID } from "crypto";
 import { Alumno } from "./Alumno";
 import { Assignment } from "./Assignment";
 import { Grupo } from "./Grupo";
-import { matcheaEntregaQuery } from "@/lib/entrega-query";
 
 @Entity()
 export class Entrega {
@@ -58,9 +57,5 @@ export class Entrega {
     if (this.repoFueBorrado()) return "borrado";
     if (this.hasRepo()) return "activo";
     return "sin-repo";
-  }
-
-  matcheaQuery(rawQuery: string): boolean {
-    return matcheaEntregaQuery(this, rawQuery);
   }
 }


### PR DESCRIPTION
## Summary
- remove Entrega.matcheaQuery and its dependency on @/lib/entrega-query
- keep delivery search behavior covered in entrega-query and admin table tests

Closes #34

## Tests
- npm run test:run -- src/domain/entities/Entrega.test.ts src/lib/entrega-query.test.ts 'src/app/admin/assignments/[id]/entregas-table.test.tsx'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Se eliminó funcionalidad de búsqueda y filtrado de entregas.

* **Tests**
  * Se removieron pruebas unitarias asociadas.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Juancete/Pdep-Classroom/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->