### PR TITLE
Fix unique active commission constraint

### DIFF
--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -617,7 +617,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
+          "unique": true,
           "length": null,
           "precision": null,
           "scale": null,
@@ -655,6 +655,17 @@
           "keyName": "comision_pkey",
           "unique": true,
           "primary": true
+        },
+        {
+          "columnNames": [
+            "activa"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "comision_unica_activa_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX comision_unica_activa_idx ON public.comision USING btree (activa) WHERE (activa IS TRUE)"
         }
       ],
       "checks": [],

--- a/migrations/Migration20260527120000_add_unique_active_comision_index.ts
+++ b/migrations/Migration20260527120000_add_unique_active_comision_index.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260527120000_add_unique_active_comision_index extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      do $$
+      begin
+        if (select count(*) from "comision" where "activa" is true) > 1 then
+          raise exception 'No se puede crear comision_unica_activa_idx: hay mas de una comision activa. Deja una sola activa y reintenta la migracion.';
+        end if;
+      end $$;
+    `);
+    this.addSql(`create unique index "comision_unica_activa_idx" on "comision" ("activa") where "activa" is true;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "comision_unica_activa_idx";`);
+  }
+
+}

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
 }));
 
-const { FakeLegajoConflictError } = vi.hoisted(() => {
+const { FakeLegajoConflictError, FakeComisionActivaDuplicadaError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
     constructor(
       public readonly legajo: string,
@@ -29,7 +29,13 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
       this.name = "LegajoConflictError";
     }
   }
-  return { FakeLegajoConflictError };
+  class FakeComisionActivaDuplicadaError extends Error {
+    constructor() {
+      super("Ya existe otra comisión activa.");
+      this.name = "ComisionActivaDuplicadaError";
+    }
+  }
+  return { FakeLegajoConflictError, FakeComisionActivaDuplicadaError };
 });
 
 vi.mock("@/lib/repositories", () => ({
@@ -40,6 +46,7 @@ vi.mock("@/lib/repositories", () => ({
   getAlumnosByComision: (...args: unknown[]) =>
     mockGetAlumnosByComision(...args),
   LegajoConflictError: FakeLegajoConflictError,
+  ComisionActivaDuplicadaError: FakeComisionActivaDuplicadaError,
 }));
 
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
@@ -127,6 +134,25 @@ describe("crearComision", () => {
     );
   });
 
+  it("retorna error de activa si otra request activó una comisión al mismo tiempo", async () => {
+    mockCreateComision.mockRejectedValue(new FakeComisionActivaDuplicadaError());
+
+    const result = await crearComision(
+      null,
+      makeFormData({ ...BASE, activa: "on" })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errors: {
+        activa: [
+          "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+        ],
+      },
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
   describe("validaciones", () => {
     it("retorna error si falta el año", async () => {
       const result = await crearComision(
@@ -197,6 +223,25 @@ describe("actualizarComision", () => {
     );
     expect(result).toMatchObject({ ok: false });
     expect(mockUpdateComision).not.toHaveBeenCalled();
+  });
+
+  it("retorna error de activa si otra request activó una comisión al mismo tiempo", async () => {
+    mockUpdateComision.mockRejectedValue(new FakeComisionActivaDuplicadaError());
+
+    const result = await actualizarComision(
+      null,
+      makeFormData({ ...BASE, id: "c1", activa: "on" })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errors: {
+        activa: [
+          "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+        ],
+      },
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -8,6 +8,7 @@ import {
   upsertAlumnos,
   LegajoConflictError,
   getAlumnosByComision,
+  ComisionActivaDuplicadaError,
 } from "@/lib/repositories";
 import { getAlumnos, getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
@@ -141,7 +142,26 @@ export async function crearComision(
   }
 
   const { anio, spreadsheetId, activa } = result.data;
-  await createComision({ anio, spreadsheetId, activa, columnConfig: toColumnConfig(result.data) });
+  try {
+    await createComision({
+      anio,
+      spreadsheetId,
+      activa,
+      columnConfig: toColumnConfig(result.data),
+    });
+  } catch (error) {
+    if (error instanceof ComisionActivaDuplicadaError) {
+      return {
+        ok: false,
+        errors: {
+          activa: [
+            "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+          ],
+        },
+      };
+    }
+    throw error;
+  }
   redirect("/admin/comisiones");
 }
 
@@ -160,7 +180,26 @@ export async function actualizarComision(
   }
 
   const { anio, spreadsheetId, activa } = result.data;
-  await updateComision(id, { anio, spreadsheetId, activa, columnConfig: toColumnConfig(result.data) });
+  try {
+    await updateComision(id, {
+      anio,
+      spreadsheetId,
+      activa,
+      columnConfig: toColumnConfig(result.data),
+    });
+  } catch (error) {
+    if (error instanceof ComisionActivaDuplicadaError) {
+      return {
+        ok: false,
+        errors: {
+          activa: [
+            "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+          ],
+        },
+      };
+    }
+    throw error;
+  }
   redirect("/admin/comisiones");
 }
 

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("migrations", () => {
+  it("garantiza una única comisión activa con un índice único parcial", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260527120000_add_unique_active_comision_index.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('create unique index "comision_unica_activa_idx"');
+    expect(migration).toContain('on "comision" ("activa") where "activa" is true');
+    expect(migration).toContain('drop index if exists "comision_unica_activa_idx"');
+    expect(migration).toContain("hay mas de una comision activa");
+  });
+});

--- a/src/lib/repositories/ComisionRepository.test.ts
+++ b/src/lib/repositories/ComisionRepository.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockTx = {
+  findOne: vi.fn(),
+  nativeUpdate: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+const mockEm = {
+  findOne: vi.fn(),
+  nativeUpdate: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+  transactional: vi.fn(async (callback: (transaction: typeof mockTx) => Promise<unknown>) =>
+    callback(mockTx)
+  ),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import {
+  createComision,
+  updateComision,
+  ComisionActivaDuplicadaError,
+} from "./ComisionRepository";
+import { Comision } from "@/domain/entities";
+
+function uniqueActiveComisionError(): Error {
+  return Object.assign(
+    new Error('duplicate key value violates unique constraint "comision_unica_activa_idx"'),
+    { code: "23505" }
+  );
+}
+
+describe("ComisionRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.transactional.mockImplementation(
+      async (callback: (transaction: typeof mockTx) => Promise<unknown>) =>
+        callback(mockTx)
+    );
+  });
+
+  describe("createComision", () => {
+    it("crea sin transacción cuando no se marca como activa", async () => {
+      const comision = await createComision({
+        anio: 2026,
+        spreadsheetId: "sheet-1",
+        activa: false,
+      });
+
+      expect(mockEm.transactional).not.toHaveBeenCalled();
+      expect(mockEm.nativeUpdate).not.toHaveBeenCalled();
+      expect(mockEm.persist).toHaveBeenCalledWith(comision);
+      expect(mockEm.flush).toHaveBeenCalled();
+      expect(comision.activa).toBe(false);
+    });
+
+    it("si activa=true, desactiva las demás y persiste dentro de una transacción", async () => {
+      const comision = await createComision({
+        anio: 2026,
+        spreadsheetId: "sheet-1",
+        activa: true,
+      });
+
+      expect(mockEm.transactional).toHaveBeenCalledOnce();
+      expect(mockTx.nativeUpdate).toHaveBeenCalledWith(Comision, {}, { activa: false });
+      expect(mockTx.persist).toHaveBeenCalledWith(comision);
+      expect(mockTx.flush).toHaveBeenCalled();
+      expect(comision.activa).toBe(true);
+    });
+
+    it("traduce la violación del índice único de comisión activa", async () => {
+      mockTx.flush.mockRejectedValueOnce(uniqueActiveComisionError());
+
+      await expect(
+        createComision({ anio: 2026, spreadsheetId: "sheet-1", activa: true })
+      ).rejects.toBeInstanceOf(ComisionActivaDuplicadaError);
+    });
+  });
+
+  describe("updateComision", () => {
+    it("actualiza sin transacción cuando no se marca como activa", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      mockEm.findOne.mockResolvedValueOnce(comision);
+
+      const result = await updateComision("c1", {
+        anio: 2026,
+        spreadsheetId: "sheet-new",
+        activa: false,
+      });
+
+      expect(result).toBe(comision);
+      expect(mockEm.transactional).not.toHaveBeenCalled();
+      expect(mockEm.nativeUpdate).not.toHaveBeenCalled();
+      expect(mockEm.flush).toHaveBeenCalled();
+      expect(comision.anio).toBe(2026);
+      expect(comision.spreadsheetId).toBe("sheet-new");
+      expect(comision.activa).toBe(false);
+    });
+
+    it("si activa=true, desactiva las demás y actualiza dentro de una transacción", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      mockTx.findOne.mockResolvedValueOnce(comision);
+
+      const result = await updateComision("c1", {
+        anio: 2026,
+        spreadsheetId: "sheet-new",
+        activa: true,
+      });
+
+      expect(result).toBe(comision);
+      expect(mockEm.transactional).toHaveBeenCalledOnce();
+      expect(mockTx.findOne).toHaveBeenCalledWith(Comision, { id: "c1" });
+      expect(mockTx.nativeUpdate).toHaveBeenCalledWith(
+        Comision,
+        { id: { $ne: "c1" } },
+        { activa: false }
+      );
+      expect(mockTx.flush).toHaveBeenCalled();
+      expect(comision.anio).toBe(2026);
+      expect(comision.spreadsheetId).toBe("sheet-new");
+      expect(comision.activa).toBe(true);
+    });
+
+    it("traduce la violación del índice único de comisión activa", async () => {
+      mockTx.findOne.mockResolvedValueOnce(new Comision(2025, "sheet-old"));
+      mockTx.flush.mockRejectedValueOnce(uniqueActiveComisionError());
+
+      await expect(
+        updateComision("c1", { anio: 2026, spreadsheetId: "sheet-1", activa: true })
+      ).rejects.toBeInstanceOf(ComisionActivaDuplicadaError);
+    });
+  });
+});

--- a/src/lib/repositories/ComisionRepository.ts
+++ b/src/lib/repositories/ComisionRepository.ts
@@ -2,11 +2,43 @@ import { getEM, deleteEntity } from "@/lib/db";
 import { Comision } from "@/domain/entities";
 import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
 
+export class ComisionActivaDuplicadaError extends Error {
+  constructor() {
+    super("Ya existe otra comisión activa.");
+    this.name = "ComisionActivaDuplicadaError";
+  }
+}
+
 export interface ComisionFormData {
   anio: number;
   spreadsheetId: string;
   activa: boolean;
   columnConfig?: ColumnConfig;
+}
+
+function esViolacionDeComisionActivaUnica(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const cause = error.cause;
+  const code =
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  const message = `${error.message} ${
+    cause instanceof Error ? cause.message : ""
+  }`;
+  return code === "23505" && message.includes("comision_unica_activa_idx");
+}
+
+async function traducirErrorDeComisionActiva<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (esViolacionDeComisionActivaUnica(error)) {
+      throw new ComisionActivaDuplicadaError();
+    }
+    throw error;
+  }
 }
 
 export async function getComisiones(): Promise<Comision[]> {
@@ -27,17 +59,29 @@ export async function getComisionActiva(): Promise<Comision | null> {
 export async function createComision(data: ComisionFormData): Promise<Comision> {
   const entityManager = await getEM();
 
-  if (data.activa) {
-    await entityManager.nativeUpdate(Comision, {}, { activa: false });
-  }
+  return traducirErrorDeComisionActiva(async () => {
+    if (!data.activa) {
+      const comision = new Comision(data.anio, data.spreadsheetId);
+      comision.activa = false;
+      comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
 
-  const comision = new Comision(data.anio, data.spreadsheetId);
-  comision.activa = data.activa;
-  comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
+      entityManager.persist(comision);
+      await entityManager.flush();
+      return comision;
+    }
 
-  entityManager.persist(comision);
-  await entityManager.flush();
-  return comision;
+    return entityManager.transactional(async (transaction) => {
+      await transaction.nativeUpdate(Comision, {}, { activa: false });
+
+      const comision = new Comision(data.anio, data.spreadsheetId);
+      comision.activa = true;
+      comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
+
+      transaction.persist(comision);
+      await transaction.flush();
+      return comision;
+    });
+  });
 }
 
 export async function updateComision(
@@ -45,20 +89,36 @@ export async function updateComision(
   data: Partial<ComisionFormData>
 ): Promise<Comision | null> {
   const entityManager = await getEM();
-  const comision = await entityManager.findOne(Comision, { id });
-  if (!comision) return null;
 
-  if (data.activa) {
-    await entityManager.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
-  }
+  return traducirErrorDeComisionActiva(async () => {
+    if (!data.activa) {
+      const comision = await entityManager.findOne(Comision, { id });
+      if (!comision) return null;
 
-  if (data.anio !== undefined) comision.anio = data.anio;
-  if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
-  if (data.activa !== undefined) comision.activa = data.activa;
-  if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
+      if (data.anio !== undefined) comision.anio = data.anio;
+      if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
+      if (data.activa !== undefined) comision.activa = data.activa;
+      if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
 
-  await entityManager.flush();
-  return comision;
+      await entityManager.flush();
+      return comision;
+    }
+
+    return entityManager.transactional(async (transaction) => {
+      const comision = await transaction.findOne(Comision, { id });
+      if (!comision) return null;
+
+      await transaction.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
+
+      if (data.anio !== undefined) comision.anio = data.anio;
+      if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
+      comision.activa = true;
+      if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
+
+      await transaction.flush();
+      return comision;
+    });
+  });
 }
 
 export async function deleteComision(id: string): Promise<void> {

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -53,5 +53,6 @@ export {
   createComision,
   updateComision,
   deleteComision,
+  ComisionActivaDuplicadaError,
 } from "./ComisionRepository";
 export type { ComisionFormData } from "./ComisionRepository";


### PR DESCRIPTION
## Summary
- add a partial unique index so PostgreSQL allows at most one active commission
- make active commission create/update operations transactional
- surface concurrent activation races as a friendly admin form error

## Tests
- pnpm test:run
- git diff --check

## Notes
- local migrations were applied successfully with `pnpm run db:migration:up`
- `pnpm exec tsc --noEmit --incremental false` still fails on pre-existing unrelated test typing issues