### PR TITLE
Asociar assignments a la comisión activa

### DIFF
--- a/src/app/admin/assignments/[id]/edit/page.test.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.test.tsx
@@ -126,6 +126,17 @@ describe("Edit Assignment page", () => {
     expect(html).not.toContain("name=\"comisionId\"");
   });
 
+  it("muestra Histórica cuando la comisión asociada no está activa", async () => {
+    const comision = new Comision(2027, "sheet-2");
+    comision.activa = false;
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("2027 (Histórica)");
+  });
+
   it("muestra Sin comisión para assignments huérfanos", async () => {
     mockGetAssignment.mockResolvedValue(makeAssignment({ comision: undefined }));
 

--- a/src/app/admin/assignments/[id]/edit/page.test.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
-import { IndividualAssignment } from "@/domain/entities";
+import { Comision, IndividualAssignment } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -61,6 +61,8 @@ import EditAssignmentPage from "./page";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: object) {
+  const comision = new Comision(2026, "sheet-1");
+  comision.activa = true;
   return Object.assign(new IndividualAssignment(), {
     id: "a1",
     titulo: "Kata Funcional",
@@ -71,6 +73,7 @@ function makeAssignment(overrides?: object) {
     deadline: new Date("2026-06-30"),
     createdAt: new Date("2026-01-01"),
     slug: "kata-funcional",
+    comision,
     ...overrides,
   });
 }
@@ -108,6 +111,28 @@ describe("Edit Assignment page", () => {
     const element = await EditAssignmentPage({ params: { id: "a1" } });
     const html = renderToStaticMarkup(element as React.ReactElement);
     expect(html).toContain("data-submit-label=\"Guardar cambios\"");
+  });
+
+  it("muestra la comisión asociada sin agregarla al formulario", async () => {
+    const comision = new Comision(2027, "sheet-2");
+    comision.activa = true;
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("Comisión:");
+    expect(html).toContain("2027 (Activa)");
+    expect(html).not.toContain("name=\"comisionId\"");
+  });
+
+  it("muestra Sin comisión para assignments huérfanos", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision: undefined }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("Sin comisión");
   });
 
   describe("defaultValues pre-populados", () => {

--- a/src/app/admin/assignments/[id]/edit/page.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.tsx
@@ -19,6 +19,14 @@ export default async function EditAssignmentPage({
   return (
     <div className="max-w-xl">
       <h1 className="text-2xl font-bold mb-6">Editar Assignment</h1>
+      <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+        Comisión:{" "}
+        <span className="font-medium text-gray-800">
+          {assignment.comision
+            ? `${assignment.comision.anio} (${assignment.comision.activa ? "Activa" : "Histórica"})`
+            : "Sin comisión"}
+        </span>
+      </div>
       <AssignmentForm
         action={actualizarAssignment}
         templates={templates}

--- a/src/app/admin/assignments/actions.test.ts
+++ b/src/app/admin/assignments/actions.test.ts
@@ -7,11 +7,16 @@ const mockCreateAssignment = vi.fn();
 const mockUpdateAssignment = vi.fn();
 const mockRedirect = vi.fn();
 
+const { FakeComisionActivaRequeridaError } = vi.hoisted(() => ({
+  FakeComisionActivaRequeridaError: class FakeComisionActivaRequeridaError extends Error {},
+}));
+
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
 }));
 
 vi.mock("@/lib/repositories", () => ({
+  ComisionActivaRequeridaError: FakeComisionActivaRequeridaError,
   createAssignment: (...args: unknown[]) => mockCreateAssignment(...args),
   updateAssignment: (...args: unknown[]) => mockUpdateAssignment(...args),
 }));
@@ -93,6 +98,23 @@ describe("crearAssignment", () => {
       );
       // el slug es generado por el repositorio, no por la action
       expect(mockRedirect).toHaveBeenCalledWith("/admin/assignments");
+    });
+
+    it("retorna error global si no hay comisión activa", async () => {
+      mockCreateAssignment.mockRejectedValue(
+        new FakeComisionActivaRequeridaError(
+          "Necesitás una comisión activa para crear assignments."
+        )
+      );
+
+      const result = await crearAssignment(null, makeFormData(BASE_INDIVIDUAL));
+
+      expect(result).toEqual({
+        ok: false,
+        errors: {},
+        formError: "Necesitás una comisión activa para crear assignments.",
+      });
+      expect(mockRedirect).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/admin/assignments/actions.ts
+++ b/src/app/admin/assignments/actions.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { requireAdmin } from "@/lib/session";
-import { createAssignment, updateAssignment } from "@/lib/repositories";
+import {
+  ComisionActivaRequeridaError,
+  createAssignment,
+  updateAssignment,
+} from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AssignmentSchema, AssignmentFormState } from "@/lib/assignment-schema";
 
@@ -31,7 +35,15 @@ export async function crearAssignment(
     return { ok: false, errors: result.error.flatten().fieldErrors };
   }
 
-  await createAssignment(result.data);
+  try {
+    await createAssignment(result.data);
+  } catch (error) {
+    if (error instanceof ComisionActivaRequeridaError) {
+      return { ok: false, errors: {}, formError: error.message };
+    }
+    throw error;
+  }
+
   redirect("/admin/assignments");
 }
 

--- a/src/app/admin/assignments/assignment-form.test.tsx
+++ b/src/app/admin/assignments/assignment-form.test.tsx
@@ -31,6 +31,10 @@ function errorState(errors: Record<string, string[]>) {
   mockUseFormState.mockReturnValue([{ ok: false, errors }, noop]);
 }
 
+function formErrorState(formError: string) {
+  mockUseFormState.mockReturnValue([{ ok: false, errors: {}, formError }, noop]);
+}
+
 const TEMPLATES = [
   { name: "kata-template", fullName: "org/kata-template", description: "Kata base" },
   { name: "tp-objetos", fullName: "org/tp-objetos", description: "TP de objetos" },
@@ -223,6 +227,16 @@ describe("AssignmentForm", () => {
         />
       );
       expect(screen.getByText("Debe ser al menos 2")).toBeInTheDocument();
+    });
+
+    it("muestra error global del formulario", () => {
+      formErrorState("Necesitás una comisión activa para crear assignments.");
+
+      render(<AssignmentForm action={noop} templates={[]} submitLabel="Crear" />);
+
+      expect(
+        screen.getByText("Necesitás una comisión activa para crear assignments.")
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -150,7 +150,10 @@ export function AssignmentForm({
   return (
     <form action={formAction} className="space-y-5" data-template-count={templates.length}>
       {state?.formError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
           {state.formError}
         </div>
       )}

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -149,6 +149,11 @@ export function AssignmentForm({
 
   return (
     <form action={formAction} className="space-y-5" data-template-count={templates.length}>
+      {state?.formError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {state.formError}
+        </div>
+      )}
       {defaultValues.id && <input type="hidden" name="id" value={defaultValues.id} />}
       {/* Título */}
       <div>

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { IndividualAssignment } from "@/domain/entities";
+import { Comision, IndividualAssignment } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -47,6 +47,8 @@ import AdminAssignmentsPage from "./page";
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
   const assignment = new IndividualAssignment();
+  const comision = new Comision(2026, "sheet-1");
+  comision.activa = true;
   assignment.id = "a1";
   assignment.titulo = "Kata Funcional";
   assignment.descripcion = "Descripción de la kata";
@@ -55,6 +57,7 @@ function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAs
   assignment.paradigma = "funcional";
   assignment.slug = "kata-funcional";
   assignment.createdAt = new Date("2026-01-01");
+  assignment.comision = comision;
   return Object.assign(assignment, overrides);
 }
 
@@ -142,6 +145,41 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("mi-template-especial");
     });
 
+    it("muestra la comisión activa asociada", async () => {
+      const comision = new Comision(2027, "sheet-2");
+      comision.activa = true;
+      mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("2027");
+      expect(html).toContain("Activa");
+    });
+
+    it("muestra comisión histórica cuando no está activa", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      comision.activa = false;
+      mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("2025");
+      expect(html).toContain("Histórica");
+    });
+
+    it("muestra Sin comisión para assignments huérfanos", async () => {
+      mockGetAssignments.mockResolvedValue([
+        makeAssignment({ comision: undefined }),
+      ]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("Sin comisión");
+    });
+
     it("muestra las cabeceras de la tabla", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
       const element = await AdminAssignmentsPage();
@@ -149,6 +187,7 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("Título");
       expect(html).toContain("Paradigma");
       expect(html).toContain("Tipo");
+      expect(html).toContain("Comisión");
       expect(html).toContain("Template");
       expect(html).toContain("Entregas");
       expect(html).toContain("Deadline");

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -46,11 +46,12 @@ export default async function AdminAssignmentsPage() {
       {sorted.length === 0 ? (
         <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px 180px">
+        <DataTable columns="2fr 1fr 1fr 1fr 1.5fr 90px 110px 180px">
           <DataHeader>
             <DataHeaderCell>Título</DataHeaderCell>
             <DataHeaderCell>Paradigma</DataHeaderCell>
             <DataHeaderCell>Tipo</DataHeaderCell>
+            <DataHeaderCell>Comisión</DataHeaderCell>
             <DataHeaderCell>Template</DataHeaderCell>
             <DataHeaderCell>Entregas</DataHeaderCell>
             <DataHeaderCell>Deadline</DataHeaderCell>
@@ -69,6 +70,24 @@ export default async function AdminAssignmentsPage() {
                 </DataCell>
                 <DataCell label="Tipo">
                   <span className="text-gray-500">{assignment.tipo}</span>
+                </DataCell>
+                <DataCell label="Comisión">
+                  {assignment.comision ? (
+                    <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
+                      {assignment.comision.anio}
+                      <span
+                        className={`rounded-full px-2 py-0.5 ${
+                          assignment.comision.activa
+                            ? "bg-green-50 text-green-700"
+                            : "bg-gray-100 text-gray-500"
+                        }`}
+                      >
+                        {assignment.comision.activa ? "Activa" : "Histórica"}
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="text-xs text-gray-400">Sin comisión</span>
+                  )}
                 </DataCell>
                 <DataCell label="Template">
                   <span className="font-mono text-xs text-gray-500 break-all">

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -9,6 +9,7 @@ const mockRequireUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockGetAssignments = vi.fn();
+const mockGetAssignmentsDeComision = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockGetGruposDeAlumno = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
@@ -21,6 +22,8 @@ vi.mock("@/lib/session", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAssignments: () => mockGetAssignments(),
+  getAssignmentsDeComision: (comisionId: string) =>
+    mockGetAssignmentsDeComision(comisionId),
   getEntregasDeUsuario: (username: string) => mockGetEntregaDeUsuario(username),
   getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
   getComisionActiva: () => mockGetComisionActiva(),
@@ -111,6 +114,7 @@ describe("Dashboard page", () => {
       throw new Error(`REDIRECT:${url}`);
     });
     mockGetAssignments.mockResolvedValue([]);
+    mockGetAssignmentsDeComision.mockResolvedValue([]);
     mockGetEntregaDeUsuario.mockResolvedValue(new Map());
     mockGetComisionActiva.mockResolvedValue({ id: "c1" });
     mockGetAlumnoByGithub.mockResolvedValue(null);
@@ -156,6 +160,21 @@ describe("Dashboard page", () => {
       expect(mockRedirect).not.toHaveBeenCalled();
     });
 
+    it("consulta assignments de la comisión activa para alumnos", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
+      mockGetAssignmentsDeComision.mockResolvedValue([makeAssignment({ titulo: "TP Vigente" })]);
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(mockGetAssignmentsDeComision).toHaveBeenCalledWith("c1");
+      expect(mockGetAssignments).not.toHaveBeenCalled();
+      expect(html).toContain("TP Vigente");
+    });
+
     it("no redirige si no hay comisión activa (deja pasar aunque no haya confirmado)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetComisionActiva.mockResolvedValue(null);
@@ -164,6 +183,7 @@ describe("Dashboard page", () => {
       const element = await DashboardPage();
       expect(element).toBeDefined();
       expect(mockRedirect).not.toHaveBeenCalled();
+      expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
     });
 
     it("no redirige a /registro aunque no esté registrado si es admin", async () => {
@@ -173,6 +193,8 @@ describe("Dashboard page", () => {
       expect(element).toBeDefined();
       expect(mockRedirect).not.toHaveBeenCalled();
       expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+      expect(mockGetAssignments).toHaveBeenCalled();
+      expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
     });
   });
 
@@ -331,7 +353,7 @@ describe("Dashboard page", () => {
     });
 
     it("muestra 'Elegir grupo' cuando es grupal y el alumno no tiene grupo", async () => {
-      mockGetAssignments.mockResolvedValue([makeGrupalAssignment()]);
+      mockGetAssignmentsDeComision.mockResolvedValue([makeGrupalAssignment()]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(new Map());
 
@@ -342,7 +364,7 @@ describe("Dashboard page", () => {
     });
 
     it("el link 'Elegir grupo' apunta a la página del grupo del assignment", async () => {
-      mockGetAssignments.mockResolvedValue([makeGrupalAssignment({ id: "tp-g1" })]);
+      mockGetAssignmentsDeComision.mockResolvedValue([makeGrupalAssignment({ id: "tp-g1" })]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(new Map());
 
@@ -353,7 +375,7 @@ describe("Dashboard page", () => {
 
     it("muestra AcceptButton cuando es grupal y el alumno ya tiene grupo", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])
@@ -367,7 +389,7 @@ describe("Dashboard page", () => {
 
     it("muestra el nombre del grupo cuando el alumno ya tiene grupo sin entrega", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])
@@ -381,7 +403,7 @@ describe("Dashboard page", () => {
     it("muestra 'Ir al repo' cuando ya tiene entrega, aunque tenga grupo", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
       const entrega = makeEntrega({ repoUrl: "https://github.com/pdep/tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map([["tp-g1", entrega]]));
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { requireUser } from "@/lib/session";
 import {
   getAssignments,
+  getAssignmentsDeComision,
   getEntregasDeUsuario,
   getAlumnoByGithub,
   getComisionActiva,
@@ -12,12 +13,14 @@ import type { Grupo } from "@/domain/entities";
 
 export default async function DashboardPage() {
   const user = await requireUser();
+  let comisionActivaId: string | null = null;
 
   if (!user.isAdmin) {
     const [alumno, comisionActiva] = await Promise.all([
       getAlumnoByGithub(user.githubUsername),
       getComisionActiva(),
     ]);
+    comisionActivaId = comisionActiva?.id ?? null;
     if (comisionActiva && (!alumno || alumno.necesitaConfirmarRegistroPara(comisionActiva))) {
       redirect("/registro");
     }
@@ -28,7 +31,11 @@ export default async function DashboardPage() {
     : getGruposDeAlumno(user.githubUsername);
 
   const [assignments, entregasMap, gruposMap] = await Promise.all([
-    getAssignments(),
+    user.isAdmin
+      ? getAssignments()
+      : comisionActivaId
+        ? getAssignmentsDeComision(comisionActivaId)
+        : Promise.resolve([]),
     getEntregasDeUsuario(user.githubUsername),
     gruposPromise,
   ]);

--- a/src/lib/assignment-schema.ts
+++ b/src/lib/assignment-schema.ts
@@ -32,5 +32,5 @@ export type AssignmentFormErrors =
   z.typeToFlattenedError<AssignmentFormData>["fieldErrors"];
 
 export type AssignmentFormState =
-  | { ok: false; errors: AssignmentFormErrors }
+  | { ok: false; errors: AssignmentFormErrors; formError?: string }
   | null;

--- a/src/lib/repositories/AssignmentRepository.test.ts
+++ b/src/lib/repositories/AssignmentRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEm = {
+  find: vi.fn(),
+  findOne: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import {
+  ComisionActivaRequeridaError,
+  createAssignment,
+  getAssignment,
+  getAssignments,
+  getAssignmentsDeComision,
+} from "./AssignmentRepository";
+import { Assignment, Comision } from "@/domain/entities";
+
+const assignmentData = {
+  titulo: "Kata Funcional",
+  slug: "",
+  descripcion: "",
+  templateRepo: "kata-template",
+  tipo: "individual" as const,
+  paradigma: "funcional",
+  deadline: "",
+};
+
+describe("AssignmentRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.find.mockResolvedValue([]);
+    mockEm.findOne.mockResolvedValue(new Comision(2026, "sheet-1"));
+    mockEm.flush.mockResolvedValue(undefined);
+  });
+
+  describe("getAssignmentsDeComision", () => {
+    it("busca assignments por comisión ordenados por fecha descendente", async () => {
+      await getAssignmentsDeComision("c1");
+
+      expect(mockEm.find).toHaveBeenCalledWith(
+        Assignment,
+        { comision: { id: "c1" } },
+        { orderBy: { createdAt: "DESC" } }
+      );
+    });
+  });
+
+  describe("getAssignments", () => {
+    it("popula comisión y ordena por fecha descendente", async () => {
+      await getAssignments();
+
+      expect(mockEm.find).toHaveBeenCalledWith(
+        Assignment,
+        {},
+        { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
+      );
+    });
+  });
+
+  describe("getAssignment", () => {
+    it("popula la comisión asociada", async () => {
+      await getAssignment("a1");
+
+      expect(mockEm.findOne).toHaveBeenCalledWith(
+        Assignment,
+        { id: "a1" },
+        { populate: ["comision"] }
+      );
+    });
+  });
+
+  describe("createAssignment", () => {
+    it("asocia el assignment a la comisión activa", async () => {
+      const comision = new Comision(2026, "sheet-1");
+      mockEm.findOne.mockResolvedValueOnce(comision);
+
+      const assignment = await createAssignment(assignmentData);
+
+      expect(mockEm.findOne).toHaveBeenCalledWith(Comision, { activa: true });
+      expect(assignment.comision).toBe(comision);
+      expect(mockEm.persist).toHaveBeenCalledWith(assignment);
+      expect(mockEm.flush).toHaveBeenCalled();
+    });
+
+    it("falla si no hay comisión activa", async () => {
+      mockEm.findOne.mockResolvedValueOnce(null);
+
+      await expect(createAssignment(assignmentData)).rejects.toBeInstanceOf(
+        ComisionActivaRequeridaError
+      );
+
+      expect(mockEm.persist).not.toHaveBeenCalled();
+      expect(mockEm.flush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -1,6 +1,7 @@
 import { getEM, deleteEntity } from "@/lib/db";
 import {
   Assignment,
+  Comision,
   IndividualAssignment,
   GrupalAssignment,
 } from "@/domain/entities";
@@ -8,20 +9,45 @@ import type { AssignmentFormData } from "@/lib/assignment-schema";
 import { slugify } from "@/lib/naming";
 import type { Paradigma } from "@/types";
 
+export class ComisionActivaRequeridaError extends Error {
+  constructor() {
+    super("Necesitás una comisión activa para crear assignments.");
+    this.name = "ComisionActivaRequeridaError";
+  }
+}
+
 export async function getAssignments(): Promise<Assignment[]> {
   const entityManager = await getEM();
-  return entityManager.find(Assignment, {}, { orderBy: { createdAt: "DESC" } });
+  return entityManager.find(
+    Assignment,
+    {},
+    { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
+  );
+}
+
+export async function getAssignmentsDeComision(
+  comisionId: string
+): Promise<Assignment[]> {
+  const entityManager = await getEM();
+  return entityManager.find(
+    Assignment,
+    { comision: { id: comisionId } },
+    { orderBy: { createdAt: "DESC" } }
+  );
 }
 
 export async function getAssignment(id: string): Promise<Assignment | null> {
   const entityManager = await getEM();
-  return entityManager.findOne(Assignment, { id });
+  return entityManager.findOne(Assignment, { id }, { populate: ["comision"] });
 }
 
 export async function createAssignment(
   data: AssignmentFormData
 ): Promise<Assignment> {
   const entityManager = await getEM();
+  const comisionActiva = await entityManager.findOne(Comision, { activa: true });
+  if (!comisionActiva) throw new ComisionActivaRequeridaError();
+
   const slug = data.slug || slugify(data.titulo);
 
   let assignment: Assignment;
@@ -39,6 +65,7 @@ export async function createAssignment(
   assignment.descripcion = data.descripcion;
   assignment.templateRepo = data.templateRepo;
   assignment.paradigma = data.paradigma as Paradigma;
+  assignment.comision = comisionActiva;
   if (data.deadline) assignment.deadline = new Date(data.deadline);
 
   entityManager.persist(assignment);

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -19,11 +19,13 @@ export type { AlumnoData } from "./AlumnoRepository";
 
 export {
   getAssignments,
+  getAssignmentsDeComision,
   getAssignment,
   createAssignment,
   updateAssignment,
   deleteAssignment,
   setInscripcionesCerradas,
+  ComisionActivaRequeridaError,
 } from "./AssignmentRepository";
 
 export {


### PR DESCRIPTION
## Summary
- Asocia los assignments nuevos a la comisión activa y falla con un mensaje de formulario cuando no existe una.
- Filtra dashboard y vistas admin por comisión activa cuando corresponde.
- Agrega cobertura del repositorio y ajusta tests de UI/actions para el nuevo comportamiento.

## Tests
- npm run test:run
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Notas de Lanzamiento

* **New Features**
  * Se agregó una nueva columna de Comisión en la tabla de assignments, mostrando el año y el estado (Activa o Histórica).
  * El dashboard ahora filtra assignments según la comisión activa del usuario.

* **Bug Fixes**
  * Se agregó validación para requerir una comisión activa al crear assignments, con mensaje de error visible cuando no existe.
  * Se muestra "Sin comisión" cuando un assignment no tiene comisión asociada.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Juancete/Pdep-Classroom/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->