### PR TITLE
Hacer idempotente la aceptación de assignments

### DIFF
--- a/migrations/Migration20260528123000_unique_entrega_logica.ts
+++ b/migrations/Migration20260528123000_unique_entrega_logica.ts
@@ -1,0 +1,62 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260528123000_unique_entrega_logica extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      update "entrega" e
+      set "alumno_id" = a."id"
+      from "alumno" a
+      where e."alumno_id" is null
+        and e."grupo_id" is null
+        and array_length(e."github_usernames", 1) = 1
+        and lower(a."github_username") = lower(e."github_usernames"[1]);
+    `);
+
+    this.addSql(`
+      do $$
+      begin
+        if exists (
+          select 1
+          from "entrega"
+          where "repo_name" is not null
+          group by "repo_name"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay repo_name duplicados.';
+        end if;
+
+        if exists (
+          select 1
+          from "entrega"
+          where "alumno_id" is not null
+          group by "assignment_id", "alumno_id"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay entregas individuales duplicadas.';
+        end if;
+
+        if exists (
+          select 1
+          from "entrega"
+          where "grupo_id" is not null
+          group by "assignment_id", "grupo_id"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay entregas grupales duplicadas.';
+        end if;
+      end $$;
+    `);
+
+    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" ("repo_name") where "repo_name" is not null;`);
+    this.addSql(`create unique index "entrega_assignment_alumno_unique_idx" on "entrega" ("assignment_id", "alumno_id") where "alumno_id" is not null;`);
+    this.addSql(`create unique index "entrega_assignment_grupo_unique_idx" on "entrega" ("assignment_id", "grupo_id") where "grupo_id" is not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "entrega_assignment_grupo_unique_idx";`);
+    this.addSql(`drop index if exists "entrega_assignment_alumno_unique_idx";`);
+    this.addSql(`drop index if exists "entrega_repo_name_unique_idx";`);
+  }
+
+}

--- a/migrations/Migration20260528123000_unique_entrega_logica.ts
+++ b/migrations/Migration20260528123000_unique_entrega_logica.ts
@@ -20,7 +20,7 @@ export class Migration20260528123000_unique_entrega_logica extends Migration {
           select 1
           from "entrega"
           where "repo_name" is not null
-          group by "repo_name"
+          group by lower("repo_name")
           having count(*) > 1
         ) then
           raise exception 'No se pueden crear índices únicos de entrega: hay repo_name duplicados.';
@@ -48,7 +48,7 @@ export class Migration20260528123000_unique_entrega_logica extends Migration {
       end $$;
     `);
 
-    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" ("repo_name") where "repo_name" is not null;`);
+    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" (lower("repo_name")) where "repo_name" is not null;`);
     this.addSql(`create unique index "entrega_assignment_alumno_unique_idx" on "entrega" ("assignment_id", "alumno_id") where "alumno_id" is not null;`);
     this.addSql(`create unique index "entrega_assignment_grupo_unique_idx" on "entrega" ("assignment_id", "grupo_id") where "grupo_id" is not null;`);
   }

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
-import {
-  IndividualAssignment,
-  GrupalAssignment,
-  Entrega,
-  type Assignment,
-} from "@/domain/entities";
+import { Entrega, GrupoNoAsignadoError } from "@/domain/entities";
 
-// ── Mocks ────────────────────────────────────────────────────
-
-const mockRequireUser = vi.fn();
-const mockCheckRateLimit = vi.fn();
-const mockGetAssignment = vi.fn();
-const mockGetEntregaDeUsuario = vi.fn();
-const mockCreateEntrega = vi.fn();
-const mockCrearEntrega = vi.fn();
-const mockRepoExists = vi.fn();
-const mockAddCollaborators = vi.fn();
-const mockGetGrupoDeAlumno = vi.fn();
+const {
+  mockRequireUser,
+  mockCheckRateLimit,
+  mockAceptarAssignment,
+  FakeAlumnoNoRegistradoError,
+  FakeAssignmentNoEncontradoError,
+} = vi.hoisted(() => ({
+  mockRequireUser: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockAceptarAssignment: vi.fn(),
+  FakeAlumnoNoRegistradoError: class AlumnoNoRegistradoError extends Error {},
+  FakeAssignmentNoEncontradoError: class AssignmentNoEncontradoError extends Error {},
+}));
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -27,24 +24,16 @@ vi.mock("@/lib/rate-limit", () => ({
   checkRateLimit: (key: string) => mockCheckRateLimit(key),
 }));
 
-vi.mock("@/lib/repositories", () => ({
-  getAssignment: (id: string) => mockGetAssignment(id),
-  getEntregaDeUsuario: (assignmentId: string, username: string) =>
-    mockGetEntregaDeUsuario(assignmentId, username),
-  createEntrega: (data: unknown) => mockCreateEntrega(data),
-  getGrupoDeAlumnoEnAssignment: (assignmentId: string, username: string) =>
-    mockGetGrupoDeAlumno(assignmentId, username),
-}));
-
-vi.mock("@/lib/github", () => ({
-  crearEntrega: (opts: unknown) => mockCrearEntrega(opts),
-  repoExists: (name: string) => mockRepoExists(name),
-  addCollaborators: (repoName: string, usernames: string[]) => mockAddCollaborators(repoName, usernames),
-}));
+vi.mock("@/lib/services/aceptarAssignment", () => {
+  return {
+    aceptarAssignment: (assignmentId: string, user: PdepUser) =>
+      mockAceptarAssignment(assignmentId, user),
+    AlumnoNoRegistradoError: FakeAlumnoNoRegistradoError,
+    AssignmentNoEncontradoError: FakeAssignmentNoEncontradoError,
+  };
+});
 
 import { POST } from "./route";
-
-// ── Helpers ──────────────────────────────────────────────────
 
 function makeUser(overrides?: Partial<PdepUser>): PdepUser {
   return {
@@ -54,23 +43,6 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
     isAdmin: false,
     ...overrides,
   };
-}
-
-type AssignmentOverrides = Partial<IndividualAssignment & GrupalAssignment>;
-
-function makeAssignment(overrides?: AssignmentOverrides): Assignment {
-  const assignment: Assignment =
-    overrides?.tipo === "grupal"
-      ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
-      : new IndividualAssignment();
-  assignment.id = "a1";
-  assignment.titulo = "Kata Funcional";
-  assignment.descripcion = "";
-  assignment.templateRepo = "kata-template";
-  assignment.paradigma = "funcional";
-  assignment.slug = "kata-funcional";
-  assignment.createdAt = new Date("2026-01-01");
-  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
@@ -89,172 +61,57 @@ function makeRequest(): Request {
   });
 }
 
-// ── Tests ────────────────────────────────────────────────────
-
 describe("POST /api/assignments/[id]/accept", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireUser.mockResolvedValue(makeUser());
     mockCheckRateLimit.mockReturnValue(true);
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregaDeUsuario.mockResolvedValue(undefined);
-    mockRepoExists.mockResolvedValue(false);
-    mockCrearEntrega.mockResolvedValue({
-      repoName: "kata-funcional-juangarcia",
-      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
-    });
-    mockCreateEntrega.mockResolvedValue(makeEntrega());
+    mockAceptarAssignment.mockResolvedValue(makeEntrega());
   });
 
-  describe("rate limiting", () => {
-    it("devuelve 429 cuando el rate limit está activo", async () => {
-      mockCheckRateLimit.mockReturnValue(false);
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(429);
-      const data = await response.json();
-      expect(data.error).toBeDefined();
-    });
-
-    it("pasa la clave correcta al rate limiter (username:assignmentId)", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCheckRateLimit).toHaveBeenCalledWith("juangarcia:a1");
-    });
-
-    it("no consulta el store si el rate limit bloquea", async () => {
-      mockCheckRateLimit.mockReturnValue(false);
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockGetAssignment).not.toHaveBeenCalled();
-    });
+  it("devuelve 429 cuando el rate limit está activo", async () => {
+    mockCheckRateLimit.mockReturnValue(false);
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(429);
+    expect(mockAceptarAssignment).not.toHaveBeenCalled();
   });
 
-  describe("autenticación", () => {
-    it("devuelve 500 si requireUser lanza (no autenticado)", async () => {
-      mockRequireUser.mockRejectedValue(new Error("redirect"));
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(500);
-    });
+  it("pasa la clave correcta al rate limiter", async () => {
+    await POST(makeRequest(), { params: { id: "a1" } });
+    expect(mockCheckRateLimit).toHaveBeenCalledWith("juangarcia:a1");
   });
 
-  describe("validaciones", () => {
-    it("devuelve 404 si el assignment no existe", async () => {
-      mockGetAssignment.mockResolvedValue(undefined);
-      const response = await POST(makeRequest(), { params: { id: "no-existe" } });
-      expect(response.status).toBe(404);
-    });
-
-    it("devuelve 409 si el usuario ya tiene entrega", async () => {
-      mockGetEntregaDeUsuario.mockResolvedValue(makeEntrega());
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(409);
-    });
-
-    it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(undefined);
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(400);
-    });
+  it("devuelve 200 con la entrega del servicio", async () => {
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.repoName).toBe("kata-funcional-juangarcia");
+    expect(mockAceptarAssignment).toHaveBeenCalledWith("a1", expect.objectContaining({
+      githubUsername: "juangarcia",
+    }));
   });
 
-  describe("creación exitosa (individual)", () => {
-    it("devuelve 200 con la entrega creada", async () => {
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-      const data = await response.json();
-      expect(data.repoName).toBe("kata-funcional-juangarcia");
-    });
-
-    it("llama a crearEntrega con los parámetros correctos", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCrearEntrega).toHaveBeenCalledWith(
-        expect.objectContaining({
-          templateRepo: "kata-template",
-          slug: "kata-funcional",
-          usernames: ["juangarcia"],
-        })
-      );
-    });
+  it("devuelve 404 si el assignment no existe", async () => {
+    mockAceptarAssignment.mockRejectedValue(new FakeAssignmentNoEncontradoError("Assignment no encontrado"));
+    const response = await POST(makeRequest(), { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
   });
 
-  describe("creación exitosa (grupal)", () => {
-    function makeGrupo(githubUsernames: string[], id = "los-lambdas") {
-      return {
-        id,
-        nombre: "Los Lambdas",
-        alumnos: { getItems: () => githubUsernames.map((username) => ({ githubUsername: username })) },
-        usernamesDeMiembros: () => githubUsernames,
-      };
-    }
-
-    it("devuelve 200 con la entrega creada para el grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(
-        makeGrupo(["juangarcia", "mariaperez"])
-      );
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-los-lambdas",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
-      });
-      mockCreateEntrega.mockResolvedValue(
-        makeEntrega({ repoName: "kata-funcional-los-lambdas" })
-      );
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-    });
-
-    it("llama a crearEntrega con los usernames del grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(
-        makeGrupo(["juangarcia", "mariaperez"])
-      );
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-los-lambdas",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
-      });
-      mockCreateEntrega.mockResolvedValue(makeEntrega());
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCrearEntrega).toHaveBeenCalledWith(
-        expect.objectContaining({
-          usernames: ["juangarcia", "mariaperez"],
-          grupoId: "los-lambdas",
-        })
-      );
-    });
-
-    it("busca el grupo por assignmentId, no por paradigma", async () => {
-      mockGetAssignment.mockResolvedValue(
-        makeAssignment({ id: "a1", tipo: "grupal" })
-      );
-      mockGetGrupoDeAlumno.mockResolvedValue(makeGrupo(["juangarcia"], "g1"));
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-grupo-x",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-grupo-x",
-      });
-      mockCreateEntrega.mockResolvedValue(makeEntrega());
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockGetGrupoDeAlumno).toHaveBeenCalledWith("a1", "juangarcia");
-    });
+  it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
+    mockAceptarAssignment.mockRejectedValue(new GrupoNoAsignadoError("a1", "juangarcia"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
   });
 
-  describe("repo ya existe", () => {
-    beforeEach(() => {
-      mockRepoExists.mockResolvedValue(true);
-      mockAddCollaborators.mockResolvedValue(undefined);
-    });
+  it("devuelve 400 si el alumno no está registrado para una entrega individual", async () => {
+    mockAceptarAssignment.mockRejectedValue(new FakeAlumnoNoRegistradoError("Completá tu registro"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
+  });
 
-    it("registra la entrega sin crear un nuevo repo si ya existe", async () => {
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-      expect(mockCrearEntrega).not.toHaveBeenCalled();
-      expect(mockCreateEntrega).toHaveBeenCalled();
-    });
-
-    it("agrega al usuario como colaborador del repo existente", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockAddCollaborators).toHaveBeenCalledWith(
-        expect.any(String),
-        ["juangarcia"]
-      );
-    });
+  it("devuelve 500 si requireUser lanza", async () => {
+    mockRequireUser.mockRejectedValue(new Error("redirect"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -91,6 +91,48 @@ describe("POST /api/assignments/[id]/accept", () => {
     }));
   });
 
+  it("mantiene idempotencia si se acepta dos veces el mismo assignment", async () => {
+    const entrega = makeEntrega();
+    mockAceptarAssignment.mockResolvedValue(entrega);
+
+    const firstResponse = await POST(makeRequest(), { params: { id: "a1" } });
+    const secondResponse = await POST(makeRequest(), { params: { id: "a1" } });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    const firstData = await firstResponse.json();
+    const secondData = await secondResponse.json();
+    expect(firstData.id).toBe(secondData.id);
+    expect(firstData.repoName).toBe(secondData.repoName);
+    expect(mockAceptarAssignment).toHaveBeenCalledTimes(2);
+  });
+
+  it("mantiene una única entrega ante aceptación concurrente por miembros del mismo grupo", async () => {
+    const entrega = makeEntrega({
+      id: "e-grupo",
+      repoName: "kata-funcional-los-lambdas",
+      githubUsernames: ["juangarcia", "marialopez"],
+    });
+    mockRequireUser
+      .mockResolvedValueOnce(makeUser({ githubUsername: "juangarcia" }))
+      .mockResolvedValueOnce(makeUser({ githubUsername: "marialopez" }));
+    mockAceptarAssignment.mockResolvedValue(entrega);
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      POST(makeRequest(), { params: { id: "a1" } }),
+      POST(makeRequest(), { params: { id: "a1" } }),
+    ]);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    const firstData = await firstResponse.json();
+    const secondData = await secondResponse.json();
+    expect(firstData.id).toBe("e-grupo");
+    expect(secondData.id).toBe("e-grupo");
+    expect(firstData.repoName).toBe("kata-funcional-los-lambdas");
+    expect(secondData.repoName).toBe("kata-funcional-los-lambdas");
+  });
+
   it("devuelve 404 si el assignment no existe", async () => {
     mockAceptarAssignment.mockRejectedValue(new FakeAssignmentNoEncontradoError("Assignment no encontrado"));
     const response = await POST(makeRequest(), { params: { id: "no-existe" } });

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { getAssignment, getEntregaDeUsuario, createEntrega, getGrupoDeAlumnoEnAssignment } from "@/lib/repositories";
-import { GrupoNoAsignadoError, type ParticipantesResueltos } from "@/domain/entities";
-import { crearEntrega, repoExists, addCollaborators } from "@/lib/github";
-import { buildRepoName } from "@/lib/naming";
+import { GrupoNoAsignadoError } from "@/domain/entities";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { internalServerError } from "@/lib/api-errors";
+import {
+  aceptarAssignment,
+  AlumnoNoRegistradoError,
+  AssignmentNoEncontradoError,
+} from "@/lib/services/aceptarAssignment";
 
 export async function POST(
   _req: Request,
@@ -21,77 +23,15 @@ export async function POST(
       );
     }
 
-    const assignment = await getAssignment(params.id);
-
-    if (!assignment) {
-      return NextResponse.json({ error: "Assignment no encontrado" }, { status: 404 });
-    }
-
-    // ── Ya tiene entrega? ────────────────────────────────────
-    const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
-    if (existente) {
-      return NextResponse.json(
-        { error: "Ya aceptaste este assignment", repoUrl: existente.repoUrl },
-        { status: 409 }
-      );
-    }
-
-    // ── Determinar quiénes van al repo ───────────────────────
-    let participantes: ParticipantesResueltos;
-    try {
-      participantes = await assignment.resolverParticipantesPara(
-        user,
-        getGrupoDeAlumnoEnAssignment
-      );
-    } catch (error) {
-      if (error instanceof GrupoNoAsignadoError) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      throw error;
-    }
-    const { usernames, grupoId } = participantes;
-
-    const templateRepo = assignment.nombreDelTemplate();
-
-    // ── Nombre del repo ──────────────────────────────────────
-    const candidateRepoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
-
-    // Verificar que no exista ya (por si otro miembro del grupo aceptó primero)
-    if (await repoExists(candidateRepoName)) {
-      // El repo fue creado por otro miembro: agregar al usuario actual como
-      // colaborador y registrar la entrega. Sin este addCollaborators el
-      // alumno quedaría sin acceso al repo que ya existe en GitHub.
-      await addCollaborators(candidateRepoName, [user.githubUsername]);
-      const org = process.env.GITHUB_ORG ?? "pdep-mn-utn";
-      const entrega = await createEntrega({
-        assignmentId: assignment.id,
-        repoName: candidateRepoName,
-        repoUrl: `https://github.com/${org}/${candidateRepoName}`,
-        githubUsernames: usernames,
-        grupoId,
-      });
-      return NextResponse.json(entrega);
-    }
-
-    // ── Crear repo y dar acceso ──────────────────────────────
-    const resultado = await crearEntrega({
-      templateRepo,
-      slug: assignment.slug,
-      usernames,
-      grupoId,
-      descripcion: `${assignment.titulo} — PdeP`,
-    });
-
-    const entrega = await createEntrega({
-      assignmentId: assignment.id,
-      repoName: resultado.repoName,
-      repoUrl: resultado.repoUrl,
-      githubUsernames: usernames,
-      grupoId,
-    });
-
+    const entrega = await aceptarAssignment(params.id, user);
     return NextResponse.json(entrega);
   } catch (error) {
+    if (error instanceof AssignmentNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof GrupoNoAsignadoError || error instanceof AlumnoNoRegistradoError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     return internalServerError(
       "POST /api/assignments/[id]/accept",
       error,

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -18,4 +18,22 @@ describe("migrations", () => {
     expect(migration).toContain('drop index if exists "comision_unica_activa_idx"');
     expect(migration).toContain("hay mas de una comision activa");
   });
+
+  it("garantiza unicidad de entregas por repo, alumno y grupo", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260528123000_unique_entrega_logica.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('create unique index "entrega_repo_name_unique_idx"');
+    expect(migration).toContain('create unique index "entrega_assignment_alumno_unique_idx"');
+    expect(migration).toContain('create unique index "entrega_assignment_grupo_unique_idx"');
+    expect(migration).toContain("hay repo_name duplicados");
+    expect(migration).toContain("hay entregas individuales duplicadas");
+    expect(migration).toContain("hay entregas grupales duplicadas");
+  });
 });

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -30,6 +30,8 @@ describe("migrations", () => {
     );
 
     expect(migration).toContain('create unique index "entrega_repo_name_unique_idx"');
+    expect(migration).toContain('on "entrega" (lower("repo_name"))');
+    expect(migration).toContain('group by lower("repo_name")');
     expect(migration).toContain('create unique index "entrega_assignment_alumno_unique_idx"');
     expect(migration).toContain('create unique index "entrega_assignment_grupo_unique_idx"');
     expect(migration).toContain("hay repo_name duplicados");

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEm = {
+  find: vi.fn(),
+  findOne: vi.fn(),
+  findOneOrFail: vi.fn(),
+  getReference: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import { Alumno, Assignment, Entrega, Grupo } from "@/domain/entities";
+import {
+  createEntrega,
+  createOrGetEntrega,
+  getEntregaLogica,
+} from "./EntregaRepository";
+
+describe("EntregaRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.find.mockResolvedValue([]);
+    mockEm.findOne.mockResolvedValue(null);
+    mockEm.findOneOrFail.mockResolvedValue({ id: "a1" });
+    mockEm.getReference.mockImplementation((Entity: unknown, id: string) => ({ Entity, id }));
+    mockEm.flush.mockResolvedValue(undefined);
+  });
+
+  it("crea una entrega individual asociando alumnoId", async () => {
+    await createEntrega({
+      assignmentId: "a1",
+      repoName: "kata-juan",
+      repoUrl: "https://github.com/org/kata-juan",
+      githubUsernames: ["juan"],
+      alumnoId: "alumno-1",
+    });
+
+    const entrega = mockEm.persist.mock.calls[0][0] as Entrega;
+    expect(mockEm.findOneOrFail).toHaveBeenCalledWith(Assignment, { id: "a1" });
+    expect(mockEm.getReference).toHaveBeenCalledWith(Alumno, "alumno-1");
+    expect(entrega.alumno).toEqual({ Entity: Alumno, id: "alumno-1" });
+    expect(entrega.grupo).toBeUndefined();
+  });
+
+  it("crea una entrega grupal asociando grupoId", async () => {
+    await createEntrega({
+      assignmentId: "a1",
+      repoName: "kata-los-lambdas",
+      repoUrl: "https://github.com/org/kata-los-lambdas",
+      githubUsernames: ["juan", "maria"],
+      grupoId: "g1",
+    });
+
+    const entrega = mockEm.persist.mock.calls[0][0] as Entrega;
+    expect(mockEm.getReference).toHaveBeenCalledWith(Grupo, "g1");
+    expect(entrega.grupo).toEqual({ Entity: Grupo, id: "g1" });
+    expect(entrega.alumno).toBeUndefined();
+  });
+
+  it("busca entrega lógica individual por assignment y alumno", async () => {
+    await getEntregaLogica({ assignmentId: "a1", alumnoId: "alumno-1" });
+
+    expect(mockEm.findOne).toHaveBeenCalledWith(
+      Entrega,
+      { assignment: { id: "a1" }, alumno: { id: "alumno-1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  });
+
+  it("busca entrega lógica grupal por assignment y grupo", async () => {
+    await getEntregaLogica({ assignmentId: "a1", grupoId: "g1" });
+
+    expect(mockEm.findOne).toHaveBeenCalledWith(
+      Entrega,
+      { assignment: { id: "a1" }, grupo: { id: "g1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  });
+
+  it("createOrGetEntrega devuelve existente por repoName sin insertar", async () => {
+    const existing = new Entrega();
+    mockEm.findOne.mockResolvedValueOnce(existing);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(existing);
+
+    expect(mockEm.persist).not.toHaveBeenCalled();
+  });
+
+  it("createOrGetEntrega reconsulta y devuelve existente ante violación única", async () => {
+    const existing = new Entrega();
+    const duplicate = new Error("duplicate key value violates unique constraint");
+    (duplicate as NodeJS.ErrnoException).code = "23505";
+
+    mockEm.findOne
+      .mockResolvedValueOnce(null) // repo lookup inicial
+      .mockResolvedValueOnce(null) // lógica lookup inicial
+      .mockResolvedValueOnce(existing); // repo lookup tras duplicate
+    mockEm.flush.mockRejectedValueOnce(duplicate);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(existing);
+  });
+});

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -83,6 +83,7 @@ describe("EntregaRepository", () => {
 
   it("createOrGetEntrega devuelve existente por repoName sin insertar", async () => {
     const existing = new Entrega();
+    existing.assignment = { id: "a1" } as Assignment;
     mockEm.findOne.mockResolvedValueOnce(existing);
 
     await expect(
@@ -98,8 +99,37 @@ describe("EntregaRepository", () => {
     expect(mockEm.persist).not.toHaveBeenCalled();
   });
 
+  it("createOrGetEntrega ignora repoName existente de otro assignment y busca por entrega lógica", async () => {
+    const repoMatch = new Entrega();
+    repoMatch.assignment = { id: "otro-assignment" } as Assignment;
+    const logicalMatch = new Entrega();
+    logicalMatch.assignment = { id: "a1" } as Assignment;
+    mockEm.findOne
+      .mockResolvedValueOnce(repoMatch)
+      .mockResolvedValueOnce(logicalMatch);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(logicalMatch);
+
+    expect(mockEm.findOne).toHaveBeenNthCalledWith(
+      2,
+      Entrega,
+      { assignment: { id: "a1" }, alumno: { id: "alumno-1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+    expect(mockEm.persist).not.toHaveBeenCalled();
+  });
+
   it("createOrGetEntrega reconsulta y devuelve existente ante violación única", async () => {
     const existing = new Entrega();
+    existing.assignment = { id: "a1" } as Assignment;
     const duplicate = new Error("duplicate key value violates unique constraint");
     (duplicate as NodeJS.ErrnoException).code = "23505";
 

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -1,5 +1,5 @@
 import { getEM } from "@/lib/db";
-import { Assignment, Grupo, Entrega } from "@/domain/entities";
+import { Alumno, Assignment, Grupo, Entrega } from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
   const entityManager = await getEM();
@@ -37,6 +37,38 @@ export async function getEntregaDeUsuario(
       )
     ) ?? null
   );
+}
+
+export async function getEntregaByRepoName(repoName: string): Promise<Entrega | null> {
+  const entityManager = await getEM();
+  return entityManager.findOne(
+    Entrega,
+    { repoName },
+    { populate: ["assignment", "grupo", "alumno"] }
+  );
+}
+
+export async function getEntregaLogica(data: {
+  assignmentId: string;
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega | null> {
+  const entityManager = await getEM();
+  if (data.grupoId) {
+    return entityManager.findOne(
+      Entrega,
+      { assignment: { id: data.assignmentId }, grupo: { id: data.grupoId } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  }
+  if (data.alumnoId) {
+    return entityManager.findOne(
+      Entrega,
+      { assignment: { id: data.assignmentId }, alumno: { id: data.alumnoId } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  }
+  return null;
 }
 
 // Devuelve el conteo de entregas por assignmentId en una sola query.
@@ -81,6 +113,7 @@ export async function createEntrega(data: {
   repoName: string;
   repoUrl: string;
   githubUsernames: string[];
+  alumnoId?: string;
   grupoId?: string;
 }): Promise<Entrega> {
   const entityManager = await getEM();
@@ -93,6 +126,10 @@ export async function createEntrega(data: {
   entrega.repoUrl = data.repoUrl;
   entrega.githubUsernames = data.githubUsernames;
 
+  if (data.alumnoId) {
+    entrega.alumno = entityManager.getReference(Alumno, data.alumnoId);
+  }
+
   if (data.grupoId) {
     entrega.grupo = entityManager.getReference(Grupo, data.grupoId);
   }
@@ -100,4 +137,50 @@ export async function createEntrega(data: {
   entityManager.persist(entrega);
   await entityManager.flush();
   return entrega;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const cause = error.cause;
+  const code =
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  return code === "23505" || /unique constraint|duplicate key/i.test(error.message);
+}
+
+async function findExistingEntrega(data: {
+  assignmentId: string;
+  repoName: string;
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega | null> {
+  return (
+    (await getEntregaByRepoName(data.repoName)) ??
+    (await getEntregaLogica({
+      assignmentId: data.assignmentId,
+      alumnoId: data.alumnoId,
+      grupoId: data.grupoId,
+    }))
+  );
+}
+
+export async function createOrGetEntrega(data: {
+  assignmentId: string;
+  repoName: string;
+  repoUrl: string;
+  githubUsernames: string[];
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega> {
+  const existing = await findExistingEntrega(data);
+  if (existing) return existing;
+
+  try {
+    return await createEntrega(data);
+  } catch (error) {
+    if (!isUniqueViolation(error)) throw error;
+    const reconciled = await findExistingEntrega(data);
+    if (reconciled) return reconciled;
+    throw error;
+  }
 }

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -154,14 +154,14 @@ async function findExistingEntrega(data: {
   alumnoId?: string;
   grupoId?: string;
 }): Promise<Entrega | null> {
-  return (
-    (await getEntregaByRepoName(data.repoName)) ??
-    (await getEntregaLogica({
-      assignmentId: data.assignmentId,
-      alumnoId: data.alumnoId,
-      grupoId: data.grupoId,
-    }))
-  );
+  const entrega = await getEntregaByRepoName(data.repoName);
+  if (entrega?.assignment?.id === data.assignmentId) return entrega;
+
+  return getEntregaLogica({
+    assignmentId: data.assignmentId,
+    alumnoId: data.alumnoId,
+    grupoId: data.grupoId,
+  });
 }
 
 export async function createOrGetEntrega(data: {

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -32,9 +32,12 @@ export {
   getEntregas,
   getEntregasDeUsuario,
   getEntregaDeUsuario,
+  getEntregaByRepoName,
+  getEntregaLogica,
   getEntregaCountsByAssignment,
   getActiveRepoCountsByAssignment,
   createEntrega,
+  createOrGetEntrega,
   clearReposDeAssignment,
 } from "./EntregaRepository";
 

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PdepUser } from "@/types";
+import {
+  Alumno,
+  Entrega,
+  GrupalAssignment,
+  IndividualAssignment,
+  type Assignment,
+} from "@/domain/entities";
+
+const mockGetAssignment = vi.fn();
+const mockGetEntregaDeUsuario = vi.fn();
+const mockGetGrupoDeAlumno = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockCreateOrGetEntrega = vi.fn();
+const mockCrearEntrega = vi.fn();
+const mockRepoExists = vi.fn();
+const mockAddCollaborators = vi.fn();
+
+vi.mock("@/lib/repositories", () => ({
+  getAssignment: (id: string) => mockGetAssignment(id),
+  getEntregaDeUsuario: (assignmentId: string, username: string) =>
+    mockGetEntregaDeUsuario(assignmentId, username),
+  getGrupoDeAlumnoEnAssignment: (assignmentId: string, username: string) =>
+    mockGetGrupoDeAlumno(assignmentId, username),
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  createOrGetEntrega: (data: unknown) => mockCreateOrGetEntrega(data),
+}));
+
+vi.mock("@/lib/github", () => ({
+  crearEntrega: (opts: unknown) => mockCrearEntrega(opts),
+  repoExists: (repoName: string) => mockRepoExists(repoName),
+  addCollaborators: (repoName: string, usernames: string[]) =>
+    mockAddCollaborators(repoName, usernames),
+}));
+
+import {
+  aceptarAssignment,
+  AlumnoNoRegistradoError,
+  AssignmentNoEncontradoError,
+} from "./aceptarAssignment";
+
+function makeUser(overrides?: Partial<PdepUser>): PdepUser {
+  return {
+    githubUsername: "juangarcia",
+    name: "Juan García",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+function makeAssignment(overrides?: Partial<IndividualAssignment & GrupalAssignment>): Assignment {
+  const assignment: Assignment =
+    overrides?.tipo === "grupal"
+      ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
+      : new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "";
+  assignment.templateRepo = "pdep-mn-utn/kata-template";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
+}
+
+function makeAlumno(overrides?: Partial<Alumno>): Alumno {
+  const alumno = new Alumno();
+  alumno.id = "alumno-1";
+  alumno.githubUsername = "juangarcia";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "García";
+  alumno.email = "juan@example.com";
+  return Object.assign(alumno, overrides);
+}
+
+function makeEntrega(overrides?: Partial<Entrega>): Entrega {
+  const entrega = new Entrega();
+  entrega.id = "e1";
+  entrega.repoName = "kata-funcional-juangarcia";
+  entrega.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-juangarcia";
+  entrega.githubUsernames = ["juangarcia"];
+  entrega.createdAt = new Date();
+  return Object.assign(entrega, overrides);
+}
+
+function makeGrupo(githubUsernames: string[], id = "los-lambdas") {
+  return {
+    id,
+    usernamesDeMiembros: () => githubUsernames,
+  };
+}
+
+describe("aceptarAssignment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAssignment.mockResolvedValue(makeAssignment());
+    mockGetEntregaDeUsuario.mockResolvedValue(null);
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockRepoExists.mockResolvedValue(false);
+    mockCrearEntrega.mockResolvedValue({
+      repoName: "kata-funcional-juangarcia",
+      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
+    });
+    mockCreateOrGetEntrega.mockResolvedValue(makeEntrega());
+  });
+
+  it("devuelve la entrega existente sin tocar GitHub", async () => {
+    const entrega = makeEntrega();
+    mockGetEntregaDeUsuario.mockResolvedValue(entrega);
+
+    await expect(aceptarAssignment("a1", makeUser())).resolves.toBe(entrega);
+
+    expect(mockRepoExists).not.toHaveBeenCalled();
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+    expect(mockCreateOrGetEntrega).not.toHaveBeenCalled();
+  });
+
+  it("falla con error de dominio si el assignment no existe", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AssignmentNoEncontradoError
+    );
+  });
+
+  it("crea repo y entrega individual con alumnoId", async () => {
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockCrearEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateRepo: "kata-template",
+        slug: "kata-funcional",
+        usernames: ["juangarcia"],
+      })
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: "a1",
+        alumnoId: "alumno-1",
+        grupoId: undefined,
+        repoName: "kata-funcional-juangarcia",
+      })
+    );
+  });
+
+  it("falla si el alumno individual no existe en DB", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AlumnoNoRegistradoError
+    );
+
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+  });
+
+  it("crea entrega grupal con grupoId y todos los miembros", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
+    mockGetGrupoDeAlumno.mockResolvedValue(makeGrupo(["juangarcia", "mariaperez"]));
+    mockCrearEntrega.mockResolvedValue({
+      repoName: "kata-funcional-los-lambdas",
+      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
+    });
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: "a1",
+        alumnoId: undefined,
+        grupoId: "los-lambdas",
+        githubUsernames: ["juangarcia", "mariaperez"],
+      })
+    );
+  });
+
+  it("reconcilia cuando el repo ya existe en GitHub", async () => {
+    mockRepoExists.mockResolvedValue(true);
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+    expect(mockAddCollaborators).toHaveBeenCalledWith(
+      "kata-funcional-juangarcia",
+      ["juangarcia"]
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoName: "kata-funcional-juangarcia",
+        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
+      })
+    );
+  });
+
+  it("si crearEntrega falla pero el repo apareció, reconcilia la entrega local", async () => {
+    mockRepoExists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockCrearEntrega.mockRejectedValue(new Error("name already exists"));
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockAddCollaborators).toHaveBeenCalledWith(
+      "kata-funcional-juangarcia",
+      ["juangarcia"]
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalled();
+  });
+
+  it("propaga el error de GitHub si el repo no existe después del fallo", async () => {
+    mockRepoExists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    mockCrearEntrega.mockRejectedValue(new Error("GitHub caído"));
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toThrow("GitHub caído");
+  });
+});

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -1,0 +1,81 @@
+import { Entrega, type ParticipantesResueltos } from "@/domain/entities";
+import type { PdepUser } from "@/types";
+import {
+  getAlumnoByGithub,
+  getAssignment,
+  getEntregaDeUsuario,
+  getGrupoDeAlumnoEnAssignment,
+  createOrGetEntrega,
+} from "@/lib/repositories";
+import { addCollaborators, crearEntrega, repoExists } from "@/lib/github";
+import { buildRepoName } from "@/lib/naming";
+
+export class AssignmentNoEncontradoError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Assignment no encontrado");
+    this.name = "AssignmentNoEncontradoError";
+  }
+}
+
+export class AlumnoNoRegistradoError extends Error {
+  constructor(public readonly githubUsername: string) {
+    super("Completá tu registro antes de aceptar este assignment.");
+    this.name = "AlumnoNoRegistradoError";
+  }
+}
+
+function repoUrlFor(repoName: string): string {
+  const org = process.env.GITHUB_ORG ?? "pdep-mn-utn";
+  return `https://github.com/${org}/${repoName}`;
+}
+
+export async function aceptarAssignment(
+  assignmentId: string,
+  user: PdepUser
+): Promise<Entrega> {
+  const assignment = await getAssignment(assignmentId);
+  if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
+
+  const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
+  if (existente) return existente;
+
+  const participantes: ParticipantesResueltos = await assignment.resolverParticipantesPara(
+    user,
+    getGrupoDeAlumnoEnAssignment
+  );
+
+  const { usernames, grupoId } = participantes;
+  const alumno = grupoId ? null : await getAlumnoByGithub(user.githubUsername);
+  if (!grupoId && !alumno) throw new AlumnoNoRegistradoError(user.githubUsername);
+
+  const repoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
+  const createLocalEntrega = (createdRepoName: string, repoUrl: string) =>
+    createOrGetEntrega({
+      assignmentId: assignment.id,
+      repoName: createdRepoName,
+      repoUrl,
+      githubUsernames: usernames,
+      alumnoId: alumno?.id,
+      grupoId,
+    });
+
+  if (await repoExists(repoName)) {
+    await addCollaborators(repoName, usernames);
+    return createLocalEntrega(repoName, repoUrlFor(repoName));
+  }
+
+  try {
+    const resultado = await crearEntrega({
+      templateRepo: assignment.nombreDelTemplate(),
+      slug: assignment.slug,
+      usernames,
+      grupoId,
+      descripcion: `${assignment.titulo} — PdeP`,
+    });
+    return createLocalEntrega(resultado.repoName, resultado.repoUrl);
+  } catch (error) {
+    if (!(await repoExists(repoName))) throw error;
+    await addCollaborators(repoName, usernames);
+    return createLocalEntrega(repoName, repoUrlFor(repoName));
+  }
+}


### PR DESCRIPTION
## Summary
- Extrae la aceptación de assignments a un servicio de aplicación idempotente.
- Reusa entregas existentes y reconcilia repos ya creados en GitHub sin duplicar registros locales.
- Agrega índices únicos parciales para entrega por repo, alumno y grupo, con tests de repositorio, servicio, route y migración.

Closes #30

## Tests
- npm run test:run
- git diff --check

## Known validation
- npx tsc --noEmit falla por errores preexistentes en tests no tocados: src/app/admin/alumnos/page.test.tsx, src/app/assignments/[id]/grupo/grupo-selector.test.tsx y src/domain/entities/Assignment.test.ts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Mejorado el manejo de errores al aceptar asignaciones con validaciones más robustas.
  * Prevención de entregas duplicadas mediante índices de integridad en la base de datos.

* **Tests**
  * Refactorización y simplificación de pruebas para el flujo de aceptación de asignaciones.
  * Cobertura ampliada de casos de error y escenarios de entrega.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Juancete/Pdep-Classroom/pull/38?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->