### PR TITLE
Unificar hooks post-confirmación de alumno

### DIFF
--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -6,12 +6,11 @@ const mockRequireAdmin = vi.fn();
 const mockCreateComision = vi.fn();
 const mockUpdateComision = vi.fn();
 const mockGetComision = vi.fn();
-const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
-const mockGetAlumnos = vi.fn();
 const mockGetAsignacionesGrupos = vi.fn();
 const mockGetAlumnosByComision = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
+const mockImportarAlumnosDeComision = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -42,7 +41,6 @@ vi.mock("@/lib/repositories", () => ({
   createComision: (...args: unknown[]) => mockCreateComision(...args),
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
-  upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
   getAlumnosByComision: (...args: unknown[]) =>
     mockGetAlumnosByComision(...args),
   LegajoConflictError: FakeLegajoConflictError,
@@ -54,8 +52,24 @@ vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
     mockIntentarSincronizarGrupos(...args),
 }));
 
+const { FakeLecturaPlanillaAlumnosError } = vi.hoisted(() => {
+  class FakeLecturaPlanillaAlumnosError extends Error {
+    constructor(cause: unknown) {
+      const message = cause instanceof Error ? cause.message : "Error desconocido";
+      super(`No se pudo leer la planilla: ${message}`);
+      this.name = "LecturaPlanillaAlumnosError";
+    }
+  }
+  return { FakeLecturaPlanillaAlumnosError };
+});
+
+vi.mock("@/lib/services/importarAlumnosDeComision", () => ({
+  importarAlumnosDeComision: (...args: unknown[]) =>
+    mockImportarAlumnosDeComision(...args),
+  LecturaPlanillaAlumnosError: FakeLecturaPlanillaAlumnosError,
+}));
+
 vi.mock("@/lib/sheets", () => ({
-  getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
   getAsignacionesGrupos: (...args: unknown[]) => mockGetAsignacionesGrupos(...args),
 }));
 
@@ -258,8 +272,10 @@ describe("sincronizarAlumnos", () => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetComision.mockResolvedValue(comisionMock);
-    mockGetAlumnos.mockResolvedValue([]);
-    mockUpsertAlumnos.mockResolvedValue(0);
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 0,
+      conErrorDeGrupo: 0,
+    });
   });
 
   it("siempre llama a requireAdmin", async () => {
@@ -271,11 +287,13 @@ describe("sincronizarAlumnos", () => {
     mockGetComision.mockResolvedValue(null);
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
     expect(result).toEqual({ status: "error", message: "Comisión no encontrada" });
-    expect(mockGetAlumnos).not.toHaveBeenCalled();
+    expect(mockImportarAlumnosDeComision).not.toHaveBeenCalled();
   });
 
   it("retorna error si no se puede leer la planilla", async () => {
-    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+    mockImportarAlumnosDeComision.mockRejectedValue(
+      new FakeLecturaPlanillaAlumnosError(new Error("acceso denegado"))
+    );
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
     expect(result).toEqual({
       status: "error",
@@ -283,41 +301,38 @@ describe("sincronizarAlumnos", () => {
     });
   });
 
-  it("sincroniza correctamente y retorna el conteo", async () => {
-    const alumnos = [
-      { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" },
-      { legajo: "222", nombre: "Beto", apellido: "Ruiz", githubUsername: "beto", email: "b@b.com" },
-    ];
-    mockGetAlumnos.mockResolvedValue(alumnos);
-    mockUpsertAlumnos.mockResolvedValue(2);
+  it("sincroniza correctamente y retorna el conteo con conErrorDeGrupo:0", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 2,
+      conErrorDeGrupo: 0,
+    });
 
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
 
-    expect(result).toEqual({ status: "ok", sincronizados: 2 });
-    expect(mockUpsertAlumnos).toHaveBeenCalledOnce();
+    expect(result).toEqual({ status: "ok", sincronizados: 2, conErrorDeGrupo: 0 });
+    expect(mockImportarAlumnosDeComision).toHaveBeenCalledWith(comisionMock);
   });
 
-  it("llama a upsertAlumnos con la comisión incluida en cada alumno", async () => {
-    const alumno = { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" };
-    mockGetAlumnos.mockResolvedValue([alumno]);
-    mockUpsertAlumnos.mockResolvedValue(1);
+  it("delega la importación al servicio de aplicación", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 1,
+      conErrorDeGrupo: 0,
+    });
 
     await sincronizarAlumnos({ status: "idle" }, makeSync());
 
-    expect(mockUpsertAlumnos).toHaveBeenCalledWith([{ ...alumno, comision: comisionMock }]);
+    expect(mockImportarAlumnosDeComision).toHaveBeenCalledWith(comisionMock);
   });
 
   it("retorna 0 sincronizados si la planilla está vacía", async () => {
-    mockGetAlumnos.mockResolvedValue([]);
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
-    expect(result).toEqual({ status: "ok", sincronizados: 0 });
+    expect(result).toEqual({ status: "ok", sincronizados: 0, conErrorDeGrupo: 0 });
   });
 
-  it("retorna error controlado si upsertAlumnos lanza LegajoConflictError", async () => {
-    mockGetAlumnos.mockResolvedValue([
-      { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" },
-    ]);
-    mockUpsertAlumnos.mockRejectedValue(new FakeLegajoConflictError("111", "otra-persona"));
+  it("retorna error controlado si el servicio propaga LegajoConflictError", async () => {
+    mockImportarAlumnosDeComision.mockRejectedValue(
+      new FakeLegajoConflictError("111", "otra-persona")
+    );
 
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
 
@@ -325,6 +340,17 @@ describe("sincronizarAlumnos", () => {
       status: "error",
       message: "El legajo 111 ya está registrado con el usuario @otra-persona. Verificá que sea el tuyo.",
     });
+  });
+
+  it("cuenta conErrorDeGrupo cuando algún hook de Google Groups falla", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 3,
+      conErrorDeGrupo: 1,
+    });
+
+    const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
+
+    expect(result).toEqual({ status: "ok", sincronizados: 3, conErrorDeGrupo: 1 });
   });
 });
 

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -5,13 +5,16 @@ import {
   createComision,
   updateComision,
   getComision,
-  upsertAlumnos,
   LegajoConflictError,
   getAlumnosByComision,
   ComisionActivaDuplicadaError,
 } from "@/lib/repositories";
-import { getAlumnos, getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
+import { getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
+import {
+  importarAlumnosDeComision,
+  LecturaPlanillaAlumnosError,
+} from "@/lib/services/importarAlumnosDeComision";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
@@ -205,7 +208,7 @@ export async function actualizarComision(
 
 export type SyncState =
   | { status: "idle" }
-  | { status: "ok"; sincronizados: number }
+  | { status: "ok"; sincronizados: number; conErrorDeGrupo: number }
   | { status: "error"; message: string };
 
 export async function sincronizarAlumnos(
@@ -218,25 +221,19 @@ export async function sincronizarAlumnos(
   const comision = await getComision(id);
   if (!comision) return { status: "error", message: "Comisión no encontrada" };
 
-  let alumnos;
   try {
-    alumnos = await getAlumnos(comision.spreadsheetId, comision.columnConfig);
+    const { sincronizados, conErrorDeGrupo } = await importarAlumnosDeComision(comision);
+    revalidatePath("/admin/comisiones");
+    return { status: "ok", sincronizados, conErrorDeGrupo };
   } catch (error) {
-    return { status: "error", message: `No se pudo leer la planilla: ${(error as Error).message}` };
-  }
-
-  let sincronizados: number;
-  try {
-    sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
-  } catch (error) {
+    if (error instanceof LecturaPlanillaAlumnosError) {
+      return { status: "error", message: error.message };
+    }
     if (error instanceof LegajoConflictError) {
       return { status: "error", message: error.message };
     }
     throw error;
   }
-
-  revalidatePath("/admin/comisiones");
-  return { status: "ok", sincronizados };
 }
 
 export type SyncGruposState =

--- a/src/app/admin/comisiones/sync-button.tsx
+++ b/src/app/admin/comisiones/sync-button.tsx
@@ -29,6 +29,9 @@ export function SyncButton({ comisionId }: { comisionId: string }) {
       {state.status === "ok" && (
         <span className="text-xs text-green-600 font-medium">
           {state.sincronizados} sincronizados
+          {state.conErrorDeGrupo > 0 && (
+            <span className="text-amber-600"> · {state.conErrorDeGrupo} sin grupo</span>
+          )}
         </span>
       )}
       {state.status === "error" && (

--- a/src/app/api/assignments/[id]/route.ts
+++ b/src/app/api/assignments/[id]/route.ts
@@ -31,7 +31,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Assignment no encontrado" }, { status: 404 });
   }
 
-  const body = await req.json();
+  const body = await req.json().catch(() => null);
   const parsed = AssignmentBaseSchema.partial().safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -3,52 +3,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockRequireUser = vi.fn();
-const mockUpsertarAlumnoEnSheets = vi.fn();
-const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
-const mockMarcarRegistroConfirmado = vi.fn();
-const mockIntentarSincronizarGrupos = vi.fn();
+const mockConfirmarYProcesarAlumno = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
-  return {
-    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-    validateRegistro: actual.validateRegistro,
-  };
-});
-
-const { FakeLegajoConflictError } = vi.hoisted(() => {
-  class FakeLegajoConflictError extends Error {
-    constructor(
-      public readonly legajo: string,
-      public readonly otroGithubUsername: string
-    ) {
-      super(
-        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
-      );
-      this.name = "LegajoConflictError";
-    }
-  }
-  return { FakeLegajoConflictError };
-});
-
-vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
-  marcarRegistroConfirmado: (...args: unknown[]) =>
-    mockMarcarRegistroConfirmado(...args),
-  LegajoConflictError: FakeLegajoConflictError,
-}));
-
-// El handler llama al wrapper `intentarSincronizarGrupos`, que encapsula
-// log + flag persistente + retorno booleano para el handler.
-vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
-  intentarSincronizarGrupos: (...args: unknown[]) =>
-    mockIntentarSincronizarGrupos(...args),
+vi.mock("@/lib/services/alumnoRegistro", () => ({
+  confirmarYProcesarAlumno: (...args: unknown[]) =>
+    mockConfirmarYProcesarAlumno(...args),
 }));
 
 import { PATCH } from "./route";
@@ -81,120 +44,106 @@ describe("PATCH /api/perfil", () => {
       image: "",
       isAdmin: false,
     });
-    mockGetComisionActiva.mockResolvedValue({
-      id: "c1",
-      spreadsheetId: "sheet-xyz",
-      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "already_member", gruposSync: "ok" },
     });
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
-    mockUpsertAlumno.mockResolvedValue(undefined);
-    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
-    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
-  it("actualiza Sheets y DB en un mismo request", async () => {
+  it("devuelve 200 con hooks en body cuando todo funciona", async () => {
     const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
     expect(response.status).toBe(200);
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledTimes(1);
-    expect(mockUpsertAlumno).toHaveBeenCalledTimes(1);
+    expect(json).toEqual({ ok: true, groupSubscription: "already_member" });
+  });
+
+  it("no incluye gruposSync en el body cuando el hook no falla", async () => {
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(json.gruposSync).toBeUndefined();
+  });
+
+  it("incluye gruposSync:'error' cuando el hook de sync falla", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "already_member", gruposSync: "error" },
+    });
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.gruposSync).toBe("error");
   });
 
   it("usa el githubUsername del usuario autenticado (no del body)", async () => {
     await PATCH(makeRequest({ ...validBody, githubUsername: "attacker" }));
-    const [inputPasado] = mockUpsertAlumno.mock.calls[0];
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
-  it("marca registroConfirmadoEn recién después de que Sheets confirmó", async () => {
-    const comision = await mockGetComisionActiva();
-    await PATCH(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
-    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
-    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
-  });
-
-  it("no marca registroConfirmadoEn si Sheets falla", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({
-      ok: false,
-      error: "sheets error",
+  it("la respuesta incluye groupSubscription (perfil también suscribe al grupo)", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added" },
     });
-    await PATCH(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
-  });
-
-  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
     const response = await PATCH(makeRequest(validBody));
-    expect(response.status).toBe(400);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    const json = await response.json();
+    expect(json.groupSubscription).toBe("added");
   });
 
-  it("devuelve 400 con field=legajo si el upsert en DB detecta conflicto de legajo", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con el error del servicio cuando ok:false", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El email es inválido",
+    });
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("El email es inválido");
+    expect(json.field).toBeUndefined();
+  });
+
+  it("devuelve 400 con field cuando el servicio devuelve field", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El legajo ya está registrado con otro usuario",
+      field: "legajo",
+    });
     const response = await PATCH(makeRequest(validBody));
     const json = await response.json();
     expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
-    expect(json.error).toContain("otro-alumno");
   });
 
-  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const response = await PATCH(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(response.status).toBe(400);
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-  });
-
-  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
-    mockGetComisionActiva.mockResolvedValue(null);
+  it("devuelve 409 cuando el servicio devuelve status 409", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "No hay comisión activa",
+    });
     const response = await PATCH(makeRequest(validBody));
     expect(response.status).toBe(409);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
-    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await PATCH(makeRequest(validBody));
     expect(response.status).toBe(500);
   });
 
-  describe("sincronización de grupos desde planilla", () => {
-    it("llama a intentarSincronizarGrupos con el github de la sesión y la comisión activa", async () => {
-      const comision = await mockGetComisionActiva();
-      await PATCH(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
-        "juangarcia",
-        comision
-      );
-    });
-
-    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const response = await PATCH(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBeUndefined();
-    });
-
-    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
-      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
-
-      const response = await PATCH(makeRequest(validBody));
-      const json = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBe("error");
-      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
-    });
-
-    it("no intenta sincronizar si la confirmación del perfil falla antes", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-      await PATCH(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
-    });
+  it("devuelve 400 si el body no es un objeto", async () => {
+    const response = await PATCH(
+      new Request("http://localhost/api/perfil", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify("cadena"),
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
-import { internalServerError } from "@/lib/api-errors";
+import { internalServerError, parseJsonObjectBody } from "@/lib/api-errors";
 import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
@@ -9,13 +9,8 @@ type PerfilInput = Omit<RegistroInput, "githubUsername">;
 export async function PATCH(req: Request) {
   try {
     const user = await requireUser();
-    const body = await req.json();
-    if (typeof body !== "object" || body === null || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
-        { status: 400 }
-      );
-    }
+    const body = await parseJsonObjectBody(req);
+    if (body instanceof NextResponse) return body;
 
     const resultado = await confirmarYProcesarAlumno({
       ...(body as PerfilInput),

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { internalServerError } from "@/lib/api-errors";
-import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
-import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
+import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -18,7 +17,7 @@ export async function PATCH(req: Request) {
       );
     }
 
-    const resultado = await confirmarDatosAlumno({
+    const resultado = await confirmarYProcesarAlumno({
       ...(body as PerfilInput),
       githubUsername: user.githubUsername,
     });
@@ -31,19 +30,10 @@ export async function PATCH(req: Request) {
       );
     }
 
-    // Los datos del alumno ya se actualizaron. Si el sync falla, el wrapper
-    // marca el flag en DB para disparar el retry automático en /perfil —
-    // degradamos la respuesta a `gruposSync: "error"` para el warning inmediato.
-    let gruposSyncFallida = false;
-    try {
-      await intentarSincronizarGrupos(user.githubUsername, resultado.comision);
-    } catch {
-      gruposSyncFallida = true;
-    }
-
     return NextResponse.json({
       ok: true,
-      ...(gruposSyncFallida && { gruposSync: "error" }),
+      groupSubscription: resultado.hooks.groupSubscription,
+      ...(resultado.hooks.gruposSync === "error" && { gruposSync: "error" }),
     });
   } catch (error) {
     return internalServerError("PATCH /api/perfil", error);

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -3,58 +3,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockRequireUser = vi.fn();
-const mockUpsertarAlumnoEnSheets = vi.fn();
-const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
-const mockMarcarRegistroConfirmado = vi.fn();
-const mockAgregarMiembroAGrupo = vi.fn();
-const mockIntentarSincronizarGrupos = vi.fn();
+const mockConfirmarYProcesarAlumno = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
-  return {
-    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-    validateRegistro: actual.validateRegistro,
-  };
-});
-
-const { FakeLegajoConflictError } = vi.hoisted(() => {
-  class FakeLegajoConflictError extends Error {
-    constructor(
-      public readonly legajo: string,
-      public readonly otroGithubUsername: string
-    ) {
-      super(
-        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
-      );
-      this.name = "LegajoConflictError";
-    }
-  }
-  return { FakeLegajoConflictError };
-});
-
-vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
-  marcarRegistroConfirmado: (...args: unknown[]) =>
-    mockMarcarRegistroConfirmado(...args),
-  LegajoConflictError: FakeLegajoConflictError,
-}));
-
-vi.mock("@/lib/googleGroups", () => ({
-  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
-}));
-
-// El handler llama al wrapper `intentarSincronizarGrupos`, que es quien se
-// encarga del logging y de persistir el flag. Si throwea, el handler lo
-// captura y degrada la respuesta a `gruposSync: "error"`.
-vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
-  intentarSincronizarGrupos: (...args: unknown[]) =>
-    mockIntentarSincronizarGrupos(...args),
+vi.mock("@/lib/services/alumnoRegistro", () => ({
+  confirmarYProcesarAlumno: (...args: unknown[]) =>
+    mockConfirmarYProcesarAlumno(...args),
 }));
 
 import { POST } from "./route";
@@ -74,7 +31,7 @@ const validBody = {
   apellido: "García",
   nombre: "Juan",
   email: "juan@gmail.com",
-  githubUsername: "juangarcia", // debe coincidir con el user autenticado del mock
+  githubUsername: "juangarcia",
 };
 
 // ── Tests ────────────────────────────────────────────────────
@@ -88,22 +45,47 @@ describe("POST /api/registro", () => {
       image: "",
       isAdmin: false,
     });
-    mockGetComisionActiva.mockResolvedValue({
-      id: "c1",
-      spreadsheetId: "sheet-xyz",
-      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added", gruposSync: "ok" },
     });
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
-    mockUpsertAlumno.mockResolvedValue(undefined);
-    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("devuelve 200 con hooks en body cuando todo funciona", async () => {
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ ok: true, groupSubscription: "added" });
+  });
+
+  it("no incluye gruposSync en el body cuando el hook no falla", async () => {
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(json.gruposSync).toBeUndefined();
+  });
+
+  it("incluye gruposSync:'error' cuando el hook de sync falla", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added", gruposSync: "error" },
+    });
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.gruposSync).toBe("error");
+  });
+
+  it("pasa el email del body como email en el contexto al servicio", async () => {
+    await POST(makeRequest(validBody));
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
+    expect(inputPasado.email).toBe("juan@gmail.com");
   });
 
   it("usa el githubUsername del usuario autenticado cuando coincide con el body", async () => {
-    const response = await POST(makeRequest(validBody));
-    expect(response.status).toBe(200);
-    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    await POST(makeRequest(validBody));
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
@@ -114,214 +96,92 @@ describe("POST /api/registro", () => {
     expect(json.field).toBe("githubUsername");
     expect(json.error).toContain("juangarcia");
     expect(json.error).toContain("attacker");
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
   });
 
   it("compara githubUsername case-insensitive (no rechaza JuanGarcia vs juangarcia)", async () => {
     const response = await POST(makeRequest({ ...validBody, githubUsername: "JuanGarcia" }));
     expect(response.status).toBe(200);
-    const [inputPasado] = mockUpsertAlumno.mock.calls[0];
-    expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
-  it("llama a upsertarAlumnoEnSheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
-      expect.any(Object),
-      "sheet-xyz",
-      comision.columnConfig
-    );
-  });
-
-  it("llama a upsertAlumno con comision pero sin registroConfirmadoEn (se marca recién después de Sheets)", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({
-        legajo: "12345",
-        githubUsername: "juangarcia",
-        email: "juan@gmail.com",
-        comision,
-      })
-    );
-    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
-    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
-  });
-
-  it("marca registroConfirmadoEn después de que Sheets confirmó la escritura", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
-    const ordenLlamadas = [
-      mockUpsertarAlumnoEnSheets.mock.invocationCallOrder[0],
-      mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
-    ];
-    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
-  });
-
-  it("no marca registroConfirmadoEn si Sheets falla (evita commit parcial)", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-    await POST(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
-  });
-
-  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con el error del servicio cuando ok:false", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El email es inválido",
+    });
     const response = await POST(makeRequest(validBody));
+    const json = await response.json();
     expect(response.status).toBe(400);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(json.error).toBe("El email es inválido");
+    expect(json.field).toBeUndefined();
   });
 
-  it("devuelve 400 con field=legajo si el upsert en DB detecta que el legajo pertenece a otro github", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con field cuando el servicio devuelve field", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El legajo ya está registrado con otro usuario",
+      field: "legajo",
+    });
     const response = await POST(makeRequest(validBody));
     const json = await response.json();
     expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
-    expect(json.error).toContain("otro-alumno");
   });
 
-  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const response = await POST(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(response.status).toBe(400);
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-  });
-
-  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
-    mockGetComisionActiva.mockResolvedValue(null);
+  it("devuelve 409 cuando el servicio devuelve status 409", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "No hay comisión activa",
+    });
     const response = await POST(makeRequest(validBody));
     expect(response.status).toBe(409);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
-    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await POST(makeRequest(validBody));
     expect(response.status).toBe(500);
     const json = await response.json();
-    // El mensaje del error interno no debe filtrarse al cliente.
     expect(json.error).toBe("Error interno del servidor");
     expect(json.error).not.toContain("boom");
   });
 
-  // ── Suscripción al Google Group ────────────────────────────
-
   describe("suscripción al Google Group", () => {
-    it("llama a agregarMiembroAGrupo con el email del alumno tras un registro exitoso", async () => {
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("juan@gmail.com");
-    });
-
-    it("devuelve groupSubscription: 'added' en el body cuando la suscripción funciona", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    it("devuelve groupSubscription:'added'", async () => {
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json).toEqual({ ok: true, groupSubscription: "added" });
+      expect(json.groupSubscription).toBe("added");
     });
 
-    it("devuelve groupSubscription: 'already_member' cuando el alumno ya estaba en el grupo", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
+    it("devuelve groupSubscription:'already_member'", async () => {
+      mockConfirmarYProcesarAlumno.mockResolvedValue({
+        ok: true,
+        comision: { id: "c1" },
+        hooks: { groupSubscription: "already_member" },
+      });
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
-      expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("already_member");
     });
 
-    it("devuelve groupSubscription: 'skipped' cuando la feature está desactivada", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.groupSubscription).toBe("skipped");
-    });
-
-    it("no rompe el registro si la suscripción falla (responde 200 con status 'error')", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({
-        status: "error",
-        error: "Sin permisos",
+    it("devuelve groupSubscription:'error' sin romper el registro", async () => {
+      mockConfirmarYProcesarAlumno.mockResolvedValue({
+        ok: true,
+        comision: { id: "c1" },
+        hooks: { groupSubscription: "error" },
       });
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
       expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("error");
-      // El alta en DB ya ocurrió antes de intentar la suscripción
-      expect(mockUpsertAlumno).toHaveBeenCalledOnce();
     });
 
-    it("enmascara el email en el log de error para no exponer PII", async () => {
-      const { logger } = await import("@/lib/logger");
-      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-      mockAgregarMiembroAGrupo.mockResolvedValue({
-        status: "error",
-        error: "Sin permisos",
-      });
-      await POST(makeRequest(validBody));
-      const loggedPayload = JSON.stringify(errorSpy.mock.calls);
-      // El email completo no debe aparecer, pero sí el dominio y un
-      // identificador útil para el admin (githubUsername).
-      expect(loggedPayload).not.toContain("juan@gmail.com");
-      expect(loggedPayload).toContain("@gmail.com");
-      expect(loggedPayload).toContain("juangarcia");
-      errorSpy.mockRestore();
-    });
-
-    it("no intenta suscribir si la escritura en Sheets falla", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
-    });
-
-    it("no intenta suscribir si no hay comisión activa", async () => {
-      mockGetComisionActiva.mockResolvedValue(null);
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
-    });
-  });
-
-  // ── Sincronización de grupos desde planilla ────────────────
-
-  describe("sincronización de grupos desde planilla", () => {
-    it("llama a intentarSincronizarGrupos con el github y la comisión activa tras un registro exitoso", async () => {
-      const comision = await mockGetComisionActiva();
-      await POST(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
-        "juangarcia",
-        comision
-      );
-    });
-
-    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBeUndefined();
-    });
-
-    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
-      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
-
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBe("error");
-      // El alta no se deshace por un fallo en el hook accesorio
-      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
-    });
-
-    it("no intenta sincronizar si el registro no se confirmó (ej. Sheets falló)", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-      await POST(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    it("no llama al servicio si la validación github↔sesión falla antes", async () => {
+      await POST(makeRequest({ ...validBody, githubUsername: "attacker" }));
+      expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -140,6 +140,18 @@ describe("POST /api/registro", () => {
     expect(response.status).toBe(409);
   });
 
+  it("devuelve 400 si el body no es un objeto", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/registro", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify("cadena"),
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
+  });
+
   it("devuelve 500 si algo tira un error inesperado", async () => {
     mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await POST(makeRequest(validBody));

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -9,7 +9,13 @@ import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 export async function POST(req: Request) {
   try {
     const user = await requireUser();
-    const body = (await req.json()) as RegistroInput;
+    const body = await req.json();
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
+        { status: 400 }
+      );
+    }
 
     // Si el form envió un githubUsername distinto al de la sesión, devolvemos
     // error con `field` para que el form lo pinte inline y pueda ofrecer el
@@ -33,7 +39,7 @@ export async function POST(req: Request) {
     }
     body.githubUsername = user.githubUsername;
 
-    const resultado = await confirmarYProcesarAlumno(body);
+    const resultado = await confirmarYProcesarAlumno(body as RegistroInput);
     if (!resultado.ok) {
       return NextResponse.json(
         resultado.field

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -3,25 +3,8 @@ import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { Alumno } from "@/domain/entities";
 import { usernameCanonicoDe } from "@/types";
-import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 import { internalServerError } from "@/lib/api-errors";
-import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
-import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
-import { logger } from "@/lib/logger";
-
-// Enmascara la parte local del email para no escupir PII a los logs,
-// preservando dominio y primeras 2 letras para que un admin pueda
-// reconocer al alumno (combinado con el githubUsername del log).
-function maskEmail(correo: string): string {
-  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
-}
-
-// Enmascara cualquier email embebido en un texto libre (p. ej. el
-// `message` de un error de googleapis, que suele citar el email del
-// miembro que se intentó agregar).
-function maskEmailsEnTexto(texto: string): string {
-  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
-}
+import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 export async function POST(req: Request) {
   try {
@@ -50,7 +33,7 @@ export async function POST(req: Request) {
     }
     body.githubUsername = user.githubUsername;
 
-    const resultado = await confirmarDatosAlumno(body);
+    const resultado = await confirmarYProcesarAlumno(body);
     if (!resultado.ok) {
       return NextResponse.json(
         resultado.field
@@ -60,36 +43,10 @@ export async function POST(req: Request) {
       );
     }
 
-    // Hooks accesorios: el alta ya está persistida. Cada uno puede fallar sin
-    // abortar el registro; la respuesta incluye un status por hook para que el
-    // form muestre el warning correspondiente.
-    const groupSubscription = await agregarMiembroAGrupo(body.email);
-    if (groupSubscription.status === "error") {
-      logger.error(
-        {
-          githubUsername: body.githubUsername,
-          maskedEmail: maskEmail(body.email),
-          err: maskEmailsEnTexto(groupSubscription.error),
-        },
-        "Error al suscribir al Google Group"
-      );
-    }
-
-    // Hook accesorio: el alta ya está persistida. Si el sync falla, el wrapper
-    // marca el flag en DB para disparar el retry automático en /perfil — solo
-    // degradamos la respuesta a `gruposSync: "error"` para que el form muestre
-    // el warning inmediato.
-    let gruposSyncFallida = false;
-    try {
-      await intentarSincronizarGrupos(body.githubUsername, resultado.comision);
-    } catch {
-      gruposSyncFallida = true;
-    }
-
     return NextResponse.json({
       ok: true,
-      groupSubscription: groupSubscription.status,
-      ...(gruposSyncFallida && { gruposSync: "error" }),
+      groupSubscription: resultado.hooks.groupSubscription,
+      ...(resultado.hooks.gruposSync === "error" && { gruposSync: "error" }),
     });
   } catch (error) {
     return internalServerError("POST /api/registro", error);

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -3,19 +3,14 @@ import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { Alumno } from "@/domain/entities";
 import { usernameCanonicoDe } from "@/types";
-import { internalServerError } from "@/lib/api-errors";
+import { internalServerError, parseJsonObjectBody } from "@/lib/api-errors";
 import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 export async function POST(req: Request) {
   try {
     const user = await requireUser();
-    const body = await req.json();
-    if (typeof body !== "object" || body === null || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
-        { status: 400 }
-      );
-    }
+    const body = await parseJsonObjectBody(req);
+    if (body instanceof NextResponse) return body;
 
     // Si el form envió un githubUsername distinto al de la sesión, devolvemos
     // error con `field` para que el form lo pinte inline y pueda ofrecer el

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Alumno } from "./Alumno";
+import { Alumno, validateRegistro } from "./Alumno";
 import type { Comision } from "./Comision";
 
 function nuevoAlumno(overrides: Partial<Alumno> = {}): Alumno {
@@ -62,6 +62,76 @@ describe("Alumno.usernameCanonico", () => {
   });
 });
 
+describe("Alumno.actualizarDatos", () => {
+  it("trimmea y normaliza los datos del alumno", () => {
+    const alumno = new Alumno();
+    const comision = fakeComision("c1");
+
+    alumno.actualizarDatos({
+      legajo: " 12345 ",
+      nombre: " Ana ",
+      apellido: " García ",
+      githubUsername: " @AnaGarcia ",
+      email: " ANA@Example.COM ",
+      comision,
+    });
+
+    expect(alumno).toMatchObject({
+      legajo: "12345",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "anagarcia",
+      email: "ana@example.com",
+      comision,
+    });
+  });
+
+  it("no pisa registroConfirmadoEn cuando el dato viene undefined", () => {
+    const comisionConfirmada = fakeComision("confirmada");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: comisionConfirmada });
+
+    alumno.actualizarDatos({
+      legajo: "54321",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+    });
+
+    expect(alumno.registroConfirmadoEn).toBe(comisionConfirmada);
+  });
+
+  it("actualiza registroConfirmadoEn cuando el dato viene definido", () => {
+    const comisionNueva = fakeComision("nueva");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("vieja") });
+
+    alumno.actualizarDatos({
+      legajo: "54321",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+      registroConfirmadoEn: comisionNueva,
+    });
+
+    expect(alumno.registroConfirmadoEn).toBe(comisionNueva);
+  });
+});
+
+describe("Alumno.toRegistroInput", () => {
+  it("devuelve los campos que espera el registro de Sheets", () => {
+    const alumno = nuevoAlumno();
+
+    expect(alumno.toRegistroInput()).toEqual({
+      legajo: "12345",
+      apellido: "García",
+      nombre: "Ana",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+    });
+  });
+});
+
 describe("Alumno.confirmoRegistroEn", () => {
   it("devuelve true cuando registroConfirmadoEn apunta a la comision activa", () => {
     const comision = fakeComision("c1");
@@ -89,6 +159,17 @@ describe("Alumno.confirmoRegistroEn", () => {
   });
 });
 
+describe("Alumno.confirmarRegistroEn", () => {
+  it("marca la comisión en la que confirmó registro", () => {
+    const comision = fakeComision("c1");
+    const alumno = nuevoAlumno();
+
+    alumno.confirmarRegistroEn(comision);
+
+    expect(alumno.registroConfirmadoEn).toBe(comision);
+  });
+});
+
 describe("Alumno.necesitaConfirmarRegistroPara", () => {
   it("devuelve true cuando el alumno no confirmó para la comision activa", () => {
     const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("c-antigua") });
@@ -105,6 +186,30 @@ describe("Alumno.necesitaConfirmarRegistroPara", () => {
 });
 
 describe("Alumno — predicados de sync", () => {
+  describe("transiciones de sync", () => {
+    it("prende y limpia el flag de sync de alumno", () => {
+      const fecha = new Date("2026-04-01T00:00:00Z");
+      const alumno = nuevoAlumno();
+
+      alumno.marcarSyncDeAlumnoFallido(fecha);
+      expect(alumno.alumnoSyncFallidoEn).toBe(fecha);
+
+      alumno.limpiarSyncDeAlumnoFallido();
+      expect(alumno.alumnoSyncFallidoEn).toBeNull();
+    });
+
+    it("prende y limpia el flag de sync de grupos", () => {
+      const fecha = new Date("2026-04-01T00:00:00Z");
+      const alumno = nuevoAlumno();
+
+      alumno.marcarSyncDeGruposFallido(fecha);
+      expect(alumno.gruposSyncFallidoEn).toBe(fecha);
+
+      alumno.limpiarSyncDeGruposFallido();
+      expect(alumno.gruposSyncFallidoEn).toBeNull();
+    });
+  });
+
   describe("tieneSyncDeAlumnoFallido", () => {
     it("devuelve false cuando el flag está limpio", () => {
       const alumno = nuevoAlumno({ alumnoSyncFallidoEn: null });
@@ -177,5 +282,40 @@ describe("Alumno — predicados de sync", () => {
         "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla."
       );
     });
+  });
+});
+
+describe("validateRegistro", () => {
+  const valid = {
+    legajo: "12345",
+    apellido: "García",
+    nombre: "Juan",
+    githubUsername: "juangarcia",
+    email: "juan@gmail.com",
+  };
+
+  it("acepta input válido", () => {
+    expect(validateRegistro(valid)).toBeNull();
+  });
+
+  it("mantiene los mensajes de error existentes", () => {
+    expect(validateRegistro({ ...valid, legajo: "" })).toBe(
+      "El legajo debe tener entre 4 y 8 dígitos"
+    );
+    expect(validateRegistro({ ...valid, apellido: "" })).toBe("El apellido es obligatorio");
+    expect(validateRegistro({ ...valid, nombre: "  " })).toBe("El nombre es obligatorio");
+    expect(validateRegistro({ ...valid, githubUsername: "" })).toBe(
+      "El usuario de GitHub es obligatorio"
+    );
+    expect(validateRegistro({ ...valid, githubUsername: "user name" })).toBe(
+      "El usuario de GitHub no tiene un formato válido"
+    );
+    expect(validateRegistro({ ...valid, email: "" })).toBe("El email no es válido");
+  });
+
+  it("rechaza github username que no es string", () => {
+    expect(validateRegistro({ ...valid, githubUsername: 123 as unknown as string })).toBe(
+      "El usuario de GitHub debe ser un texto"
+    );
   });
 });

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -318,4 +318,26 @@ describe("validateRegistro", () => {
       "El usuario de GitHub debe ser un texto"
     );
   });
+
+  it("no tira TypeError cuando legajo, apellido, nombre o email no son strings", () => {
+    expect(() =>
+      validateRegistro({ ...valid, legajo: 12345 as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, apellido: null as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, nombre: undefined as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, email: 42 as unknown as string })
+    ).not.toThrow();
+  });
+
+  it("devuelve error de validación (no null) cuando legajo, apellido, nombre o email no son strings", () => {
+    expect(validateRegistro({ ...valid, legajo: 12345 as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, apellido: null as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, nombre: undefined as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, email: 42 as unknown as string })).not.toBeNull();
+  });
 });

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -27,16 +27,16 @@ export function isValidEmail(email: string): boolean {
 export function validateRegistro(input: RegistroInput): string | null {
   const { legajo, apellido, nombre, githubUsername, email } = input;
 
-  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
+  if (typeof legajo !== "string" || !legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
     return "El legajo debe tener entre 4 y 8 dígitos";
-  if (!apellido.trim()) return "El apellido es obligatorio";
-  if (!nombre.trim()) return "El nombre es obligatorio";
+  if (typeof apellido !== "string" || !apellido.trim()) return "El apellido es obligatorio";
+  if (typeof nombre !== "string" || !nombre.trim()) return "El nombre es obligatorio";
   if (typeof githubUsername !== "string")
     return "El usuario de GitHub debe ser un texto";
   if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
   if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
     return "El usuario de GitHub no tiene un formato válido";
-  if (!isValidEmail(email)) return "El email no es válido";
+  if (typeof email !== "string" || !isValidEmail(email)) return "El email no es válido";
   return null;
 }
 

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -3,6 +3,43 @@ import { randomUUID } from "crypto";
 import { Comision } from "./Comision";
 import { ALUMNO_LEGAJO_PATTERN, ALUMNO_EMAIL_PATTERN, normalizarGithubUsername } from "./domain-constants";
 
+export interface RegistroInput {
+  legajo: string;
+  apellido: string;
+  nombre: string;
+  githubUsername: string;
+  email: string;
+}
+
+export interface AlumnoData extends RegistroInput {
+  comision?: Comision;
+  registroConfirmadoEn?: Comision;
+}
+
+// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
+// Suficiente para detectar typos comunes sin sobre-complicar.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
+export function validateRegistro(input: RegistroInput): string | null {
+  const { legajo, apellido, nombre, githubUsername, email } = input;
+
+  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
+    return "El legajo debe tener entre 4 y 8 dígitos";
+  if (!apellido.trim()) return "El apellido es obligatorio";
+  if (!nombre.trim()) return "El nombre es obligatorio";
+  if (typeof githubUsername !== "string")
+    return "El usuario de GitHub debe ser un texto";
+  if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
+  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
+    return "El usuario de GitHub no tiene un formato válido";
+  if (!isValidEmail(email)) return "El email no es válido";
+  return null;
+}
+
 @Entity()
 export class Alumno {
   static readonly LEGAJO_PATTERN = ALUMNO_LEGAJO_PATTERN;
@@ -61,6 +98,32 @@ export class Alumno {
     return `${this.apellido}, ${this.nombre}`;
   }
 
+  actualizarDatos(data: AlumnoData): void {
+    this.legajo = data.legajo.trim();
+    this.nombre = data.nombre.trim();
+    this.apellido = data.apellido.trim();
+    this.githubUsername = Alumno.normalizarUsername(data.githubUsername);
+    this.email = Alumno.normalizarEmail(data.email);
+    this.comision = data.comision;
+    if (data.registroConfirmadoEn !== undefined) {
+      this.registroConfirmadoEn = data.registroConfirmadoEn;
+    }
+  }
+
+  toRegistroInput(): RegistroInput {
+    return {
+      legajo: this.legajo,
+      apellido: this.apellido,
+      nombre: this.nombre,
+      githubUsername: this.githubUsername,
+      email: this.email,
+    };
+  }
+
+  confirmarRegistroEn(comision: Comision): void {
+    this.registroConfirmadoEn = comision;
+  }
+
   confirmoRegistroEn(comision: Comision | null): boolean {
     if (!comision) return false;
     return this.registroConfirmadoEn?.id === comision.id;
@@ -74,8 +137,24 @@ export class Alumno {
     return this.alumnoSyncFallidoEn !== null;
   }
 
+  marcarSyncDeAlumnoFallido(fecha = new Date()): void {
+    this.alumnoSyncFallidoEn = fecha;
+  }
+
+  limpiarSyncDeAlumnoFallido(): void {
+    this.alumnoSyncFallidoEn = null;
+  }
+
   tieneSyncDeGruposFallido(): boolean {
     return this.gruposSyncFallidoEn !== null;
+  }
+
+  marcarSyncDeGruposFallido(fecha = new Date()): void {
+    this.gruposSyncFallidoEn = fecha;
+  }
+
+  limpiarSyncDeGruposFallido(): void {
+    this.gruposSyncFallidoEn = null;
   }
 
   tieneSyncPendiente(): boolean {

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -211,3 +211,25 @@ describe("Assignment.cargarGruposCon", () => {
     expect(result).toBe(grupos);
   });
 });
+
+describe("Assignment.aplicarCamposExtra", () => {
+  it("IndividualAssignment ignora cualquier campo extra sin lanzar error", () => {
+    const individual = new IndividualAssignment();
+    expect(() => individual.aplicarCamposExtra({ maxIntegrantes: 5 })).not.toThrow();
+    expect(() => individual.aplicarCamposExtra({})).not.toThrow();
+  });
+
+  it("GrupalAssignment setea maxIntegrantes cuando viene en los datos", () => {
+    const grupal = new GrupalAssignment();
+    grupal.maxIntegrantes = 3;
+    grupal.aplicarCamposExtra({ maxIntegrantes: 6 });
+    expect(grupal.maxIntegrantes).toBe(6);
+  });
+
+  it("GrupalAssignment no modifica maxIntegrantes si no viene en los datos", () => {
+    const grupal = new GrupalAssignment();
+    grupal.maxIntegrantes = 3;
+    grupal.aplicarCamposExtra({});
+    expect(grupal.maxIntegrantes).toBe(3);
+  });
+});

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -107,6 +107,13 @@ export abstract class Assignment {
    */
   abstract extraFormDefaults(): Partial<{ maxIntegrantes: number }>;
 
+  /**
+   * Aplica los campos extra del form al subtipo (inverso de `extraFormDefaults()`).
+   * Individual: no-op. Grupal: setea `maxIntegrantes` si viene en `data`.
+   * Evita `instanceof GrupalAssignment` en la capa de repositorios.
+   */
+  abstract aplicarCamposExtra(data: Partial<{ maxIntegrantes: number }>): void;
+
   /** Nombre del repo template sin el prefijo de organización (ej. "org/repo" → "repo"). */
   nombreDelTemplate(): string {
     return this.templateRepo.includes("/")

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -80,6 +80,10 @@ export class GrupalAssignment extends Assignment {
     return { maxIntegrantes: this.maxIntegrantes };
   }
 
+  aplicarCamposExtra(data: Partial<{ maxIntegrantes: number }>): void {
+    if (data.maxIntegrantes !== undefined) this.maxIntegrantes = data.maxIntegrantes;
+  }
+
   cargarGruposCon(loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
     return loader(this.id);
   }

--- a/src/domain/entities/IndividualAssignment.ts
+++ b/src/domain/entities/IndividualAssignment.ts
@@ -39,6 +39,10 @@ export class IndividualAssignment extends Assignment {
     return {};
   }
 
+  aplicarCamposExtra(_data: Partial<{ maxIntegrantes: number }>): void {
+    // Los assignments individuales no tienen campos extra.
+  }
+
   cargarGruposCon(_loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
     return Promise.resolve([]);
   }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,4 +1,10 @@
-export { Alumno } from "./Alumno";
+export {
+  Alumno,
+  isValidEmail,
+  validateRegistro,
+  type AlumnoData,
+  type RegistroInput,
+} from "./Alumno";
 export { Comision } from "./Comision";
 export { Assignment } from "./Assignment";
 export type {

--- a/src/lib/api-errors.test.ts
+++ b/src/lib/api-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { NextResponse } from "next/server";
+import { parseJsonObjectBody } from "./api-errors";
+
+function makeRequest(body: unknown, contentType = "application/json"): Request {
+  return new Request("http://test.local/api/test", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("parseJsonObjectBody", () => {
+  it("devuelve el objeto cuando el body es un objeto plano válido", async () => {
+    const request = makeRequest({ legajo: "12345", nombre: "Juan" });
+    const result = await parseJsonObjectBody(request);
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(result).toEqual({ legajo: "12345", nombre: "Juan" });
+  });
+
+  it("devuelve NextResponse 400 cuando el body es null JSON", async () => {
+    const request = makeRequest(null);
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain("No pudimos leer los datos enviados");
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un array JSON", async () => {
+    const request = makeRequest([1, 2, 3]);
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body no es JSON válido", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "esto-no-es-json",
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    // El bug original devolvía 500 porque req.json() tiraba excepción sin .catch().
+    // Con el helper, un body mal formado devuelve 400.
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un string JSON", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify("un string"),
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un número JSON", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(42),
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,6 +1,29 @@
 import { NextResponse } from "next/server";
 import { logger } from "./logger";
 
+/**
+ * Parsea el body de un request JSON y verifica que sea un objeto plano.
+ * Devuelve el objeto si es válido, o una `NextResponse` 400 si no lo es
+ * (body no-JSON, null, array). Usar `.catch()` internamente evita que un
+ * body mal formado propague una excepción y termine devolviendo 500.
+ *
+ * Patrón de uso:
+ *   const body = await parseJsonObjectBody(req);
+ *   if (body instanceof NextResponse) return body;
+ */
+export async function parseJsonObjectBody(
+  req: Request
+): Promise<Record<string, unknown> | NextResponse> {
+  const body = await req.json().catch(() => null);
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "No pudimos leer los datos enviados. Volvé a intentar." },
+      { status: 400 }
+    );
+  }
+  return body as Record<string, unknown>;
+}
+
 // Loggea el error completo server-side y devuelve siempre un 500 con mensaje
 // genérico — evita filtrar detalles internos (stack traces, esquemas de DB,
 // mensajes de librerías de terceros) al cliente.

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockMembersInsert = vi.fn();
 const mockJWT = vi.fn();
 
+const mockMembersDelete = vi.fn();
+
 vi.mock("googleapis", () => ({
   google: {
     auth: {
@@ -13,12 +15,15 @@ vi.mock("googleapis", () => ({
       },
     },
     admin: () => ({
-      members: { insert: (...args: unknown[]) => mockMembersInsert(...args) },
+      members: {
+        insert: (...args: unknown[]) => mockMembersInsert(...args),
+        delete: (...args: unknown[]) => mockMembersDelete(...args),
+      },
     }),
   },
 }));
 
-import { agregarMiembroAGrupo } from "./googleGroups";
+import { agregarMiembroAGrupo, quitarMiembroDeGrupo } from "./googleGroups";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -50,6 +55,7 @@ describe("agregarMiembroAGrupo", () => {
     process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
     process.env.GOOGLE_SERVICE_ACCOUNT_KEY = FAKE_SA_KEY;
     mockMembersInsert.mockResolvedValue({ data: {} });
+    mockMembersDelete.mockResolvedValue({ data: {} });
     mockJWT.mockReturnValue({});
   });
 
@@ -142,4 +148,62 @@ describe("agregarMiembroAGrupo", () => {
     expect(result).toEqual({ status: "error", error: "Sin permisos" });
   });
 
+});
+
+describe("quitarMiembroDeGrupo", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = FAKE_SA_KEY;
+    mockMembersDelete.mockResolvedValue({ data: {} });
+    mockJWT.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL no está configurada", async () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "skipped" });
+    expect(mockMembersDelete).not.toHaveBeenCalled();
+  });
+
+  it("elimina el miembro del grupo (happy path)", async () => {
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "removed" });
+    expect(mockMembersDelete).toHaveBeenCalledWith(
+      { groupKey: "pdep@googlegroups.com", memberKey: "juan@gmail.com" },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("retorna 'not_member' cuando la API devuelve 404 en err.code", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(404, "notFound"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'not_member' cuando la API devuelve 404 en err.status", async () => {
+    const err = Object.assign(new Error("Not Found"), { status: 404 });
+    mockMembersDelete.mockRejectedValue(err);
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'not_member' cuando reason 'resourceNotFound' viene en err.errors", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(400, "resourceNotFound"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'error' con mensaje cuando la API falla con otro código", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(403, "forbidden", "Sin permisos"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "error", error: "Sin permisos" });
+  });
 });

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -86,3 +86,56 @@ export async function agregarMiembroAGrupo(
     return { status: "error", error: message };
   }
 }
+
+// ── Des-suscribir alumno del grupo ──────────────────────────
+
+// Detecta "el miembro no estaba en el grupo": la baja es idempotente, así que
+// un 404 (o reason notFound/resourceNotFound) lo tratamos como éxito silencioso.
+// Mismo enfoque defensivo que `isDuplicateError`: el status puede venir por
+// err.code, err.status o anidado en response.data.error.errors.
+function isNotFoundError(error: unknown): boolean {
+  const apiError = error as {
+    code?: number;
+    status?: number;
+    errors?: { reason?: string }[];
+    response?: { data?: { error?: { errors?: { reason?: string }[] } } };
+  };
+  if (apiError.code === 404 || apiError.status === 404) return true;
+  const hasNotFoundReason = (errors?: { reason?: string }[]) =>
+    Boolean(
+      errors?.some(
+        (errorEntry) =>
+          errorEntry.reason === "notFound" || errorEntry.reason === "resourceNotFound"
+      )
+    );
+  return (
+    hasNotFoundReason(apiError.errors) ||
+    hasNotFoundReason(apiError.response?.data?.error?.errors)
+  );
+}
+
+export type QuitarMiembroResult =
+  | { status: "removed" }
+  | { status: "not_member" }
+  | { status: "skipped" }
+  | { status: "error"; error: string };
+
+export async function quitarMiembroDeGrupo(
+  memberEmail: string
+): Promise<QuitarMiembroResult> {
+  const groupEmail = getGroupEmail();
+  if (!groupEmail) return { status: "skipped" };
+
+  try {
+    const admin = getDirectoryClient();
+    await admin.members.delete(
+      { groupKey: groupEmail, memberKey: memberEmail },
+      { signal: AbortSignal.timeout(10_000) }
+    );
+    return { status: "removed" };
+  } catch (error) {
+    if (isNotFoundError(error)) return { status: "not_member" };
+    const message = error instanceof Error ? error.message : "Error al quitar del grupo";
+    return { status: "error", error: message };
+  }
+}

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -1,6 +1,8 @@
 import { getEM } from "@/lib/db";
-import { Alumno } from "@/domain/entities";
+import { Alumno, type AlumnoData } from "@/domain/entities";
 import type { Comision } from "@/domain/entities";
+
+export type { AlumnoData } from "@/domain/entities";
 
 // El legajo es la PK del alumno en la cursada: dos alumnos no pueden compartirlo.
 // La UNIQUE constraint de la DB ya lo garantiza, pero lanzamos este error antes
@@ -43,6 +45,20 @@ export async function getAlumnoByGithub(
   });
 }
 
+export async function getAlumnosByGithubUsernames(
+  githubUsernames: string[]
+): Promise<Alumno[]> {
+  const usernamesCanonicos = [
+    ...new Set(githubUsernames.map((username) => Alumno.normalizarUsername(username))),
+  ];
+  if (usernamesCanonicos.length === 0) return [];
+
+  const entityManager = await getEM();
+  return entityManager.find(Alumno, {
+    githubUsername: { $in: usernamesCanonicos },
+  });
+}
+
 export async function getAlumnoByLegajo(
   legajo: string
 ): Promise<Alumno | null> {
@@ -50,36 +66,11 @@ export async function getAlumnoByLegajo(
   return entityManager.findOne(Alumno, { legajo: legajo.trim() });
 }
 
-export interface AlumnoData {
-  legajo: string;
-  nombre: string;
-  apellido: string;
-  githubUsername: string;
-  email: string;
-  comision?: Comision;
-  registroConfirmadoEn?: Comision;
-}
-
-// Copia los campos de `data` sobre `alumno`. Para `registroConfirmadoEn`
-// se ignora `undefined` para no pisar un valor ya confirmado cuando el caller
-// (ej. sync desde Sheets) no trae ese dato.
-function applyAlumnoData(alumno: Alumno, data: AlumnoData): void {
-  alumno.legajo = data.legajo.trim();
-  alumno.nombre = data.nombre.trim();
-  alumno.apellido = data.apellido.trim();
-  alumno.githubUsername = Alumno.normalizarUsername(data.githubUsername);
-  alumno.email = Alumno.normalizarEmail(data.email);
-  alumno.comision = data.comision;
-  if (data.registroConfirmadoEn !== undefined) {
-    alumno.registroConfirmadoEn = data.registroConfirmadoEn;
-  }
-}
-
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
   await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
   const entityManager = await getEM();
   const alumno = new Alumno();
-  applyAlumnoData(alumno, data);
+  alumno.actualizarDatos(data);
   entityManager.persist(alumno);
   await entityManager.flush();
   return alumno;
@@ -94,7 +85,7 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   });
 
   if (existing) {
-    applyAlumnoData(existing, data);
+    existing.actualizarDatos(data);
     await entityManager.flush();
     return existing;
   }
@@ -115,7 +106,7 @@ export async function marcarRegistroConfirmado(
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.registroConfirmadoEn = comision;
+  alumno.confirmarRegistroEn(comision);
   await entityManager.flush();
 }
 
@@ -125,7 +116,7 @@ export async function marcarGruposSyncFallido(githubUsername: string): Promise<v
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.gruposSyncFallidoEn = new Date();
+  alumno.marcarSyncDeGruposFallido();
   await entityManager.flush();
 }
 
@@ -137,7 +128,7 @@ export async function marcarGruposSyncOk(githubUsername: string): Promise<void> 
   // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
   // exitosa del happy path.
   if (!alumno || !alumno.gruposSyncFallidoEn) return;
-  alumno.gruposSyncFallidoEn = null;
+  alumno.limpiarSyncDeGruposFallido();
   await entityManager.flush();
 }
 
@@ -147,7 +138,7 @@ export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<v
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.alumnoSyncFallidoEn = new Date();
+  alumno.marcarSyncDeAlumnoFallido();
   await entityManager.flush();
 }
 
@@ -157,7 +148,7 @@ export async function marcarAlumnoSyncOk(githubUsername: string): Promise<void> 
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno || !alumno.alumnoSyncFallidoEn) return;
-  alumno.alumnoSyncFallidoEn = null;
+  alumno.limpiarSyncDeAlumnoFallido();
   await entityManager.flush();
 }
 
@@ -219,10 +210,10 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     const key = Alumno.normalizarUsername(data.githubUsername);
     const existing = existentesPorGithub.get(key);
     if (existing) {
-      applyAlumnoData(existing, data);
+      existing.actualizarDatos(data);
     } else {
       const alumno = new Alumno();
-      applyAlumnoData(alumno, data);
+      alumno.actualizarDatos(data);
       entityManager.persist(alumno);
       // Si el batch trae otra fila con el mismo github (typo o fila duplicada
       // en la planilla), debe reutilizar esta instancia — sin esto, el UNIQUE

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -52,13 +52,8 @@ export async function createAssignment(
 
   let assignment: Assignment;
 
-  if (data.tipo === "grupal") {
-    const grupal = new GrupalAssignment();
-    grupal.maxIntegrantes = data.maxIntegrantes!;
-    assignment = grupal;
-  } else {
-    assignment = new IndividualAssignment();
-  }
+  assignment = data.tipo === "grupal" ? new GrupalAssignment() : new IndividualAssignment();
+  assignment.aplicarCamposExtra(data);
 
   assignment.titulo = data.titulo;
   assignment.slug = slug;
@@ -91,9 +86,7 @@ export async function updateAssignment(
   if (data.deadline !== undefined)
     assignment.deadline = data.deadline ? new Date(data.deadline) : undefined;
 
-  if (assignment instanceof GrupalAssignment && data.maxIntegrantes !== undefined) {
-    assignment.maxIntegrantes = data.maxIntegrantes;
-  }
+  assignment.aplicarCamposExtra(data);
 
   await entityManager.flush();
   return assignment;

--- a/src/lib/repositories/ComisionRepository.ts
+++ b/src/lib/repositories/ComisionRepository.ts
@@ -1,6 +1,7 @@
 import { getEM, deleteEntity } from "@/lib/db";
 import { Comision } from "@/domain/entities";
 import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 
 export class ComisionActivaDuplicadaError extends Error {
   constructor() {
@@ -18,14 +19,11 @@ export interface ComisionFormData {
 
 function esViolacionDeComisionActivaUnica(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  const cause = error.cause;
-  const code =
-    (error as NodeJS.ErrnoException).code ??
-    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  const code = extractDbErrorCode(error);
   const message = `${error.message} ${
-    cause instanceof Error ? cause.message : ""
+    error.cause instanceof Error ? error.cause.message : ""
   }`;
-  return code === "23505" && message.includes("comision_unica_activa_idx");
+  return code === UNIQUE_VIOLATION && message.includes("comision_unica_activa_idx");
 }
 
 async function traducirErrorDeComisionActiva<T>(

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -1,4 +1,5 @@
 import { getEM } from "@/lib/db";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 import { Alumno, Assignment, Grupo, Entrega } from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
@@ -141,11 +142,8 @@ export async function createEntrega(data: {
 
 function isUniqueViolation(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  const cause = error.cause;
-  const code =
-    (error as NodeJS.ErrnoException).code ??
-    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
-  return code === "23505" || /unique constraint|duplicate key/i.test(error.message);
+  const code = extractDbErrorCode(error);
+  return code === UNIQUE_VIOLATION || /unique constraint|duplicate key/i.test(error.message);
 }
 
 async function findExistingEntrega(data: {

--- a/src/lib/repositories/db-errors.test.ts
+++ b/src/lib/repositories/db-errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
+
+describe("extractDbErrorCode", () => {
+  it("devuelve undefined si el error no es una instancia de Error", () => {
+    expect(extractDbErrorCode("string-error")).toBeUndefined();
+    expect(extractDbErrorCode(null)).toBeUndefined();
+    expect(extractDbErrorCode(42)).toBeUndefined();
+    expect(extractDbErrorCode(undefined)).toBeUndefined();
+  });
+
+  it("extrae el código directamente de error.code", () => {
+    const error = Object.assign(new Error("unique violation"), { code: "23505" });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("extrae el código desde error.cause.code cuando error.code no existe", () => {
+    const cause = Object.assign(new Error("inner"), { code: "23505" });
+    const error = new Error("outer", { cause });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("prefiere error.code sobre cause.code si ambos existen", () => {
+    const cause = Object.assign(new Error("inner"), { code: "12345" });
+    const error = Object.assign(new Error("outer", { cause }), { code: "23505" });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("devuelve undefined si ni error.code ni cause.code están presentes", () => {
+    const error = new Error("sin code");
+    expect(extractDbErrorCode(error)).toBeUndefined();
+  });
+
+  it("devuelve undefined si cause no es un objeto", () => {
+    const error = Object.assign(new Error("outer"), { cause: "string-cause" });
+    expect(extractDbErrorCode(error)).toBeUndefined();
+  });
+});
+
+describe("UNIQUE_VIOLATION", () => {
+  it("es el código de violación de unicidad de Postgres", () => {
+    expect(UNIQUE_VIOLATION).toBe("23505");
+  });
+});

--- a/src/lib/repositories/db-errors.ts
+++ b/src/lib/repositories/db-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Constante y helper compartidos para detectar errores del driver de Postgres.
+ * Cada repositorio define su propio predicado específico (qué constraint viola)
+ * y llama a `extractDbErrorCode` para obtener el código de error sin duplicar
+ * la lógica de introspección de `error.cause`.
+ */
+
+export const UNIQUE_VIOLATION = "23505";
+
+/**
+ * Extrae el código de error del driver de Postgres desde un error desconocido.
+ * El driver puede colocar el código directamente en `error.code` o anidado
+ * en `error.cause.code` — esta función los unifica.
+ * Devuelve `undefined` si el error no es una instancia de `Error`.
+ */
+export function extractDbErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const cause = error.cause;
+  return (
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object"
+      ? (cause as NodeJS.ErrnoException).code
+      : undefined)
+  );
+}

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -1,6 +1,7 @@
 export {
   getAlumnos,
   getAlumnoByGithub,
+  getAlumnosByGithubUsernames,
   getAlumnoByLegajo,
   createAlumno,
   upsertAlumno,

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockGetComisionActiva = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockEjecutarHooksPostConfirmacion = vi.fn();
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -24,10 +26,17 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
 
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
   marcarRegistroConfirmado: (...args: unknown[]) =>
     mockMarcarRegistroConfirmado(...args),
   LegajoConflictError: FakeLegajoConflictError,
+}));
+
+vi.mock("./hooksPostConfirmacion", () => ({
+  ejecutarHooksPostConfirmacion: (...args: unknown[]) =>
+    mockEjecutarHooksPostConfirmacion(...args),
+  HOOKS_CONFIRMACION_ALUMNO: [],
 }));
 
 // Para `validateRegistro` usamos la implementación real: es pura y testearla
@@ -41,7 +50,7 @@ vi.mock("@/lib/sheets", async () => {
   };
 });
 
-import { confirmarDatosAlumno } from "./alumnoRegistro";
+import { confirmarDatosAlumno, confirmarYProcesarAlumno } from "./alumnoRegistro";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -73,9 +82,11 @@ describe("confirmarDatosAlumno", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockGetAlumnoByGithub.mockResolvedValue(null);
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({});
   });
 
   it("devuelve { ok: true, comision } cuando todo el flujo funciona", async () => {
@@ -225,5 +236,75 @@ describe("confirmarDatosAlumno", () => {
   it("deja propagar errores inesperados del upsert en DB (no-LegajoConflictError)", async () => {
     mockUpsertAlumno.mockRejectedValue(new Error("conexión caída"));
     await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("conexión caída");
+  });
+});
+
+// ── confirmarYProcesarAlumno ─────────────────────────────────
+
+describe("confirmarYProcesarAlumno", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({ groupSubscription: "added", gruposSync: "ok" });
+  });
+
+  it("propaga el resultado { ok: false } cuando confirmarDatosAlumno falla", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    const resultado = await confirmarYProcesarAlumno(validInput);
+    expect(resultado).toMatchObject({ ok: false, status: 409 });
+    expect(mockEjecutarHooksPostConfirmacion).not.toHaveBeenCalled();
+  });
+
+  it("devuelve { ok: true, comision, hooks } cuando todo funciona", async () => {
+    const resultado = await confirmarYProcesarAlumno(validInput);
+    expect(resultado).toEqual({
+      ok: true,
+      comision: comisionActiva,
+      hooks: { groupSubscription: "added", gruposSync: "ok" },
+    });
+  });
+
+  it("ejecuta los hooks pasando el contexto del alumno", async () => {
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: validInput.githubUsername,
+        email: validInput.email,
+        comision: comisionActiva,
+      }),
+      expect.any(Array)
+    );
+  });
+
+  it("pasa emailPrevio: undefined cuando el alumno no existe en DB antes de confirmar", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({ emailPrevio: undefined }),
+      expect.any(Array)
+    );
+  });
+
+  it("pasa el email previo del alumno existente para que el hook lo des-suscriba si cambió", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({ emailPrevio: "viejo@gmail.com" }),
+      expect.any(Array)
+    );
+  });
+
+  it("lee el email previo ANTES de confirmar (upsertAlumno pisa el email en DB)", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
+    await confirmarYProcesarAlumno(validInput);
+    const ordenLlamadas = [
+      mockGetAlumnoByGithub.mock.invocationCallOrder[0],
+      mockUpsertAlumno.mock.invocationCallOrder[0],
+    ];
+    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
   });
 });

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -1,12 +1,19 @@
-import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
+import { validateRegistro, type RegistroInput } from "@/domain/entities";
+import { upsertarAlumnoEnSheets } from "@/lib/sheets";
 import {
   getComisionActiva,
+  getAlumnoByGithub,
   upsertAlumno,
   marcarRegistroConfirmado,
   LegajoConflictError,
 } from "@/lib/repositories";
 import { Comision } from "@/domain/entities";
 import { logger } from "@/lib/logger";
+import {
+  ejecutarHooksPostConfirmacion,
+  HOOKS_CONFIRMACION_ALUMNO,
+  type ResultadoHooks,
+} from "./hooksPostConfirmacion";
 
 /**
  * Resultado de `confirmarDatosAlumno` — discriminated union con el status HTTP
@@ -28,9 +35,9 @@ export type ResultadoConfirmacion =
  * valida los datos del alumno, persiste en DB (DB-primero para atomicidad
  * sobre legajo↔github) y refleja en la planilla.
  *
- * El handler es quien agrega lo específico: registro hace la validación de
- * coherencia github↔sesión antes de llamar, y después de un resultado OK
- * dispara los hooks accesorios (Google Groups, sync de grupos desde planilla).
+ * El handler agrega lo específico de HTTP, como la validación de coherencia
+ * github↔sesión. El flujo de aplicación `confirmarYProcesarAlumno` encadena los
+ * hooks accesorios después de una confirmación OK.
  */
 export async function confirmarDatosAlumno(
   input: RegistroInput
@@ -103,4 +110,45 @@ export async function confirmarDatosAlumno(
   }
 
   return { ok: true, comision: comisionActiva };
+}
+
+export type ResultadoConfirmacionConHooks =
+  | { ok: true; comision: Comision; hooks: ResultadoHooks }
+  | {
+      ok: false;
+      status: 400 | 409;
+      error: string;
+      field?: "legajo" | "githubUsername";
+    };
+
+/**
+ * Orquesta el evento completo "alumno confirmado/actualizado" para los flujos de
+ * un único alumno (registro y perfil): confirma los datos y dispara los hooks
+ * accesorios (Google Groups + sync de grupos). Captura el email previo ANTES de
+ * confirmar para que, si cambió, el hook de Google Groups des-suscriba la
+ * dirección vieja. La ruta sólo valida entrada, llama acá y traduce el resultado
+ * a HTTP.
+ */
+export async function confirmarYProcesarAlumno(
+  input: RegistroInput
+): Promise<ResultadoConfirmacionConHooks> {
+  // El email previo se lee antes de confirmar: `upsertAlumno` (dentro de
+  // `confirmarDatosAlumno`) pisa el email en la DB, así que después ya no
+  // tendríamos la dirección vieja para des-suscribirla del grupo.
+  const emailPrevio = (await getAlumnoByGithub(input.githubUsername))?.email;
+
+  const resultado = await confirmarDatosAlumno(input);
+  if (!resultado.ok) return resultado;
+
+  const hooks = await ejecutarHooksPostConfirmacion(
+    {
+      githubUsername: input.githubUsername,
+      email: input.email,
+      comision: resultado.comision,
+      emailPrevio,
+    },
+    HOOKS_CONFIRMACION_ALUMNO
+  );
+
+  return { ok: true, comision: resultado.comision, hooks };
 }

--- a/src/lib/services/hooksPostConfirmacion.test.ts
+++ b/src/lib/services/hooksPostConfirmacion.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockAgregarMiembroAGrupo = vi.fn();
+const mockQuitarMiembroDeGrupo = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
+
+vi.mock("@/lib/googleGroups", () => ({
+  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
+  quitarMiembroDeGrupo: (...args: unknown[]) => mockQuitarMiembroDeGrupo(...args),
+}));
+
+vi.mock("./intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
+}));
+
+import {
+  hookGoogleGroups,
+  hookGruposSync,
+  ejecutarHooksPostConfirmacion,
+  HOOKS_CONFIRMACION_ALUMNO,
+  HOOKS_IMPORTACION_ALUMNO,
+  type ContextoAlumno,
+} from "./hooksPostConfirmacion";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<ContextoAlumno> = {}): ContextoAlumno {
+  return {
+    githubUsername: "juangarcia",
+    email: "juan@gmail.com",
+    comision: { id: "c1" } as never,
+    ...overrides,
+  };
+}
+
+// ── hookGoogleGroups ─────────────────────────────────────────
+
+describe("hookGoogleGroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "removed" });
+  });
+
+  it("devuelve el status de la suscripción del email actual", async () => {
+    const resultado = await hookGoogleGroups(makeCtx());
+    expect(resultado).toEqual({ groupSubscription: "added" });
+  });
+
+  it("pasa el email del contexto a agregarMiembroAGrupo", async () => {
+    await hookGoogleGroups(makeCtx({ email: "nueva@utn.edu.ar" }));
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("nueva@utn.edu.ar");
+  });
+
+  it("loguea (con email enmascarado) cuando la suscripción falla", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "Sin permisos" });
+
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com" }));
+
+    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
+    expect(loggedPayload).not.toContain("juan@gmail.com");
+    expect(loggedPayload).toContain("@gmail.com");
+    expect(loggedPayload).toContain("juangarcia");
+    errorSpy.mockRestore();
+  });
+
+  it("devuelve groupSubscription:'error' cuando la suscripción falla (sin throwear)", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    const resultado = await hookGoogleGroups(makeCtx());
+    expect(resultado).toEqual({ groupSubscription: "error" });
+  });
+
+  it("no intenta quitar el email previo cuando no hay emailPrevio", async () => {
+    await hookGoogleGroups(makeCtx({ emailPrevio: undefined }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no intenta quitar el email previo cuando el email no cambió", async () => {
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "juan@gmail.com" }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no intenta quitar el email previo cuando la normalización coincide (case, espacios)", async () => {
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "  JUAN@GMAIL.COM  " }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("quita el email previo cuando el email cambió", async () => {
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
+  });
+
+  it("quita el email previo cuando el email actual ya estaba suscripto", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
+  });
+
+  it("no quita el email previo si falló la suscripción del email actual", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no quita el email previo si la suscripción del email actual fue skipeada", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no degrada groupSubscription cuando la baja del email previo falla", async () => {
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    const resultado = await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(resultado).toEqual({ groupSubscription: "added" });
+  });
+
+  it("loguea (con email enmascarado) cuando la baja del email previo falla", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+
+    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
+    expect(loggedPayload).not.toContain("viejo@gmail.com");
+    expect(loggedPayload).toContain("@gmail.com");
+    errorSpy.mockRestore();
+  });
+});
+
+// ── hookGruposSync ───────────────────────────────────────────
+
+describe("hookGruposSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("devuelve gruposSync:'ok' cuando el wrapper resuelve sin error", async () => {
+    const resultado = await hookGruposSync(makeCtx());
+    expect(resultado).toEqual({ gruposSync: "ok" });
+  });
+
+  it("devuelve gruposSync:'error' (sin throwear) cuando el wrapper lanza", async () => {
+    mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
+    const resultado = await hookGruposSync(makeCtx());
+    expect(resultado).toEqual({ gruposSync: "error" });
+  });
+
+  it("pasa githubUsername y comision a intentarSincronizarGrupos", async () => {
+    const comision = { id: "c2" } as never;
+    await hookGruposSync(makeCtx({ githubUsername: "anagarcia", comision }));
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("anagarcia", comision);
+  });
+});
+
+// ── ejecutarHooksPostConfirmacion ────────────────────────────
+
+describe("ejecutarHooksPostConfirmacion", () => {
+  it("devuelve resultado vacío cuando la lista de hooks está vacía", async () => {
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), []);
+    expect(resultado).toEqual({});
+  });
+
+  it("mergea los slices de resultado de múltiples hooks", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [
+      hookGoogleGroups,
+      hookGruposSync,
+    ]);
+
+    expect(resultado).toEqual({ groupSubscription: "added", gruposSync: "ok" });
+  });
+
+  it("el slice de un hook posterior pisa el anterior si comparten clave", async () => {
+    const hookA = vi.fn().mockResolvedValue({ groupSubscription: "added" });
+    const hookB = vi.fn().mockResolvedValue({ groupSubscription: "already_member" });
+
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [hookA, hookB]);
+
+    expect(resultado).toEqual({ groupSubscription: "already_member" });
+  });
+});
+
+// ── Políticas por origen ─────────────────────────────────────
+
+describe("HOOKS_CONFIRMACION_ALUMNO (registro y perfil)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("corre Google Groups y sync de grupos", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_CONFIRMACION_ALUMNO);
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledOnce();
+  });
+});
+
+describe("HOOKS_IMPORTACION_ALUMNO (importación admin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+  });
+
+  it("corre Google Groups", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
+  });
+
+  // La sync de grupos NO se hace inline en la importación: queda en la action
+  // dedicada `sincronizarGruposDeLaComision` (lectura única de la hoja, UI propia).
+  it("NO corre sync de grupos (queda delegado a sincronizarGruposDeLaComision)", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/hooksPostConfirmacion.ts
+++ b/src/lib/services/hooksPostConfirmacion.ts
@@ -1,0 +1,131 @@
+import {
+  agregarMiembroAGrupo,
+  quitarMiembroDeGrupo,
+  type AgregarMiembroResult,
+} from "@/lib/googleGroups";
+import { intentarSincronizarGrupos } from "./intentarSincronizarGrupos";
+import { logger } from "@/lib/logger";
+import { Alumno, type Comision } from "@/domain/entities";
+
+/**
+ * Contexto del evento "alumno confirmado/actualizado". `emailPrevio` es el email
+ * que el alumno tenía en la DB antes de esta confirmación; se usa para des-suscribir
+ * del Google Group la dirección vieja cuando el email cambió. En un alta nueva
+ * (registro de un alumno inexistente) o en la importación no hay previo, así que
+ * sólo se suscribe la dirección actual.
+ */
+export type ContextoAlumno = {
+  githubUsername: string;
+  email: string;
+  comision: Comision;
+  emailPrevio?: string;
+};
+
+export type ResultadoHooks = {
+  groupSubscription?: AgregarMiembroResult["status"];
+  gruposSync?: "ok" | "error";
+};
+
+export type HookPostConfirmacion = (ctx: ContextoAlumno) => Promise<ResultadoHooks>;
+
+// Enmascara la parte local del email para no escupir PII a los logs,
+// preservando dominio y primeras 2 letras para que un admin pueda
+// reconocer al alumno (combinado con el githubUsername del log).
+function maskEmail(correo: string): string {
+  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
+}
+
+// Enmascara cualquier email embebido en un texto libre (p. ej. el `message` de
+// un error de googleapis, que suele citar el email del miembro afectado).
+function maskEmailsEnTexto(texto: string): string {
+  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
+}
+
+/**
+ * Suscribe al alumno al Google Group con su email actual y, si el email cambió
+ * respecto al previo, des-suscribe la dirección vieja sólo cuando el alta nueva
+ * quedó asegurada. La baja es best-effort: se loguea pero no degrada la
+ * respuesta. El status devuelto refleja la suscripción del email actual, no la
+ * baja del viejo.
+ */
+export const hookGoogleGroups: HookPostConfirmacion = async ({
+  githubUsername,
+  email,
+  emailPrevio,
+}) => {
+  const suscripcion = await agregarMiembroAGrupo(email);
+  if (suscripcion.status === "error") {
+    logger.error(
+      {
+        githubUsername,
+        maskedEmail: maskEmail(email),
+        err: maskEmailsEnTexto(suscripcion.error),
+      },
+      "Error al suscribir al Google Group"
+    );
+  }
+
+  const puedeQuitarEmailPrevio =
+    suscripcion.status === "added" || suscripcion.status === "already_member";
+  if (
+    puedeQuitarEmailPrevio &&
+    emailPrevio &&
+    Alumno.normalizarEmail(emailPrevio) !== Alumno.normalizarEmail(email)
+  ) {
+    const baja = await quitarMiembroDeGrupo(emailPrevio);
+    if (baja.status === "error") {
+      logger.error(
+        {
+          githubUsername,
+          maskedEmail: maskEmail(emailPrevio),
+          err: maskEmailsEnTexto(baja.error),
+        },
+        "Error al des-suscribir el email anterior del Google Group"
+      );
+    }
+  }
+
+  return { groupSubscription: suscripcion.status };
+};
+
+/**
+ * Sincroniza los grupos del alumno desde la planilla. El wrapper
+ * `intentarSincronizarGrupos` ya loguea y marca el flag en DB para disparar el
+ * retry automático en `/perfil`; acá sólo traducimos el throw a una respuesta
+ * degradada para el warning inmediato.
+ */
+export const hookGruposSync: HookPostConfirmacion = async ({ githubUsername, comision }) => {
+  try {
+    await intentarSincronizarGrupos(githubUsername, comision);
+    return { gruposSync: "ok" };
+  } catch {
+    return { gruposSync: "error" };
+  }
+};
+
+/**
+ * Corre la lista de hooks accesorios del origen y mergea sus resultados. Cada
+ * hook es auto-contenido (corre, loguea, degrada); el runner no ramifica por
+ * origen — cada flujo declara qué hooks corre vía la lista que pasa.
+ */
+export async function ejecutarHooksPostConfirmacion(
+  ctx: ContextoAlumno,
+  hooks: HookPostConfirmacion[]
+): Promise<ResultadoHooks> {
+  let resultado: ResultadoHooks = {};
+  for (const hook of hooks) {
+    resultado = { ...resultado, ...(await hook(ctx)) };
+  }
+  return resultado;
+}
+
+// Política por origen: qué hooks corre cada flujo del evento "alumno confirmado".
+export const HOOKS_CONFIRMACION_ALUMNO: HookPostConfirmacion[] = [
+  hookGoogleGroups,
+  hookGruposSync,
+];
+
+// La importación admin suscribe al grupo pero NO sincroniza grupos inline: eso
+// queda en la action dedicada `sincronizarGruposDeLaComision` (lectura única de
+// la hoja, UI de progreso propia).
+export const HOOKS_IMPORTACION_ALUMNO: HookPostConfirmacion[] = [hookGoogleGroups];

--- a/src/lib/services/importarAlumnosDeComision.test.ts
+++ b/src/lib/services/importarAlumnosDeComision.test.ts
@@ -144,6 +144,19 @@ describe("importarAlumnosDeComision", () => {
     );
   });
 
+  it("no duplica el prefijo cuando getAlumnos ya incluye 'No se pudo leer la planilla'", async () => {
+    mockGetAlumnos.mockRejectedValue(
+      new Error("No se pudo leer la planilla de alumnos: timeout")
+    );
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      "No se pudo leer la planilla de alumnos: timeout"
+    );
+    await expect(importarAlumnosDeComision(comision as never)).rejects.not.toThrow(
+      "No se pudo leer la planilla: No se pudo leer la planilla"
+    );
+  });
+
   it("propaga errores de upsertAlumnos", async () => {
     const error = new Error("legajo duplicado");
     mockUpsertAlumnos.mockRejectedValue(error);

--- a/src/lib/services/importarAlumnosDeComision.test.ts
+++ b/src/lib/services/importarAlumnosDeComision.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetAlumnos = vi.fn();
+const mockGetAlumnosByGithubUsernames = vi.fn();
+const mockUpsertAlumnos = vi.fn();
+const mockEjecutarHooksPostConfirmacion = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
+
+vi.mock("@/lib/sheets", () => ({
+  getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnosByGithubUsernames: (...args: unknown[]) =>
+    mockGetAlumnosByGithubUsernames(...args),
+  upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
+}));
+
+vi.mock("./hooksPostConfirmacion", () => ({
+  ejecutarHooksPostConfirmacion: (...args: unknown[]) =>
+    mockEjecutarHooksPostConfirmacion(...args),
+  HOOKS_IMPORTACION_ALUMNO: ["google-groups-hook"],
+}));
+
+vi.mock("./intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
+}));
+
+import {
+  importarAlumnosDeComision,
+  LecturaPlanillaAlumnosError,
+} from "./importarAlumnosDeComision";
+
+describe("importarAlumnosDeComision", () => {
+  const comision = { id: "c1", spreadsheetId: "sheet-abc", columnConfig: {} };
+  const alumnos = [
+    {
+      legajo: "111",
+      nombre: "Ana",
+      apellido: "López",
+      githubUsername: "Ana",
+      email: "ana-nuevo@b.com",
+    },
+    {
+      legajo: "222",
+      nombre: "Beto",
+      apellido: "Ruiz",
+      githubUsername: "beto",
+      email: "beto@b.com",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAlumnos.mockResolvedValue(alumnos);
+    mockGetAlumnosByGithubUsernames.mockResolvedValue([]);
+    mockUpsertAlumnos.mockResolvedValue(2);
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({ groupSubscription: "added" });
+  });
+
+  it("lee alumnos desde la planilla configurada de la comisión", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnos).toHaveBeenCalledWith("sheet-abc", {});
+  });
+
+  it("captura emails previos antes de upsertAlumnos", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnosByGithubUsernames.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUpsertAlumnos.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("busca alumnos previos por githubUsername en batch", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnosByGithubUsernames).toHaveBeenCalledWith(["Ana", "beto"]);
+  });
+
+  it("persiste los alumnos con la comisión incluida", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockUpsertAlumnos).toHaveBeenCalledWith(
+      alumnos.map((alumno) => ({ ...alumno, comision }))
+    );
+  });
+
+  it("pasa emailPrevio al hook cuando el alumno ya existía", async () => {
+    mockGetAlumnosByGithubUsernames.mockResolvedValue([
+      { githubUsername: "ana", usernameCanonico: "ana", email: "ana-viejo@b.com" },
+    ]);
+
+    await importarAlumnosDeComision(comision as never);
+
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: "Ana",
+        email: "ana-nuevo@b.com",
+        emailPrevio: "ana-viejo@b.com",
+      }),
+      ["google-groups-hook"]
+    );
+  });
+
+  it("pasa emailPrevio undefined cuando el alumno no existía", async () => {
+    await importarAlumnosDeComision(comision as never);
+
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: "Ana",
+        email: "ana-nuevo@b.com",
+        emailPrevio: undefined,
+      }),
+      ["google-groups-hook"]
+    );
+  });
+
+  it("cuenta conErrorDeGrupo cuando falla alguna suscripción", async () => {
+    mockEjecutarHooksPostConfirmacion
+      .mockResolvedValueOnce({ groupSubscription: "error" })
+      .mockResolvedValueOnce({ groupSubscription: "added" });
+
+    const result = await importarAlumnosDeComision(comision as never);
+
+    expect(result).toEqual({ sincronizados: 2, conErrorDeGrupo: 1 });
+  });
+
+  it("no ejecuta sync de grupos inline", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+
+  it("envuelve errores de lectura de Sheets", async () => {
+    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      LecturaPlanillaAlumnosError
+    );
+  });
+
+  it("preserva el mensaje actual para errores de lectura de Sheets", async () => {
+    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      "No se pudo leer la planilla: acceso denegado"
+    );
+  });
+
+  it("propaga errores de upsertAlumnos", async () => {
+    const error = new Error("legajo duplicado");
+    mockUpsertAlumnos.mockRejectedValue(error);
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toBe(error);
+  });
+});

--- a/src/lib/services/importarAlumnosDeComision.ts
+++ b/src/lib/services/importarAlumnosDeComision.ts
@@ -17,7 +17,10 @@ export type ResultadoImportacionAlumnos = {
 export class LecturaPlanillaAlumnosError extends Error {
   constructor(cause: unknown) {
     const message = cause instanceof Error ? cause.message : "Error desconocido";
-    super(`No se pudo leer la planilla: ${message}`, { cause });
+    const fullMessage = message.startsWith("No se pudo leer la planilla")
+      ? message
+      : `No se pudo leer la planilla: ${message}`;
+    super(fullMessage, { cause });
     this.name = "LecturaPlanillaAlumnosError";
   }
 }

--- a/src/lib/services/importarAlumnosDeComision.ts
+++ b/src/lib/services/importarAlumnosDeComision.ts
@@ -1,0 +1,67 @@
+import { Alumno, type Comision } from "@/domain/entities";
+import {
+  getAlumnosByGithubUsernames,
+  upsertAlumnos,
+} from "@/lib/repositories";
+import { getAlumnos } from "@/lib/sheets";
+import {
+  ejecutarHooksPostConfirmacion,
+  HOOKS_IMPORTACION_ALUMNO,
+} from "./hooksPostConfirmacion";
+
+export type ResultadoImportacionAlumnos = {
+  sincronizados: number;
+  conErrorDeGrupo: number;
+};
+
+export class LecturaPlanillaAlumnosError extends Error {
+  constructor(cause: unknown) {
+    const message = cause instanceof Error ? cause.message : "Error desconocido";
+    super(`No se pudo leer la planilla: ${message}`, { cause });
+    this.name = "LecturaPlanillaAlumnosError";
+  }
+}
+
+/**
+ * Caso de uso de importación admin: lee alumnos desde Sheets, persiste el bulk
+ * upsert y dispara los hooks accesorios de importación. Captura emails previos
+ * antes del flush para que Google Groups pueda des-suscribir direcciones viejas.
+ */
+export async function importarAlumnosDeComision(
+  comision: Comision
+): Promise<ResultadoImportacionAlumnos> {
+  let alumnos;
+  try {
+    alumnos = await getAlumnos(comision.spreadsheetId, comision.columnConfig);
+  } catch (error) {
+    throw new LecturaPlanillaAlumnosError(error);
+  }
+
+  const existentes = await getAlumnosByGithubUsernames(
+    alumnos.map((alumno) => alumno.githubUsername)
+  );
+  const emailPrevioPorGithub = new Map(
+    existentes.map((alumno) => [alumno.usernameCanonico, alumno.email])
+  );
+
+  const sincronizados = await upsertAlumnos(
+    alumnos.map((alumno) => ({ ...alumno, comision }))
+  );
+
+  let conErrorDeGrupo = 0;
+  for (const alumno of alumnos) {
+    const githubUsername = Alumno.normalizarUsername(alumno.githubUsername);
+    const { groupSubscription } = await ejecutarHooksPostConfirmacion(
+      {
+        githubUsername: alumno.githubUsername,
+        email: alumno.email,
+        comision,
+        emailPrevio: emailPrevioPorGithub.get(githubUsername),
+      },
+      HOOKS_IMPORTACION_ALUMNO
+    );
+    if (groupSubscription === "error") conErrorDeGrupo++;
+  }
+
+  return { sincronizados, conErrorDeGrupo };
+}

--- a/src/lib/services/verificarConsistenciaAlumno.test.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Alumno } from "@/domain/entities";
+import { Alumno } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -31,15 +31,14 @@ const comision = {
 } as unknown as Parameters<typeof verificarConsistenciaAlumno>[1];
 
 function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
-  return {
-    id: "uuid-1",
-    legajo: "12345",
-    nombre: "Juan",
-    apellido: "Garcia",
-    githubUsername: "juangarcia",
-    email: "juan@example.com",
-    ...overrides,
-  } as Alumno;
+  const alumno = new Alumno();
+  alumno.id = "uuid-1";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "Garcia";
+  alumno.githubUsername = "juangarcia";
+  alumno.email = "juan@example.com";
+  return Object.assign(alumno, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/lib/services/verificarConsistenciaAlumno.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.ts
@@ -32,13 +32,7 @@ export async function verificarConsistenciaAlumno(
 
   try {
     const resultado = await upsertarAlumnoEnSheets(
-      {
-        legajo: alumno.legajo,
-        apellido: alumno.apellido,
-        nombre: alumno.nombre,
-        githubUsername: alumno.githubUsername,
-        email: alumno.email,
-      },
+      alumno.toRegistroInput(),
       comision.spreadsheetId,
       comision.columnConfig
     );

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -1,5 +1,10 @@
 import { google } from "googleapis";
-import { Alumno } from "@/domain/entities";
+import {
+  Alumno,
+  isValidEmail,
+  validateRegistro,
+  type RegistroInput,
+} from "@/domain/entities";
 import {
   type ColumnConfig,
   DEFAULT_COLUMN_CONFIG,
@@ -7,6 +12,9 @@ import {
   type Paradigma,
   PARADIGMAS,
 } from "@/types";
+
+export { isValidEmail, validateRegistro };
+export type { RegistroInput };
 
 // ── Auth con service account ────────────────────────────────
 
@@ -70,11 +78,13 @@ export function parseAlumnosRows(
     .filter((row) => row[config.legajo] && row[config.githubUsername])
     .map((row) => {
       const alumno = new Alumno();
-      alumno.legajo = norm(row[config.legajo]);
-      alumno.apellido = norm(row[config.apellido]);
-      alumno.nombre = norm(row[config.nombre]);
-      alumno.githubUsername = Alumno.normalizarUsername(row[config.githubUsername]);
-      alumno.email = norm(row[config.email]);
+      alumno.actualizarDatos({
+        legajo: norm(row[config.legajo]),
+        apellido: norm(row[config.apellido]),
+        nombre: norm(row[config.nombre]),
+        githubUsername: norm(row[config.githubUsername]),
+        email: norm(row[config.email]),
+      });
       return alumno;
     });
 }
@@ -140,40 +150,6 @@ async function findAlumnoRowIndex(
   );
   if (rowIndex === -1) return null;
   return config.headerRows + 1 + rowIndex;
-}
-
-// ── Registro de alumno ──────────────────────────────────────
-
-export interface RegistroInput {
-  legajo: string;
-  apellido: string;
-  nombre: string;
-  githubUsername: string;
-  email: string;
-}
-
-// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
-// Suficiente para detectar typos comunes sin sobre-complicar.
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-export function isValidEmail(email: string): boolean {
-  return EMAIL_REGEX.test(email.trim());
-}
-
-export function validateRegistro(input: RegistroInput): string | null {
-  const { legajo, apellido, nombre, githubUsername, email } = input;
-
-  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
-    return "El legajo debe tener entre 4 y 8 dígitos";
-  if (!apellido.trim()) return "El apellido es obligatorio";
-  if (!nombre.trim()) return "El nombre es obligatorio";
-  if (typeof githubUsername !== "string")
-    return "El usuario de GitHub debe ser un texto";
-  if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
-  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
-    return "El usuario de GitHub no tiene un formato válido";
-  if (!isValidEmail(email)) return "El email no es válido";
-  return null;
 }
 
 // ── Upsert de alumno en la planilla ─────────────────────────


### PR DESCRIPTION
Closes #33

## Resumen

- **hooksPostConfirmacion**: módulo central con `hookGoogleGroups` (suscribe el email nuevo, des-suscribe el anterior cuando cambia), `hookGruposSync`, runner `ejecutarHooksPostConfirmacion` y listas de política por origen (`HOOKS_CONFIRMACION_ALUMNO` para registro/perfil, `HOOKS_IMPORTACION_ALUMNO` para admin)
- **googleGroups**: nueva `quitarMiembroDeGrupo` con detección de 404/notFound análoga a `isDuplicateError`
- **confirmarYProcesarAlumno**: orquesta `confirmarDatosAlumno` + hooks; registro y perfil quedan uniformes — perfil ahora suscribe al Google Group y des-suscribe el email anterior si cambió
- **importarAlumnosDeComision**: caso de uso nuevo que extrae la lógica de `sincronizarAlumnos`; captura emails previos en batch antes del flush para des-suscripción; `SyncState` ok expone `conErrorDeGrupo`
- **Dominio consolidado**: `AlumnoData`, `RegistroInput`, `validateRegistro`, `isValidEmail` movidos a `Alumno.ts`; `applyAlumnoData` reemplazada por `Alumno.actualizarDatos`; nuevos métodos `confirmarRegistroEn`, `marcar/limpiarSync*`
- **getAlumnosByGithubUsernames** en `AlumnoRepository` para la captura de emails previos en batch

## Test plan

- [ ] Registro: alumno nuevo queda suscripto al Google Group; `groupSubscription` llega al cliente
- [ ] Perfil: cambiar el email des-suscribe el email anterior y suscribe el nuevo; si Google Groups no está configurado (`GOOGLE_GROUP_EMAIL` ausente), todo degrada a `skipped` sin error
- [ ] Importación admin: `sincronizarAlumnos` suscribe cada alumno al grupo; `sync-button` muestra "N sin grupo" cuando alguno falla
- [ ] Importación: alumnos que ya tenían otro email quedan des-suscriptos del email viejo
- [ ] Sync de grupos (action dedicada `sincronizarGruposDeLaComision`) sigue funcionando independiente de la importación

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced student registration with detailed error tracking for group synchronization failures
  * Commission student import now reports synchronization error counts
  * Improved email validation during registration process

* **Bug Fixes**
  * More robust handling of Google Groups subscription/unsubscription errors
  * Better error recovery during student data import

* **Refactor**
  * Consolidated student confirmation and post-registration hook execution into unified workflow
  * Centralized data validation for student registration inputs

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Juancete/Pdep-Classroom/pull/39?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->