### PR TITLE
Release: consistencia DB/planilla, assignments, hooks post-confirmación

### DIFF
--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -617,7 +617,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
+          "unique": true,
           "length": null,
           "precision": null,
           "scale": null,
@@ -655,6 +655,17 @@
           "keyName": "comision_pkey",
           "unique": true,
           "primary": true
+        },
+        {
+          "columnNames": [
+            "activa"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "comision_unica_activa_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX comision_unica_activa_idx ON public.comision USING btree (activa) WHERE (activa IS TRUE)"
         }
       ],
       "checks": [],

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,93 +22,13 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
+        "anio": {
+          "name": "anio",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": true,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -116,15 +36,47 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "integer"
         },
-        "registro_confirmado_en_id": {
-          "name": "registro_confirmado_en_id",
-          "type": "uuid",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "activa": {
+          "name": "activa",
+          "type": "boolean",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,
@@ -132,106 +84,26 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "grupos_sync_fallido_en": {
-          "name": "grupos_sync_fallido_en",
-          "type": "timestamptz(6)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "alumno_sync_fallido_en": {
-          "name": "alumno_sync_fallido_en",
-          "type": "timestamptz(6)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
+          "mappedType": "json"
         }
       },
-      "name": "alumno",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_github_username_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "constraint": true,
-          "keyName": "alumno_legajo_unique",
-          "unique": true,
-          "primary": false
-        },
-        {
+          "keyName": "comision_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "alumno_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "columnNames": [
-            "comision_id"
-          ],
-          "constraintName": "alumno_comision_id_foreign",
-          "localTableName": "public.alumno",
-          "referencedTableName": "public.comision",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        },
-        "alumno_registro_confirmado_en_id_foreign": {
-          "columnNames": [
-            "registro_confirmado_en_id"
-          ],
-          "constraintName": "alumno_registro_confirmado_en_id_foreign",
-          "localTableName": "public.alumno",
-          "referencedTableName": "public.comision",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {},
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -372,7 +244,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz(6)",
+          "type": "timestamptz",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -404,15 +276,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int4",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": 32,
-          "scale": 0,
+          "precision": null,
+          "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -420,11 +292,11 @@
         },
         "inscripciones_cerradas": {
           "name": "inscripciones_cerradas",
-          "type": "bool",
+          "type": "boolean",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -440,43 +312,270 @@
       "indexes": [
         {
           "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "assignment_pkey",
-          "unique": true,
-          "primary": true
-        },
-        {
-          "columnNames": [
             "tipo"
           ],
           "composite": false,
-          "constraint": false,
           "keyName": "assignment_tipo_index",
-          "unique": false,
-          "primary": false
+          "constraint": false,
+          "primary": false,
+          "unique": false
+        },
+        {
+          "keyName": "assignment_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "constraintName": "assignment_comision_id_foreign",
           "columnNames": [
             "comision_id"
           ],
-          "constraintName": "assignment_comision_id_foreign",
           "localTableName": "public.assignment",
-          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "referencedTableName": "public.comision",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "grupos_sync_fallido_en": {
+          "name": "grupos_sync_fallido_en",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "alumno_sync_fallido_en": {
+          "name": "alumno_sync_fallido_en",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        }
+      },
+      "name": "alumno",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "keyName": "alumno_legajo_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "keyName": "alumno_github_username_unique",
+          "constraint": true,
+          "primary": false,
+          "unique": true
+        },
+        {
+          "keyName": "alumno_pkey",
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": true,
+          "primary": true,
+          "unique": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "constraintName": "alumno_comision_id_foreign",
+          "columnNames": [
+            "comision_id"
+          ],
+          "localTableName": "public.alumno",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.comision",
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "localTableName": "public.alumno",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.comision",
+          "deleteRule": "set null",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -517,48 +616,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "assignment_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
-          "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "assignment_alumnos_assignment_id_foreign": {
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "columnNames": [
             "assignment_id"
           ],
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
           "localTableName": "public.assignment_alumnos",
-          "referencedTableName": "public.assignment",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "assignment_alumnos_alumno_id_foreign": {
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.assignment_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -578,24 +676,8 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -610,25 +692,29 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "bool",
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": true,
+          "unique": false,
           "length": null,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -640,38 +726,72 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
-      "name": "comision",
+      "name": "grupo",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "comision_pkey",
-          "unique": true,
-          "primary": true
-        },
-        {
-          "columnNames": [
-            "activa"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "comision_unica_activa_idx",
-          "unique": true,
-          "primary": false,
-          "expression": "CREATE UNIQUE INDEX comision_unica_activa_idx ON public.comision USING btree (activa) WHERE (activa IS TRUE)"
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {},
-      "comment": null
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "constraintName": "grupo_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        }
+      },
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -698,6 +818,22 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
           "unique": false,
           "length": null,
           "precision": null,
@@ -771,41 +907,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamptz(6)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
         "repo_deleted": {
           "name": "repo_deleted",
-          "type": "bool",
+          "type": "boolean",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -818,202 +922,81 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "boolean"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamptz",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
+          "keyName": "entrega_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": false,
-          "keyName": "entrega_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
+        "entrega_assignment_id_foreign": {
+          "constraintName": "entrega_assignment_id_foreign",
+          "columnNames": [
+            "assignment_id"
+          ],
+          "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.assignment",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
         "entrega_alumno_id_foreign": {
+          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
-          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
-        },
-        "entrega_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "entrega_assignment_id_foreign",
-          "localTableName": "public.entrega",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
+          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedColumnNames": [
+            "id"
+          ],
           "referencedTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "set null"
+          "deleteRule": "set null",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int4",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": 32,
-          "scale": 0,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "integer"
-        },
-        "creado_por": {
-          "name": "creado_por",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        }
-      },
-      "name": "grupo",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": false,
-          "keyName": "grupo_pkey",
-          "unique": true,
-          "primary": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "columnNames": [
-            "assignment_id"
-          ],
-          "constraintName": "grupo_assignment_id_foreign",
-          "localTableName": "public.grupo",
-          "referencedTableName": "public.assignment",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        }
-      },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     },
     {
       "columns": {
@@ -1054,48 +1037,47 @@
       "schema": "public",
       "indexes": [
         {
+          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": false,
-          "keyName": "grupo_alumnos_pkey",
-          "unique": true,
-          "primary": true
+          "constraint": true,
+          "primary": true,
+          "unique": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_alumno_id_foreign": {
-          "columnNames": [
-            "alumno_id"
-          ],
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
-          "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
-        },
         "grupo_alumnos_grupo_id_foreign": {
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
           "localTableName": "public.grupo_alumnos",
-          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "updateRule": "cascade",
-          "deleteRule": "cascade"
+          "referencedTableName": "public.grupo",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
+        },
+        "grupo_alumnos_alumno_id_foreign": {
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
+          "columnNames": [
+            "alumno_id"
+          ],
+          "localTableName": "public.grupo_alumnos",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "referencedTableName": "public.alumno",
+          "deleteRule": "cascade",
+          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {},
-      "comment": null
+      "nativeEnums": {}
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260527120000_add_unique_active_comision_index.ts
+++ b/migrations/Migration20260527120000_add_unique_active_comision_index.ts
@@ -1,0 +1,21 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260527120000_add_unique_active_comision_index extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      do $$
+      begin
+        if (select count(*) from "comision" where "activa" is true) > 1 then
+          raise exception 'No se puede crear comision_unica_activa_idx: hay mas de una comision activa. Deja una sola activa y reintenta la migracion.';
+        end if;
+      end $$;
+    `);
+    this.addSql(`create unique index "comision_unica_activa_idx" on "comision" ("activa") where "activa" is true;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "comision_unica_activa_idx";`);
+  }
+
+}

--- a/migrations/Migration20260528123000_unique_entrega_logica.ts
+++ b/migrations/Migration20260528123000_unique_entrega_logica.ts
@@ -1,0 +1,62 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260528123000_unique_entrega_logica extends Migration {
+
+  override async up(): Promise<void> {
+    this.addSql(`
+      update "entrega" e
+      set "alumno_id" = a."id"
+      from "alumno" a
+      where e."alumno_id" is null
+        and e."grupo_id" is null
+        and array_length(e."github_usernames", 1) = 1
+        and lower(a."github_username") = lower(e."github_usernames"[1]);
+    `);
+
+    this.addSql(`
+      do $$
+      begin
+        if exists (
+          select 1
+          from "entrega"
+          where "repo_name" is not null
+          group by "repo_name"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay repo_name duplicados.';
+        end if;
+
+        if exists (
+          select 1
+          from "entrega"
+          where "alumno_id" is not null
+          group by "assignment_id", "alumno_id"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay entregas individuales duplicadas.';
+        end if;
+
+        if exists (
+          select 1
+          from "entrega"
+          where "grupo_id" is not null
+          group by "assignment_id", "grupo_id"
+          having count(*) > 1
+        ) then
+          raise exception 'No se pueden crear índices únicos de entrega: hay entregas grupales duplicadas.';
+        end if;
+      end $$;
+    `);
+
+    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" ("repo_name") where "repo_name" is not null;`);
+    this.addSql(`create unique index "entrega_assignment_alumno_unique_idx" on "entrega" ("assignment_id", "alumno_id") where "alumno_id" is not null;`);
+    this.addSql(`create unique index "entrega_assignment_grupo_unique_idx" on "entrega" ("assignment_id", "grupo_id") where "grupo_id" is not null;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index if exists "entrega_assignment_grupo_unique_idx";`);
+    this.addSql(`drop index if exists "entrega_assignment_alumno_unique_idx";`);
+    this.addSql(`drop index if exists "entrega_repo_name_unique_idx";`);
+  }
+
+}

--- a/migrations/Migration20260528123000_unique_entrega_logica.ts
+++ b/migrations/Migration20260528123000_unique_entrega_logica.ts
@@ -20,7 +20,7 @@ export class Migration20260528123000_unique_entrega_logica extends Migration {
           select 1
           from "entrega"
           where "repo_name" is not null
-          group by "repo_name"
+          group by lower("repo_name")
           having count(*) > 1
         ) then
           raise exception 'No se pueden crear índices únicos de entrega: hay repo_name duplicados.';
@@ -48,7 +48,7 @@ export class Migration20260528123000_unique_entrega_logica extends Migration {
       end $$;
     `);
 
-    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" ("repo_name") where "repo_name" is not null;`);
+    this.addSql(`create unique index "entrega_repo_name_unique_idx" on "entrega" (lower("repo_name")) where "repo_name" is not null;`);
     this.addSql(`create unique index "entrega_assignment_alumno_unique_idx" on "entrega" ("assignment_id", "alumno_id") where "alumno_id" is not null;`);
     this.addSql(`create unique index "entrega_assignment_grupo_unique_idx" on "entrega" ("assignment_id", "grupo_id") where "grupo_id" is not null;`);
   }

--- a/migrations/Migration20260529130107_alumno_comision_not_null_and_cascade.ts
+++ b/migrations/Migration20260529130107_alumno_comision_not_null_and_cascade.ts
@@ -5,6 +5,7 @@ export class Migration20260529130107_alumno_comision_not_null_and_cascade extend
   override async up(): Promise<void> {
     // alumno.comision_id: NOT NULL + on delete cascade
     // Un alumno siempre pertenece a una comisión; borrar la comisión borra sus alumnos.
+    this.addSql(`delete from "alumno" where "comision_id" is null;`);
     this.addSql(`alter table "alumno" drop constraint "alumno_comision_id_foreign";`);
     this.addSql(`alter table "alumno" alter column "comision_id" set not null;`);
     this.addSql(`alter table "alumno" add constraint "alumno_comision_id_foreign" foreign key ("comision_id") references "comision" ("id") on update cascade on delete cascade;`);

--- a/migrations/Migration20260529130107_alumno_comision_not_null_and_cascade.ts
+++ b/migrations/Migration20260529130107_alumno_comision_not_null_and_cascade.ts
@@ -1,0 +1,28 @@
+import { Migration } from '@mikro-orm/migrations';
+
+export class Migration20260529130107_alumno_comision_not_null_and_cascade extends Migration {
+
+  override async up(): Promise<void> {
+    // alumno.comision_id: NOT NULL + on delete cascade
+    // Un alumno siempre pertenece a una comisión; borrar la comisión borra sus alumnos.
+    this.addSql(`alter table "alumno" drop constraint "alumno_comision_id_foreign";`);
+    this.addSql(`alter table "alumno" alter column "comision_id" set not null;`);
+    this.addSql(`alter table "alumno" add constraint "alumno_comision_id_foreign" foreign key ("comision_id") references "comision" ("id") on update cascade on delete cascade;`);
+
+    // assignment.comision_id: on delete cascade (seguía en set null)
+    // Consistencia: borrar una comisión vieja borra también sus assignments
+    // (que a su vez cascade-an a grupos, entregas e inscripciones por FKs existentes).
+    this.addSql(`alter table "assignment" drop constraint "assignment_comision_id_foreign";`);
+    this.addSql(`alter table "assignment" add constraint "assignment_comision_id_foreign" foreign key ("comision_id") references "comision" ("id") on update cascade on delete cascade;`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`alter table "alumno" drop constraint "alumno_comision_id_foreign";`);
+    this.addSql(`alter table "alumno" alter column "comision_id" drop not null;`);
+    this.addSql(`alter table "alumno" add constraint "alumno_comision_id_foreign" foreign key ("comision_id") references "comision" ("id") on update cascade on delete set null;`);
+
+    this.addSql(`alter table "assignment" drop constraint "assignment_comision_id_foreign";`);
+    this.addSql(`alter table "assignment" add constraint "assignment_comision_id_foreign" foreign key ("comision_id") references "comision" ("id") on update cascade on delete set null;`);
+  }
+
+}

--- a/src/app/admin/alumnos/page.test.tsx
+++ b/src/app/admin/alumnos/page.test.tsx
@@ -31,7 +31,7 @@ function makeAlumno(overrides?: Partial<Alumno>): Alumno {
   alumno.apellido = "Garcia";
   alumno.githubUsername = "juangarcia";
   alumno.email = "juan@example.com";
-  alumno.comision = "miércoles noche";
+  alumno.comision = { id: "c1", anio: 2026, spreadsheetId: "sheet-1", activa: true } as Alumno["comision"];
   return Object.assign(alumno, overrides);
 }
 

--- a/src/app/admin/assignments/[id]/edit/page.test.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.test.tsx
@@ -126,6 +126,17 @@ describe("Edit Assignment page", () => {
     expect(html).not.toContain("name=\"comisionId\"");
   });
 
+  it("muestra Histórica cuando la comisión asociada no está activa", async () => {
+    const comision = new Comision(2027, "sheet-2");
+    comision.activa = false;
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("2027 (Histórica)");
+  });
+
   it("muestra Sin comisión para assignments huérfanos", async () => {
     mockGetAssignment.mockResolvedValue(makeAssignment({ comision: undefined }));
 

--- a/src/app/admin/assignments/[id]/edit/page.test.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
 import React from "react";
-import { IndividualAssignment } from "@/domain/entities";
+import { Comision, IndividualAssignment } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -61,6 +61,8 @@ import EditAssignmentPage from "./page";
 // ── Helpers ──────────────────────────────────────────────────
 
 function makeAssignment(overrides?: object) {
+  const comision = new Comision(2026, "sheet-1");
+  comision.activa = true;
   return Object.assign(new IndividualAssignment(), {
     id: "a1",
     titulo: "Kata Funcional",
@@ -71,6 +73,7 @@ function makeAssignment(overrides?: object) {
     deadline: new Date("2026-06-30"),
     createdAt: new Date("2026-01-01"),
     slug: "kata-funcional",
+    comision,
     ...overrides,
   });
 }
@@ -108,6 +111,28 @@ describe("Edit Assignment page", () => {
     const element = await EditAssignmentPage({ params: { id: "a1" } });
     const html = renderToStaticMarkup(element as React.ReactElement);
     expect(html).toContain("data-submit-label=\"Guardar cambios\"");
+  });
+
+  it("muestra la comisión asociada sin agregarla al formulario", async () => {
+    const comision = new Comision(2027, "sheet-2");
+    comision.activa = true;
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("Comisión:");
+    expect(html).toContain("2027 (Activa)");
+    expect(html).not.toContain("name=\"comisionId\"");
+  });
+
+  it("muestra Sin comisión para assignments huérfanos", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision: undefined }));
+
+    const element = await EditAssignmentPage({ params: { id: "a1" } });
+    const html = renderToStaticMarkup(element as React.ReactElement);
+
+    expect(html).toContain("Sin comisión");
   });
 
   describe("defaultValues pre-populados", () => {

--- a/src/app/admin/assignments/[id]/edit/page.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.tsx
@@ -19,6 +19,14 @@ export default async function EditAssignmentPage({
   return (
     <div className="max-w-xl">
       <h1 className="text-2xl font-bold mb-6">Editar Assignment</h1>
+      <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
+        Comisión:{" "}
+        <span className="font-medium text-gray-800">
+          {assignment.comision
+            ? `${assignment.comision.anio} (${assignment.comision.activa ? "Activa" : "Histórica"})`
+            : "Sin comisión"}
+        </span>
+      </div>
       <AssignmentForm
         action={actualizarAssignment}
         templates={templates}

--- a/src/app/admin/assignments/actions.test.ts
+++ b/src/app/admin/assignments/actions.test.ts
@@ -7,11 +7,16 @@ const mockCreateAssignment = vi.fn();
 const mockUpdateAssignment = vi.fn();
 const mockRedirect = vi.fn();
 
+const { FakeComisionActivaRequeridaError } = vi.hoisted(() => ({
+  FakeComisionActivaRequeridaError: class FakeComisionActivaRequeridaError extends Error {},
+}));
+
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
 }));
 
 vi.mock("@/lib/repositories", () => ({
+  ComisionActivaRequeridaError: FakeComisionActivaRequeridaError,
   createAssignment: (...args: unknown[]) => mockCreateAssignment(...args),
   updateAssignment: (...args: unknown[]) => mockUpdateAssignment(...args),
 }));
@@ -93,6 +98,23 @@ describe("crearAssignment", () => {
       );
       // el slug es generado por el repositorio, no por la action
       expect(mockRedirect).toHaveBeenCalledWith("/admin/assignments");
+    });
+
+    it("retorna error global si no hay comisión activa", async () => {
+      mockCreateAssignment.mockRejectedValue(
+        new FakeComisionActivaRequeridaError(
+          "Necesitás una comisión activa para crear assignments."
+        )
+      );
+
+      const result = await crearAssignment(null, makeFormData(BASE_INDIVIDUAL));
+
+      expect(result).toEqual({
+        ok: false,
+        errors: {},
+        formError: "Necesitás una comisión activa para crear assignments.",
+      });
+      expect(mockRedirect).not.toHaveBeenCalled();
     });
   });
 

--- a/src/app/admin/assignments/actions.ts
+++ b/src/app/admin/assignments/actions.ts
@@ -1,7 +1,11 @@
 "use server";
 
 import { requireAdmin } from "@/lib/session";
-import { createAssignment, updateAssignment } from "@/lib/repositories";
+import {
+  ComisionActivaRequeridaError,
+  createAssignment,
+  updateAssignment,
+} from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AssignmentSchema, AssignmentFormState } from "@/lib/assignment-schema";
 
@@ -31,7 +35,15 @@ export async function crearAssignment(
     return { ok: false, errors: result.error.flatten().fieldErrors };
   }
 
-  await createAssignment(result.data);
+  try {
+    await createAssignment(result.data);
+  } catch (error) {
+    if (error instanceof ComisionActivaRequeridaError) {
+      return { ok: false, errors: {}, formError: error.message };
+    }
+    throw error;
+  }
+
   redirect("/admin/assignments");
 }
 

--- a/src/app/admin/assignments/assignment-form.test.tsx
+++ b/src/app/admin/assignments/assignment-form.test.tsx
@@ -31,6 +31,10 @@ function errorState(errors: Record<string, string[]>) {
   mockUseFormState.mockReturnValue([{ ok: false, errors }, noop]);
 }
 
+function formErrorState(formError: string) {
+  mockUseFormState.mockReturnValue([{ ok: false, errors: {}, formError }, noop]);
+}
+
 const TEMPLATES = [
   { name: "kata-template", fullName: "org/kata-template", description: "Kata base" },
   { name: "tp-objetos", fullName: "org/tp-objetos", description: "TP de objetos" },
@@ -223,6 +227,16 @@ describe("AssignmentForm", () => {
         />
       );
       expect(screen.getByText("Debe ser al menos 2")).toBeInTheDocument();
+    });
+
+    it("muestra error global del formulario", () => {
+      formErrorState("Necesitás una comisión activa para crear assignments.");
+
+      render(<AssignmentForm action={noop} templates={[]} submitLabel="Crear" />);
+
+      expect(
+        screen.getByText("Necesitás una comisión activa para crear assignments.")
+      ).toBeInTheDocument();
     });
   });
 

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -150,7 +150,10 @@ export function AssignmentForm({
   return (
     <form action={formAction} className="space-y-5" data-template-count={templates.length}>
       {state?.formError && (
-        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+        <div
+          role="alert"
+          className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700"
+        >
           {state.formError}
         </div>
       )}

--- a/src/app/admin/assignments/assignment-form.tsx
+++ b/src/app/admin/assignments/assignment-form.tsx
@@ -149,6 +149,11 @@ export function AssignmentForm({
 
   return (
     <form action={formAction} className="space-y-5" data-template-count={templates.length}>
+      {state?.formError && (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {state.formError}
+        </div>
+      )}
       {defaultValues.id && <input type="hidden" name="id" value={defaultValues.id} />}
       {/* Título */}
       <div>

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderToStaticMarkup } from "react-dom/server";
-import { IndividualAssignment } from "@/domain/entities";
+import { Comision, IndividualAssignment } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -47,6 +47,8 @@ import AdminAssignmentsPage from "./page";
 
 function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
   const assignment = new IndividualAssignment();
+  const comision = new Comision(2026, "sheet-1");
+  comision.activa = true;
   assignment.id = "a1";
   assignment.titulo = "Kata Funcional";
   assignment.descripcion = "Descripción de la kata";
@@ -55,6 +57,7 @@ function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAs
   assignment.paradigma = "funcional";
   assignment.slug = "kata-funcional";
   assignment.createdAt = new Date("2026-01-01");
+  assignment.comision = comision;
   return Object.assign(assignment, overrides);
 }
 
@@ -142,6 +145,41 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("mi-template-especial");
     });
 
+    it("muestra la comisión activa asociada", async () => {
+      const comision = new Comision(2027, "sheet-2");
+      comision.activa = true;
+      mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("2027");
+      expect(html).toContain("Activa");
+    });
+
+    it("muestra comisión histórica cuando no está activa", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      comision.activa = false;
+      mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("2025");
+      expect(html).toContain("Histórica");
+    });
+
+    it("muestra Sin comisión para assignments huérfanos", async () => {
+      mockGetAssignments.mockResolvedValue([
+        makeAssignment({ comision: undefined }),
+      ]);
+
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(html).toContain("Sin comisión");
+    });
+
     it("muestra las cabeceras de la tabla", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
       const element = await AdminAssignmentsPage();
@@ -149,6 +187,7 @@ describe("Admin Assignments page", () => {
       expect(html).toContain("Título");
       expect(html).toContain("Paradigma");
       expect(html).toContain("Tipo");
+      expect(html).toContain("Comisión");
       expect(html).toContain("Template");
       expect(html).toContain("Entregas");
       expect(html).toContain("Deadline");

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -46,11 +46,12 @@ export default async function AdminAssignmentsPage() {
       {sorted.length === 0 ? (
         <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
       ) : (
-        <DataTable columns="2fr 1fr 1fr 1.5fr 90px 110px 180px">
+        <DataTable columns="2fr 1fr 1fr 1fr 1.5fr 90px 110px 180px">
           <DataHeader>
             <DataHeaderCell>Título</DataHeaderCell>
             <DataHeaderCell>Paradigma</DataHeaderCell>
             <DataHeaderCell>Tipo</DataHeaderCell>
+            <DataHeaderCell>Comisión</DataHeaderCell>
             <DataHeaderCell>Template</DataHeaderCell>
             <DataHeaderCell>Entregas</DataHeaderCell>
             <DataHeaderCell>Deadline</DataHeaderCell>
@@ -69,6 +70,24 @@ export default async function AdminAssignmentsPage() {
                 </DataCell>
                 <DataCell label="Tipo">
                   <span className="text-gray-500">{assignment.tipo}</span>
+                </DataCell>
+                <DataCell label="Comisión">
+                  {assignment.comision ? (
+                    <span className="inline-flex items-center gap-1.5 text-xs text-gray-600">
+                      {assignment.comision.anio}
+                      <span
+                        className={`rounded-full px-2 py-0.5 ${
+                          assignment.comision.activa
+                            ? "bg-green-50 text-green-700"
+                            : "bg-gray-100 text-gray-500"
+                        }`}
+                      >
+                        {assignment.comision.activa ? "Activa" : "Histórica"}
+                      </span>
+                    </span>
+                  ) : (
+                    <span className="text-xs text-gray-400">Sin comisión</span>
+                  )}
                 </DataCell>
                 <DataCell label="Template">
                   <span className="font-mono text-xs text-gray-500 break-all">

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -17,7 +17,7 @@ vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
 }));
 
-const { FakeLegajoConflictError } = vi.hoisted(() => {
+const { FakeLegajoConflictError, FakeComisionActivaDuplicadaError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
     constructor(
       public readonly legajo: string,
@@ -29,7 +29,13 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
       this.name = "LegajoConflictError";
     }
   }
-  return { FakeLegajoConflictError };
+  class FakeComisionActivaDuplicadaError extends Error {
+    constructor() {
+      super("Ya existe otra comisión activa.");
+      this.name = "ComisionActivaDuplicadaError";
+    }
+  }
+  return { FakeLegajoConflictError, FakeComisionActivaDuplicadaError };
 });
 
 vi.mock("@/lib/repositories", () => ({
@@ -40,6 +46,7 @@ vi.mock("@/lib/repositories", () => ({
   getAlumnosByComision: (...args: unknown[]) =>
     mockGetAlumnosByComision(...args),
   LegajoConflictError: FakeLegajoConflictError,
+  ComisionActivaDuplicadaError: FakeComisionActivaDuplicadaError,
 }));
 
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
@@ -127,6 +134,25 @@ describe("crearComision", () => {
     );
   });
 
+  it("retorna error de activa si otra request activó una comisión al mismo tiempo", async () => {
+    mockCreateComision.mockRejectedValue(new FakeComisionActivaDuplicadaError());
+
+    const result = await crearComision(
+      null,
+      makeFormData({ ...BASE, activa: "on" })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errors: {
+        activa: [
+          "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+        ],
+      },
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+
   describe("validaciones", () => {
     it("retorna error si falta el año", async () => {
       const result = await crearComision(
@@ -197,6 +223,25 @@ describe("actualizarComision", () => {
     );
     expect(result).toMatchObject({ ok: false });
     expect(mockUpdateComision).not.toHaveBeenCalled();
+  });
+
+  it("retorna error de activa si otra request activó una comisión al mismo tiempo", async () => {
+    mockUpdateComision.mockRejectedValue(new FakeComisionActivaDuplicadaError());
+
+    const result = await actualizarComision(
+      null,
+      makeFormData({ ...BASE, id: "c1", activa: "on" })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      errors: {
+        activa: [
+          "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+        ],
+      },
+    });
+    expect(mockRedirect).not.toHaveBeenCalled();
   });
 });
 

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -6,12 +6,11 @@ const mockRequireAdmin = vi.fn();
 const mockCreateComision = vi.fn();
 const mockUpdateComision = vi.fn();
 const mockGetComision = vi.fn();
-const mockUpsertAlumnos = vi.fn();
 const mockRedirect = vi.fn();
-const mockGetAlumnos = vi.fn();
 const mockGetAsignacionesGrupos = vi.fn();
 const mockGetAlumnosByComision = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
+const mockImportarAlumnosDeComision = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -42,7 +41,6 @@ vi.mock("@/lib/repositories", () => ({
   createComision: (...args: unknown[]) => mockCreateComision(...args),
   updateComision: (...args: unknown[]) => mockUpdateComision(...args),
   getComision: (...args: unknown[]) => mockGetComision(...args),
-  upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
   getAlumnosByComision: (...args: unknown[]) =>
     mockGetAlumnosByComision(...args),
   LegajoConflictError: FakeLegajoConflictError,
@@ -54,8 +52,24 @@ vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
     mockIntentarSincronizarGrupos(...args),
 }));
 
+const { FakeLecturaPlanillaAlumnosError } = vi.hoisted(() => {
+  class FakeLecturaPlanillaAlumnosError extends Error {
+    constructor(cause: unknown) {
+      const message = cause instanceof Error ? cause.message : "Error desconocido";
+      super(`No se pudo leer la planilla: ${message}`);
+      this.name = "LecturaPlanillaAlumnosError";
+    }
+  }
+  return { FakeLecturaPlanillaAlumnosError };
+});
+
+vi.mock("@/lib/services/importarAlumnosDeComision", () => ({
+  importarAlumnosDeComision: (...args: unknown[]) =>
+    mockImportarAlumnosDeComision(...args),
+  LecturaPlanillaAlumnosError: FakeLecturaPlanillaAlumnosError,
+}));
+
 vi.mock("@/lib/sheets", () => ({
-  getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
   getAsignacionesGrupos: (...args: unknown[]) => mockGetAsignacionesGrupos(...args),
 }));
 
@@ -258,8 +272,10 @@ describe("sincronizarAlumnos", () => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(undefined);
     mockGetComision.mockResolvedValue(comisionMock);
-    mockGetAlumnos.mockResolvedValue([]);
-    mockUpsertAlumnos.mockResolvedValue(0);
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 0,
+      conErrorDeGrupo: 0,
+    });
   });
 
   it("siempre llama a requireAdmin", async () => {
@@ -271,11 +287,13 @@ describe("sincronizarAlumnos", () => {
     mockGetComision.mockResolvedValue(null);
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
     expect(result).toEqual({ status: "error", message: "Comisión no encontrada" });
-    expect(mockGetAlumnos).not.toHaveBeenCalled();
+    expect(mockImportarAlumnosDeComision).not.toHaveBeenCalled();
   });
 
   it("retorna error si no se puede leer la planilla", async () => {
-    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+    mockImportarAlumnosDeComision.mockRejectedValue(
+      new FakeLecturaPlanillaAlumnosError(new Error("acceso denegado"))
+    );
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
     expect(result).toEqual({
       status: "error",
@@ -283,41 +301,38 @@ describe("sincronizarAlumnos", () => {
     });
   });
 
-  it("sincroniza correctamente y retorna el conteo", async () => {
-    const alumnos = [
-      { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" },
-      { legajo: "222", nombre: "Beto", apellido: "Ruiz", githubUsername: "beto", email: "b@b.com" },
-    ];
-    mockGetAlumnos.mockResolvedValue(alumnos);
-    mockUpsertAlumnos.mockResolvedValue(2);
+  it("sincroniza correctamente y retorna el conteo con conErrorDeGrupo:0", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 2,
+      conErrorDeGrupo: 0,
+    });
 
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
 
-    expect(result).toEqual({ status: "ok", sincronizados: 2 });
-    expect(mockUpsertAlumnos).toHaveBeenCalledOnce();
+    expect(result).toEqual({ status: "ok", sincronizados: 2, conErrorDeGrupo: 0 });
+    expect(mockImportarAlumnosDeComision).toHaveBeenCalledWith(comisionMock);
   });
 
-  it("llama a upsertAlumnos con la comisión incluida en cada alumno", async () => {
-    const alumno = { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" };
-    mockGetAlumnos.mockResolvedValue([alumno]);
-    mockUpsertAlumnos.mockResolvedValue(1);
+  it("delega la importación al servicio de aplicación", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 1,
+      conErrorDeGrupo: 0,
+    });
 
     await sincronizarAlumnos({ status: "idle" }, makeSync());
 
-    expect(mockUpsertAlumnos).toHaveBeenCalledWith([{ ...alumno, comision: comisionMock }]);
+    expect(mockImportarAlumnosDeComision).toHaveBeenCalledWith(comisionMock);
   });
 
   it("retorna 0 sincronizados si la planilla está vacía", async () => {
-    mockGetAlumnos.mockResolvedValue([]);
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
-    expect(result).toEqual({ status: "ok", sincronizados: 0 });
+    expect(result).toEqual({ status: "ok", sincronizados: 0, conErrorDeGrupo: 0 });
   });
 
-  it("retorna error controlado si upsertAlumnos lanza LegajoConflictError", async () => {
-    mockGetAlumnos.mockResolvedValue([
-      { legajo: "111", nombre: "Ana", apellido: "López", githubUsername: "ana", email: "a@b.com" },
-    ]);
-    mockUpsertAlumnos.mockRejectedValue(new FakeLegajoConflictError("111", "otra-persona"));
+  it("retorna error controlado si el servicio propaga LegajoConflictError", async () => {
+    mockImportarAlumnosDeComision.mockRejectedValue(
+      new FakeLegajoConflictError("111", "otra-persona")
+    );
 
     const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
 
@@ -325,6 +340,17 @@ describe("sincronizarAlumnos", () => {
       status: "error",
       message: "El legajo 111 ya está registrado con el usuario @otra-persona. Verificá que sea el tuyo.",
     });
+  });
+
+  it("cuenta conErrorDeGrupo cuando algún hook de Google Groups falla", async () => {
+    mockImportarAlumnosDeComision.mockResolvedValue({
+      sincronizados: 3,
+      conErrorDeGrupo: 1,
+    });
+
+    const result = await sincronizarAlumnos({ status: "idle" }, makeSync());
+
+    expect(result).toEqual({ status: "ok", sincronizados: 3, conErrorDeGrupo: 1 });
   });
 });
 

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -5,13 +5,16 @@ import {
   createComision,
   updateComision,
   getComision,
-  upsertAlumnos,
   LegajoConflictError,
   getAlumnosByComision,
   ComisionActivaDuplicadaError,
 } from "@/lib/repositories";
-import { getAlumnos, getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
+import { getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
+import {
+  importarAlumnosDeComision,
+  LecturaPlanillaAlumnosError,
+} from "@/lib/services/importarAlumnosDeComision";
 import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
@@ -205,7 +208,7 @@ export async function actualizarComision(
 
 export type SyncState =
   | { status: "idle" }
-  | { status: "ok"; sincronizados: number }
+  | { status: "ok"; sincronizados: number; conErrorDeGrupo: number }
   | { status: "error"; message: string };
 
 export async function sincronizarAlumnos(
@@ -218,25 +221,19 @@ export async function sincronizarAlumnos(
   const comision = await getComision(id);
   if (!comision) return { status: "error", message: "Comisión no encontrada" };
 
-  let alumnos;
   try {
-    alumnos = await getAlumnos(comision.spreadsheetId, comision.columnConfig);
+    const { sincronizados, conErrorDeGrupo } = await importarAlumnosDeComision(comision);
+    revalidatePath("/admin/comisiones");
+    return { status: "ok", sincronizados, conErrorDeGrupo };
   } catch (error) {
-    return { status: "error", message: `No se pudo leer la planilla: ${(error as Error).message}` };
-  }
-
-  let sincronizados: number;
-  try {
-    sincronizados = await upsertAlumnos(alumnos.map((alumno) => ({ ...alumno, comision })));
-  } catch (error) {
+    if (error instanceof LecturaPlanillaAlumnosError) {
+      return { status: "error", message: error.message };
+    }
     if (error instanceof LegajoConflictError) {
       return { status: "error", message: error.message };
     }
     throw error;
   }
-
-  revalidatePath("/admin/comisiones");
-  return { status: "ok", sincronizados };
 }
 
 export type SyncGruposState =

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -8,6 +8,7 @@ import {
   upsertAlumnos,
   LegajoConflictError,
   getAlumnosByComision,
+  ComisionActivaDuplicadaError,
 } from "@/lib/repositories";
 import { getAlumnos, getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
@@ -141,7 +142,26 @@ export async function crearComision(
   }
 
   const { anio, spreadsheetId, activa } = result.data;
-  await createComision({ anio, spreadsheetId, activa, columnConfig: toColumnConfig(result.data) });
+  try {
+    await createComision({
+      anio,
+      spreadsheetId,
+      activa,
+      columnConfig: toColumnConfig(result.data),
+    });
+  } catch (error) {
+    if (error instanceof ComisionActivaDuplicadaError) {
+      return {
+        ok: false,
+        errors: {
+          activa: [
+            "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+          ],
+        },
+      };
+    }
+    throw error;
+  }
   redirect("/admin/comisiones");
 }
 
@@ -160,7 +180,26 @@ export async function actualizarComision(
   }
 
   const { anio, spreadsheetId, activa } = result.data;
-  await updateComision(id, { anio, spreadsheetId, activa, columnConfig: toColumnConfig(result.data) });
+  try {
+    await updateComision(id, {
+      anio,
+      spreadsheetId,
+      activa,
+      columnConfig: toColumnConfig(result.data),
+    });
+  } catch (error) {
+    if (error instanceof ComisionActivaDuplicadaError) {
+      return {
+        ok: false,
+        errors: {
+          activa: [
+            "Otra comisión fue activada al mismo tiempo. Recargá la página y volvé a intentar.",
+          ],
+        },
+      };
+    }
+    throw error;
+  }
   redirect("/admin/comisiones");
 }
 

--- a/src/app/admin/comisiones/sync-button.tsx
+++ b/src/app/admin/comisiones/sync-button.tsx
@@ -29,6 +29,9 @@ export function SyncButton({ comisionId }: { comisionId: string }) {
       {state.status === "ok" && (
         <span className="text-xs text-green-600 font-medium">
           {state.sincronizados} sincronizados
+          {state.conErrorDeGrupo > 0 && (
+            <span className="text-amber-600"> · {state.conErrorDeGrupo} sin grupo</span>
+          )}
         </span>
       )}
       {state.status === "error" && (

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -1,23 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
-import {
-  IndividualAssignment,
-  GrupalAssignment,
-  Entrega,
-  type Assignment,
-} from "@/domain/entities";
+import { Entrega, GrupoNoAsignadoError } from "@/domain/entities";
 
-// ── Mocks ────────────────────────────────────────────────────
-
-const mockRequireUser = vi.fn();
-const mockCheckRateLimit = vi.fn();
-const mockGetAssignment = vi.fn();
-const mockGetEntregaDeUsuario = vi.fn();
-const mockCreateEntrega = vi.fn();
-const mockCrearEntrega = vi.fn();
-const mockRepoExists = vi.fn();
-const mockAddCollaborators = vi.fn();
-const mockGetGrupoDeAlumno = vi.fn();
+const {
+  mockRequireUser,
+  mockCheckRateLimit,
+  mockAceptarAssignment,
+  FakeAlumnoNoRegistradoError,
+  FakeAssignmentNoEncontradoError,
+} = vi.hoisted(() => ({
+  mockRequireUser: vi.fn(),
+  mockCheckRateLimit: vi.fn(),
+  mockAceptarAssignment: vi.fn(),
+  FakeAlumnoNoRegistradoError: class AlumnoNoRegistradoError extends Error {},
+  FakeAssignmentNoEncontradoError: class AssignmentNoEncontradoError extends Error {},
+}));
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
@@ -27,24 +24,16 @@ vi.mock("@/lib/rate-limit", () => ({
   checkRateLimit: (key: string) => mockCheckRateLimit(key),
 }));
 
-vi.mock("@/lib/repositories", () => ({
-  getAssignment: (id: string) => mockGetAssignment(id),
-  getEntregaDeUsuario: (assignmentId: string, username: string) =>
-    mockGetEntregaDeUsuario(assignmentId, username),
-  createEntrega: (data: unknown) => mockCreateEntrega(data),
-  getGrupoDeAlumnoEnAssignment: (assignmentId: string, username: string) =>
-    mockGetGrupoDeAlumno(assignmentId, username),
-}));
-
-vi.mock("@/lib/github", () => ({
-  crearEntrega: (opts: unknown) => mockCrearEntrega(opts),
-  repoExists: (name: string) => mockRepoExists(name),
-  addCollaborators: (repoName: string, usernames: string[]) => mockAddCollaborators(repoName, usernames),
-}));
+vi.mock("@/lib/services/aceptarAssignment", () => {
+  return {
+    aceptarAssignment: (assignmentId: string, user: PdepUser) =>
+      mockAceptarAssignment(assignmentId, user),
+    AlumnoNoRegistradoError: FakeAlumnoNoRegistradoError,
+    AssignmentNoEncontradoError: FakeAssignmentNoEncontradoError,
+  };
+});
 
 import { POST } from "./route";
-
-// ── Helpers ──────────────────────────────────────────────────
 
 function makeUser(overrides?: Partial<PdepUser>): PdepUser {
   return {
@@ -54,23 +43,6 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
     isAdmin: false,
     ...overrides,
   };
-}
-
-type AssignmentOverrides = Partial<IndividualAssignment & GrupalAssignment>;
-
-function makeAssignment(overrides?: AssignmentOverrides): Assignment {
-  const assignment: Assignment =
-    overrides?.tipo === "grupal"
-      ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
-      : new IndividualAssignment();
-  assignment.id = "a1";
-  assignment.titulo = "Kata Funcional";
-  assignment.descripcion = "";
-  assignment.templateRepo = "kata-template";
-  assignment.paradigma = "funcional";
-  assignment.slug = "kata-funcional";
-  assignment.createdAt = new Date("2026-01-01");
-  return Object.assign(assignment, overrides);
 }
 
 function makeEntrega(overrides?: Partial<Entrega>): Entrega {
@@ -89,172 +61,57 @@ function makeRequest(): Request {
   });
 }
 
-// ── Tests ────────────────────────────────────────────────────
-
 describe("POST /api/assignments/[id]/accept", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireUser.mockResolvedValue(makeUser());
     mockCheckRateLimit.mockReturnValue(true);
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregaDeUsuario.mockResolvedValue(undefined);
-    mockRepoExists.mockResolvedValue(false);
-    mockCrearEntrega.mockResolvedValue({
-      repoName: "kata-funcional-juangarcia",
-      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
-    });
-    mockCreateEntrega.mockResolvedValue(makeEntrega());
+    mockAceptarAssignment.mockResolvedValue(makeEntrega());
   });
 
-  describe("rate limiting", () => {
-    it("devuelve 429 cuando el rate limit está activo", async () => {
-      mockCheckRateLimit.mockReturnValue(false);
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(429);
-      const data = await response.json();
-      expect(data.error).toBeDefined();
-    });
-
-    it("pasa la clave correcta al rate limiter (username:assignmentId)", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCheckRateLimit).toHaveBeenCalledWith("juangarcia:a1");
-    });
-
-    it("no consulta el store si el rate limit bloquea", async () => {
-      mockCheckRateLimit.mockReturnValue(false);
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockGetAssignment).not.toHaveBeenCalled();
-    });
+  it("devuelve 429 cuando el rate limit está activo", async () => {
+    mockCheckRateLimit.mockReturnValue(false);
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(429);
+    expect(mockAceptarAssignment).not.toHaveBeenCalled();
   });
 
-  describe("autenticación", () => {
-    it("devuelve 500 si requireUser lanza (no autenticado)", async () => {
-      mockRequireUser.mockRejectedValue(new Error("redirect"));
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(500);
-    });
+  it("pasa la clave correcta al rate limiter", async () => {
+    await POST(makeRequest(), { params: { id: "a1" } });
+    expect(mockCheckRateLimit).toHaveBeenCalledWith("juangarcia:a1");
   });
 
-  describe("validaciones", () => {
-    it("devuelve 404 si el assignment no existe", async () => {
-      mockGetAssignment.mockResolvedValue(undefined);
-      const response = await POST(makeRequest(), { params: { id: "no-existe" } });
-      expect(response.status).toBe(404);
-    });
-
-    it("devuelve 409 si el usuario ya tiene entrega", async () => {
-      mockGetEntregaDeUsuario.mockResolvedValue(makeEntrega());
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(409);
-    });
-
-    it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(undefined);
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(400);
-    });
+  it("devuelve 200 con la entrega del servicio", async () => {
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.repoName).toBe("kata-funcional-juangarcia");
+    expect(mockAceptarAssignment).toHaveBeenCalledWith("a1", expect.objectContaining({
+      githubUsername: "juangarcia",
+    }));
   });
 
-  describe("creación exitosa (individual)", () => {
-    it("devuelve 200 con la entrega creada", async () => {
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-      const data = await response.json();
-      expect(data.repoName).toBe("kata-funcional-juangarcia");
-    });
-
-    it("llama a crearEntrega con los parámetros correctos", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCrearEntrega).toHaveBeenCalledWith(
-        expect.objectContaining({
-          templateRepo: "kata-template",
-          slug: "kata-funcional",
-          usernames: ["juangarcia"],
-        })
-      );
-    });
+  it("devuelve 404 si el assignment no existe", async () => {
+    mockAceptarAssignment.mockRejectedValue(new FakeAssignmentNoEncontradoError("Assignment no encontrado"));
+    const response = await POST(makeRequest(), { params: { id: "no-existe" } });
+    expect(response.status).toBe(404);
   });
 
-  describe("creación exitosa (grupal)", () => {
-    function makeGrupo(githubUsernames: string[], id = "los-lambdas") {
-      return {
-        id,
-        nombre: "Los Lambdas",
-        alumnos: { getItems: () => githubUsernames.map((username) => ({ githubUsername: username })) },
-        usernamesDeMiembros: () => githubUsernames,
-      };
-    }
-
-    it("devuelve 200 con la entrega creada para el grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(
-        makeGrupo(["juangarcia", "mariaperez"])
-      );
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-los-lambdas",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
-      });
-      mockCreateEntrega.mockResolvedValue(
-        makeEntrega({ repoName: "kata-funcional-los-lambdas" })
-      );
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-    });
-
-    it("llama a crearEntrega con los usernames del grupo", async () => {
-      mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
-      mockGetGrupoDeAlumno.mockResolvedValue(
-        makeGrupo(["juangarcia", "mariaperez"])
-      );
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-los-lambdas",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
-      });
-      mockCreateEntrega.mockResolvedValue(makeEntrega());
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockCrearEntrega).toHaveBeenCalledWith(
-        expect.objectContaining({
-          usernames: ["juangarcia", "mariaperez"],
-          grupoId: "los-lambdas",
-        })
-      );
-    });
-
-    it("busca el grupo por assignmentId, no por paradigma", async () => {
-      mockGetAssignment.mockResolvedValue(
-        makeAssignment({ id: "a1", tipo: "grupal" })
-      );
-      mockGetGrupoDeAlumno.mockResolvedValue(makeGrupo(["juangarcia"], "g1"));
-      mockCrearEntrega.mockResolvedValue({
-        repoName: "kata-funcional-grupo-x",
-        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-grupo-x",
-      });
-      mockCreateEntrega.mockResolvedValue(makeEntrega());
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockGetGrupoDeAlumno).toHaveBeenCalledWith("a1", "juangarcia");
-    });
+  it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
+    mockAceptarAssignment.mockRejectedValue(new GrupoNoAsignadoError("a1", "juangarcia"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
   });
 
-  describe("repo ya existe", () => {
-    beforeEach(() => {
-      mockRepoExists.mockResolvedValue(true);
-      mockAddCollaborators.mockResolvedValue(undefined);
-    });
+  it("devuelve 400 si el alumno no está registrado para una entrega individual", async () => {
+    mockAceptarAssignment.mockRejectedValue(new FakeAlumnoNoRegistradoError("Completá tu registro"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(400);
+  });
 
-    it("registra la entrega sin crear un nuevo repo si ya existe", async () => {
-      const response = await POST(makeRequest(), { params: { id: "a1" } });
-      expect(response.status).toBe(200);
-      expect(mockCrearEntrega).not.toHaveBeenCalled();
-      expect(mockCreateEntrega).toHaveBeenCalled();
-    });
-
-    it("agrega al usuario como colaborador del repo existente", async () => {
-      await POST(makeRequest(), { params: { id: "a1" } });
-      expect(mockAddCollaborators).toHaveBeenCalledWith(
-        expect.any(String),
-        ["juangarcia"]
-      );
-    });
+  it("devuelve 500 si requireUser lanza", async () => {
+    mockRequireUser.mockRejectedValue(new Error("redirect"));
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -91,6 +91,48 @@ describe("POST /api/assignments/[id]/accept", () => {
     }));
   });
 
+  it("mantiene idempotencia si se acepta dos veces el mismo assignment", async () => {
+    const entrega = makeEntrega();
+    mockAceptarAssignment.mockResolvedValue(entrega);
+
+    const firstResponse = await POST(makeRequest(), { params: { id: "a1" } });
+    const secondResponse = await POST(makeRequest(), { params: { id: "a1" } });
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    const firstData = await firstResponse.json();
+    const secondData = await secondResponse.json();
+    expect(firstData.id).toBe(secondData.id);
+    expect(firstData.repoName).toBe(secondData.repoName);
+    expect(mockAceptarAssignment).toHaveBeenCalledTimes(2);
+  });
+
+  it("mantiene una única entrega ante aceptación concurrente por miembros del mismo grupo", async () => {
+    const entrega = makeEntrega({
+      id: "e-grupo",
+      repoName: "kata-funcional-los-lambdas",
+      githubUsernames: ["juangarcia", "marialopez"],
+    });
+    mockRequireUser
+      .mockResolvedValueOnce(makeUser({ githubUsername: "juangarcia" }))
+      .mockResolvedValueOnce(makeUser({ githubUsername: "marialopez" }));
+    mockAceptarAssignment.mockResolvedValue(entrega);
+
+    const [firstResponse, secondResponse] = await Promise.all([
+      POST(makeRequest(), { params: { id: "a1" } }),
+      POST(makeRequest(), { params: { id: "a1" } }),
+    ]);
+
+    expect(firstResponse.status).toBe(200);
+    expect(secondResponse.status).toBe(200);
+    const firstData = await firstResponse.json();
+    const secondData = await secondResponse.json();
+    expect(firstData.id).toBe("e-grupo");
+    expect(secondData.id).toBe("e-grupo");
+    expect(firstData.repoName).toBe("kata-funcional-los-lambdas");
+    expect(secondData.repoName).toBe("kata-funcional-los-lambdas");
+  });
+
   it("devuelve 404 si el assignment no existe", async () => {
     mockAceptarAssignment.mockRejectedValue(new FakeAssignmentNoEncontradoError("Assignment no encontrado"));
     const response = await POST(makeRequest(), { params: { id: "no-existe" } });

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -1,11 +1,13 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
-import { getAssignment, getEntregaDeUsuario, createEntrega, getGrupoDeAlumnoEnAssignment } from "@/lib/repositories";
-import { GrupoNoAsignadoError, type ParticipantesResueltos } from "@/domain/entities";
-import { crearEntrega, repoExists, addCollaborators } from "@/lib/github";
-import { buildRepoName } from "@/lib/naming";
+import { GrupoNoAsignadoError } from "@/domain/entities";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { internalServerError } from "@/lib/api-errors";
+import {
+  aceptarAssignment,
+  AlumnoNoRegistradoError,
+  AssignmentNoEncontradoError,
+} from "@/lib/services/aceptarAssignment";
 
 export async function POST(
   _req: Request,
@@ -21,77 +23,15 @@ export async function POST(
       );
     }
 
-    const assignment = await getAssignment(params.id);
-
-    if (!assignment) {
-      return NextResponse.json({ error: "Assignment no encontrado" }, { status: 404 });
-    }
-
-    // ── Ya tiene entrega? ────────────────────────────────────
-    const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
-    if (existente) {
-      return NextResponse.json(
-        { error: "Ya aceptaste este assignment", repoUrl: existente.repoUrl },
-        { status: 409 }
-      );
-    }
-
-    // ── Determinar quiénes van al repo ───────────────────────
-    let participantes: ParticipantesResueltos;
-    try {
-      participantes = await assignment.resolverParticipantesPara(
-        user,
-        getGrupoDeAlumnoEnAssignment
-      );
-    } catch (error) {
-      if (error instanceof GrupoNoAsignadoError) {
-        return NextResponse.json({ error: error.message }, { status: 400 });
-      }
-      throw error;
-    }
-    const { usernames, grupoId } = participantes;
-
-    const templateRepo = assignment.nombreDelTemplate();
-
-    // ── Nombre del repo ──────────────────────────────────────
-    const candidateRepoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
-
-    // Verificar que no exista ya (por si otro miembro del grupo aceptó primero)
-    if (await repoExists(candidateRepoName)) {
-      // El repo fue creado por otro miembro: agregar al usuario actual como
-      // colaborador y registrar la entrega. Sin este addCollaborators el
-      // alumno quedaría sin acceso al repo que ya existe en GitHub.
-      await addCollaborators(candidateRepoName, [user.githubUsername]);
-      const org = process.env.GITHUB_ORG ?? "pdep-mn-utn";
-      const entrega = await createEntrega({
-        assignmentId: assignment.id,
-        repoName: candidateRepoName,
-        repoUrl: `https://github.com/${org}/${candidateRepoName}`,
-        githubUsernames: usernames,
-        grupoId,
-      });
-      return NextResponse.json(entrega);
-    }
-
-    // ── Crear repo y dar acceso ──────────────────────────────
-    const resultado = await crearEntrega({
-      templateRepo,
-      slug: assignment.slug,
-      usernames,
-      grupoId,
-      descripcion: `${assignment.titulo} — PdeP`,
-    });
-
-    const entrega = await createEntrega({
-      assignmentId: assignment.id,
-      repoName: resultado.repoName,
-      repoUrl: resultado.repoUrl,
-      githubUsernames: usernames,
-      grupoId,
-    });
-
+    const entrega = await aceptarAssignment(params.id, user);
     return NextResponse.json(entrega);
   } catch (error) {
+    if (error instanceof AssignmentNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof GrupoNoAsignadoError || error instanceof AlumnoNoRegistradoError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
+    }
     return internalServerError(
       "POST /api/assignments/[id]/accept",
       error,

--- a/src/app/api/assignments/[id]/route.test.ts
+++ b/src/app/api/assignments/[id]/route.test.ts
@@ -124,4 +124,18 @@ describe("PATCH /api/assignments/[id]", () => {
     await PATCH(request, { params: { id: "a1" } });
     expect(mockUpdateAssignment).toHaveBeenCalledWith("a1", { paradigma: "logico" });
   });
+
+  it("devuelve 400 con formErrors cuando el body no es JSON válido o es null", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment());
+    const request = new Request("http://localhost/api/assignments/a1", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    const response = await PATCH(request, { params: { id: "a1" } });
+    expect(response.status).toBe(400);
+    const data = await response.json();
+    expect(data.formErrors).toBeDefined();
+    expect(data.formErrors.length).toBeGreaterThan(0);
+  });
 });

--- a/src/app/api/assignments/[id]/route.ts
+++ b/src/app/api/assignments/[id]/route.ts
@@ -34,8 +34,9 @@ export async function PATCH(
   const body = await req.json().catch(() => null);
   const parsed = AssignmentBaseSchema.partial().safeParse(body);
   if (!parsed.success) {
+    const { fieldErrors, formErrors } = parsed.error.flatten();
     return NextResponse.json(
-      { error: "Datos inválidos", fields: parsed.error.flatten().fieldErrors },
+      { error: "Datos inválidos", fields: fieldErrors, formErrors },
       { status: 400 }
     );
   }

--- a/src/app/api/assignments/[id]/route.ts
+++ b/src/app/api/assignments/[id]/route.ts
@@ -31,7 +31,7 @@ export async function PATCH(
     return NextResponse.json({ error: "Assignment no encontrado" }, { status: 404 });
   }
 
-  const body = await req.json();
+  const body = await req.json().catch(() => null);
   const parsed = AssignmentBaseSchema.partial().safeParse(body);
   if (!parsed.success) {
     return NextResponse.json(

--- a/src/app/api/perfil/route.test.ts
+++ b/src/app/api/perfil/route.test.ts
@@ -3,52 +3,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockRequireUser = vi.fn();
-const mockUpsertarAlumnoEnSheets = vi.fn();
-const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
-const mockMarcarRegistroConfirmado = vi.fn();
-const mockIntentarSincronizarGrupos = vi.fn();
+const mockConfirmarYProcesarAlumno = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
-  return {
-    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-    validateRegistro: actual.validateRegistro,
-  };
-});
-
-const { FakeLegajoConflictError } = vi.hoisted(() => {
-  class FakeLegajoConflictError extends Error {
-    constructor(
-      public readonly legajo: string,
-      public readonly otroGithubUsername: string
-    ) {
-      super(
-        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
-      );
-      this.name = "LegajoConflictError";
-    }
-  }
-  return { FakeLegajoConflictError };
-});
-
-vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
-  marcarRegistroConfirmado: (...args: unknown[]) =>
-    mockMarcarRegistroConfirmado(...args),
-  LegajoConflictError: FakeLegajoConflictError,
-}));
-
-// El handler llama al wrapper `intentarSincronizarGrupos`, que encapsula
-// log + flag persistente + retorno booleano para el handler.
-vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
-  intentarSincronizarGrupos: (...args: unknown[]) =>
-    mockIntentarSincronizarGrupos(...args),
+vi.mock("@/lib/services/alumnoRegistro", () => ({
+  confirmarYProcesarAlumno: (...args: unknown[]) =>
+    mockConfirmarYProcesarAlumno(...args),
 }));
 
 import { PATCH } from "./route";
@@ -81,120 +44,106 @@ describe("PATCH /api/perfil", () => {
       image: "",
       isAdmin: false,
     });
-    mockGetComisionActiva.mockResolvedValue({
-      id: "c1",
-      spreadsheetId: "sheet-xyz",
-      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "already_member", gruposSync: "ok" },
     });
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
-    mockUpsertAlumno.mockResolvedValue(undefined);
-    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
-    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
-  it("actualiza Sheets y DB en un mismo request", async () => {
+  it("devuelve 200 con hooks en body cuando todo funciona", async () => {
     const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
     expect(response.status).toBe(200);
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledTimes(1);
-    expect(mockUpsertAlumno).toHaveBeenCalledTimes(1);
+    expect(json).toEqual({ ok: true, groupSubscription: "already_member" });
+  });
+
+  it("no incluye gruposSync en el body cuando el hook no falla", async () => {
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(json.gruposSync).toBeUndefined();
+  });
+
+  it("incluye gruposSync:'error' cuando el hook de sync falla", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "already_member", gruposSync: "error" },
+    });
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.gruposSync).toBe("error");
   });
 
   it("usa el githubUsername del usuario autenticado (no del body)", async () => {
     await PATCH(makeRequest({ ...validBody, githubUsername: "attacker" }));
-    const [inputPasado] = mockUpsertAlumno.mock.calls[0];
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
-  it("marca registroConfirmadoEn recién después de que Sheets confirmó", async () => {
-    const comision = await mockGetComisionActiva();
-    await PATCH(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
-    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
-    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
-  });
-
-  it("no marca registroConfirmadoEn si Sheets falla", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({
-      ok: false,
-      error: "sheets error",
+  it("la respuesta incluye groupSubscription (perfil también suscribe al grupo)", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added" },
     });
-    await PATCH(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
-  });
-
-  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
     const response = await PATCH(makeRequest(validBody));
-    expect(response.status).toBe(400);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    const json = await response.json();
+    expect(json.groupSubscription).toBe("added");
   });
 
-  it("devuelve 400 con field=legajo si el upsert en DB detecta conflicto de legajo", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con el error del servicio cuando ok:false", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El email es inválido",
+    });
+    const response = await PATCH(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(400);
+    expect(json.error).toBe("El email es inválido");
+    expect(json.field).toBeUndefined();
+  });
+
+  it("devuelve 400 con field cuando el servicio devuelve field", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El legajo ya está registrado con otro usuario",
+      field: "legajo",
+    });
     const response = await PATCH(makeRequest(validBody));
     const json = await response.json();
     expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
-    expect(json.error).toContain("otro-alumno");
   });
 
-  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const response = await PATCH(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(response.status).toBe(400);
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-  });
-
-  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
-    mockGetComisionActiva.mockResolvedValue(null);
+  it("devuelve 409 cuando el servicio devuelve status 409", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "No hay comisión activa",
+    });
     const response = await PATCH(makeRequest(validBody));
     expect(response.status).toBe(409);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
-    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await PATCH(makeRequest(validBody));
     expect(response.status).toBe(500);
   });
 
-  describe("sincronización de grupos desde planilla", () => {
-    it("llama a intentarSincronizarGrupos con el github de la sesión y la comisión activa", async () => {
-      const comision = await mockGetComisionActiva();
-      await PATCH(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
-        "juangarcia",
-        comision
-      );
-    });
-
-    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const response = await PATCH(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBeUndefined();
-    });
-
-    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
-      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
-
-      const response = await PATCH(makeRequest(validBody));
-      const json = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBe("error");
-      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
-    });
-
-    it("no intenta sincronizar si la confirmación del perfil falla antes", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-      await PATCH(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
-    });
+  it("devuelve 400 si el body no es un objeto", async () => {
+    const response = await PATCH(
+      new Request("http://localhost/api/perfil", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify("cadena"),
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
   });
 });

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
-import { internalServerError } from "@/lib/api-errors";
+import { internalServerError, parseJsonObjectBody } from "@/lib/api-errors";
 import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
@@ -9,13 +9,8 @@ type PerfilInput = Omit<RegistroInput, "githubUsername">;
 export async function PATCH(req: Request) {
   try {
     const user = await requireUser();
-    const body = await req.json();
-    if (typeof body !== "object" || body === null || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
-        { status: 400 }
-      );
-    }
+    const body = await parseJsonObjectBody(req);
+    if (body instanceof NextResponse) return body;
 
     const resultado = await confirmarYProcesarAlumno({
       ...(body as PerfilInput),

--- a/src/app/api/perfil/route.ts
+++ b/src/app/api/perfil/route.ts
@@ -2,8 +2,7 @@ import { NextResponse } from "next/server";
 import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { internalServerError } from "@/lib/api-errors";
-import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
-import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
+import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 type PerfilInput = Omit<RegistroInput, "githubUsername">;
 
@@ -18,7 +17,7 @@ export async function PATCH(req: Request) {
       );
     }
 
-    const resultado = await confirmarDatosAlumno({
+    const resultado = await confirmarYProcesarAlumno({
       ...(body as PerfilInput),
       githubUsername: user.githubUsername,
     });
@@ -31,19 +30,10 @@ export async function PATCH(req: Request) {
       );
     }
 
-    // Los datos del alumno ya se actualizaron. Si el sync falla, el wrapper
-    // marca el flag en DB para disparar el retry automático en /perfil —
-    // degradamos la respuesta a `gruposSync: "error"` para el warning inmediato.
-    let gruposSyncFallida = false;
-    try {
-      await intentarSincronizarGrupos(user.githubUsername, resultado.comision);
-    } catch {
-      gruposSyncFallida = true;
-    }
-
     return NextResponse.json({
       ok: true,
-      ...(gruposSyncFallida && { gruposSync: "error" }),
+      groupSubscription: resultado.hooks.groupSubscription,
+      ...(resultado.hooks.gruposSync === "error" && { gruposSync: "error" }),
     });
   } catch (error) {
     return internalServerError("PATCH /api/perfil", error);

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -3,58 +3,15 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockRequireUser = vi.fn();
-const mockUpsertarAlumnoEnSheets = vi.fn();
-const mockGetComisionActiva = vi.fn();
-const mockUpsertAlumno = vi.fn();
-const mockMarcarRegistroConfirmado = vi.fn();
-const mockAgregarMiembroAGrupo = vi.fn();
-const mockIntentarSincronizarGrupos = vi.fn();
+const mockConfirmarYProcesarAlumno = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireUser: () => mockRequireUser(),
 }));
 
-vi.mock("@/lib/sheets", async () => {
-  const actual = await vi.importActual<typeof import("@/lib/sheets")>("@/lib/sheets");
-  return {
-    upsertarAlumnoEnSheets: (...args: unknown[]) => mockUpsertarAlumnoEnSheets(...args),
-    validateRegistro: actual.validateRegistro,
-  };
-});
-
-const { FakeLegajoConflictError } = vi.hoisted(() => {
-  class FakeLegajoConflictError extends Error {
-    constructor(
-      public readonly legajo: string,
-      public readonly otroGithubUsername: string
-    ) {
-      super(
-        `El legajo ${legajo} ya está registrado con el usuario @${otroGithubUsername}. Verificá que sea el tuyo.`
-      );
-      this.name = "LegajoConflictError";
-    }
-  }
-  return { FakeLegajoConflictError };
-});
-
-vi.mock("@/lib/repositories", () => ({
-  getComisionActiva: () => mockGetComisionActiva(),
-  upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
-  marcarRegistroConfirmado: (...args: unknown[]) =>
-    mockMarcarRegistroConfirmado(...args),
-  LegajoConflictError: FakeLegajoConflictError,
-}));
-
-vi.mock("@/lib/googleGroups", () => ({
-  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
-}));
-
-// El handler llama al wrapper `intentarSincronizarGrupos`, que es quien se
-// encarga del logging y de persistir el flag. Si throwea, el handler lo
-// captura y degrada la respuesta a `gruposSync: "error"`.
-vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
-  intentarSincronizarGrupos: (...args: unknown[]) =>
-    mockIntentarSincronizarGrupos(...args),
+vi.mock("@/lib/services/alumnoRegistro", () => ({
+  confirmarYProcesarAlumno: (...args: unknown[]) =>
+    mockConfirmarYProcesarAlumno(...args),
 }));
 
 import { POST } from "./route";
@@ -74,7 +31,7 @@ const validBody = {
   apellido: "García",
   nombre: "Juan",
   email: "juan@gmail.com",
-  githubUsername: "juangarcia", // debe coincidir con el user autenticado del mock
+  githubUsername: "juangarcia",
 };
 
 // ── Tests ────────────────────────────────────────────────────
@@ -88,22 +45,47 @@ describe("POST /api/registro", () => {
       image: "",
       isAdmin: false,
     });
-    mockGetComisionActiva.mockResolvedValue({
-      id: "c1",
-      spreadsheetId: "sheet-xyz",
-      columnConfig: { sheetName: "Alumnos", headerRows: 1, legajo: 0, apellido: 1, nombre: 2, githubUsername: 3, email: 4 },
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added", gruposSync: "ok" },
     });
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
-    mockUpsertAlumno.mockResolvedValue(undefined);
-    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("devuelve 200 con hooks en body cuando todo funciona", async () => {
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json).toEqual({ ok: true, groupSubscription: "added" });
+  });
+
+  it("no incluye gruposSync en el body cuando el hook no falla", async () => {
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(json.gruposSync).toBeUndefined();
+  });
+
+  it("incluye gruposSync:'error' cuando el hook de sync falla", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: true,
+      comision: { id: "c1" },
+      hooks: { groupSubscription: "added", gruposSync: "error" },
+    });
+    const response = await POST(makeRequest(validBody));
+    const json = await response.json();
+    expect(response.status).toBe(200);
+    expect(json.gruposSync).toBe("error");
+  });
+
+  it("pasa el email del body como email en el contexto al servicio", async () => {
+    await POST(makeRequest(validBody));
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
+    expect(inputPasado.email).toBe("juan@gmail.com");
   });
 
   it("usa el githubUsername del usuario autenticado cuando coincide con el body", async () => {
-    const response = await POST(makeRequest(validBody));
-    expect(response.status).toBe(200);
-    const [inputPasado] = mockUpsertarAlumnoEnSheets.mock.calls[0];
+    await POST(makeRequest(validBody));
+    const [inputPasado] = mockConfirmarYProcesarAlumno.mock.calls[0];
     expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
@@ -114,214 +96,92 @@ describe("POST /api/registro", () => {
     expect(json.field).toBe("githubUsername");
     expect(json.error).toContain("juangarcia");
     expect(json.error).toContain("attacker");
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
   });
 
   it("compara githubUsername case-insensitive (no rechaza JuanGarcia vs juangarcia)", async () => {
     const response = await POST(makeRequest({ ...validBody, githubUsername: "JuanGarcia" }));
     expect(response.status).toBe(200);
-    const [inputPasado] = mockUpsertAlumno.mock.calls[0];
-    expect(inputPasado.githubUsername).toBe("juangarcia");
   });
 
-  it("llama a upsertarAlumnoEnSheets con el spreadsheetId y columnConfig de la comisión activa", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockUpsertarAlumnoEnSheets).toHaveBeenCalledWith(
-      expect.any(Object),
-      "sheet-xyz",
-      comision.columnConfig
-    );
-  });
-
-  it("llama a upsertAlumno con comision pero sin registroConfirmadoEn (se marca recién después de Sheets)", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockUpsertAlumno).toHaveBeenCalledWith(
-      expect.objectContaining({
-        legajo: "12345",
-        githubUsername: "juangarcia",
-        email: "juan@gmail.com",
-        comision,
-      })
-    );
-    const [dataPasada] = mockUpsertAlumno.mock.calls[0];
-    expect(dataPasada.registroConfirmadoEn).toBeUndefined();
-  });
-
-  it("marca registroConfirmadoEn después de que Sheets confirmó la escritura", async () => {
-    const comision = await mockGetComisionActiva();
-    await POST(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).toHaveBeenCalledWith("juangarcia", comision);
-    const ordenLlamadas = [
-      mockUpsertarAlumnoEnSheets.mock.invocationCallOrder[0],
-      mockMarcarRegistroConfirmado.mock.invocationCallOrder[0],
-    ];
-    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
-  });
-
-  it("no marca registroConfirmadoEn si Sheets falla (evita commit parcial)", async () => {
-    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-    await POST(makeRequest(validBody));
-    expect(mockMarcarRegistroConfirmado).not.toHaveBeenCalled();
-  });
-
-  it("no toca Sheets si el upsert en DB falla con LegajoConflictError", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con el error del servicio cuando ok:false", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El email es inválido",
+    });
     const response = await POST(makeRequest(validBody));
+    const json = await response.json();
     expect(response.status).toBe(400);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
+    expect(json.error).toBe("El email es inválido");
+    expect(json.field).toBeUndefined();
   });
 
-  it("devuelve 400 con field=legajo si el upsert en DB detecta que el legajo pertenece a otro github", async () => {
-    mockUpsertAlumno.mockRejectedValue(
-      new FakeLegajoConflictError("12345", "otro-alumno")
-    );
+  it("devuelve 400 con field cuando el servicio devuelve field", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 400,
+      error: "El legajo ya está registrado con otro usuario",
+      field: "legajo",
+    });
     const response = await POST(makeRequest(validBody));
     const json = await response.json();
     expect(response.status).toBe(400);
     expect(json.field).toBe("legajo");
-    expect(json.error).toContain("otro-alumno");
   });
 
-  it("devuelve 400 si la validación de inputs falla sin tocar DB ni Sheets", async () => {
-    const response = await POST(makeRequest({ ...validBody, email: "no-es-email" }));
-    expect(response.status).toBe(400);
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-  });
-
-  it("devuelve 409 sin tocar Sheets ni DB si no hay comisión activa", async () => {
-    mockGetComisionActiva.mockResolvedValue(null);
+  it("devuelve 409 cuando el servicio devuelve status 409", async () => {
+    mockConfirmarYProcesarAlumno.mockResolvedValue({
+      ok: false,
+      status: 409,
+      error: "No hay comisión activa",
+    });
     const response = await POST(makeRequest(validBody));
     expect(response.status).toBe(409);
-    expect(mockUpsertarAlumnoEnSheets).not.toHaveBeenCalled();
-    expect(mockUpsertAlumno).not.toHaveBeenCalled();
   });
 
   it("devuelve 500 si algo tira un error inesperado", async () => {
-    mockUpsertarAlumnoEnSheets.mockRejectedValue(new Error("boom"));
+    mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await POST(makeRequest(validBody));
     expect(response.status).toBe(500);
     const json = await response.json();
-    // El mensaje del error interno no debe filtrarse al cliente.
     expect(json.error).toBe("Error interno del servidor");
     expect(json.error).not.toContain("boom");
   });
 
-  // ── Suscripción al Google Group ────────────────────────────
-
   describe("suscripción al Google Group", () => {
-    it("llama a agregarMiembroAGrupo con el email del alumno tras un registro exitoso", async () => {
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("juan@gmail.com");
-    });
-
-    it("devuelve groupSubscription: 'added' en el body cuando la suscripción funciona", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    it("devuelve groupSubscription:'added'", async () => {
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json).toEqual({ ok: true, groupSubscription: "added" });
+      expect(json.groupSubscription).toBe("added");
     });
 
-    it("devuelve groupSubscription: 'already_member' cuando el alumno ya estaba en el grupo", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
+    it("devuelve groupSubscription:'already_member'", async () => {
+      mockConfirmarYProcesarAlumno.mockResolvedValue({
+        ok: true,
+        comision: { id: "c1" },
+        hooks: { groupSubscription: "already_member" },
+      });
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
-      expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("already_member");
     });
 
-    it("devuelve groupSubscription: 'skipped' cuando la feature está desactivada", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.groupSubscription).toBe("skipped");
-    });
-
-    it("no rompe el registro si la suscripción falla (responde 200 con status 'error')", async () => {
-      mockAgregarMiembroAGrupo.mockResolvedValue({
-        status: "error",
-        error: "Sin permisos",
+    it("devuelve groupSubscription:'error' sin romper el registro", async () => {
+      mockConfirmarYProcesarAlumno.mockResolvedValue({
+        ok: true,
+        comision: { id: "c1" },
+        hooks: { groupSubscription: "error" },
       });
       const response = await POST(makeRequest(validBody));
       const json = await response.json();
       expect(response.status).toBe(200);
       expect(json.groupSubscription).toBe("error");
-      // El alta en DB ya ocurrió antes de intentar la suscripción
-      expect(mockUpsertAlumno).toHaveBeenCalledOnce();
     });
 
-    it("enmascara el email en el log de error para no exponer PII", async () => {
-      const { logger } = await import("@/lib/logger");
-      const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-      mockAgregarMiembroAGrupo.mockResolvedValue({
-        status: "error",
-        error: "Sin permisos",
-      });
-      await POST(makeRequest(validBody));
-      const loggedPayload = JSON.stringify(errorSpy.mock.calls);
-      // El email completo no debe aparecer, pero sí el dominio y un
-      // identificador útil para el admin (githubUsername).
-      expect(loggedPayload).not.toContain("juan@gmail.com");
-      expect(loggedPayload).toContain("@gmail.com");
-      expect(loggedPayload).toContain("juangarcia");
-      errorSpy.mockRestore();
-    });
-
-    it("no intenta suscribir si la escritura en Sheets falla", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "Legajo duplicado" });
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
-    });
-
-    it("no intenta suscribir si no hay comisión activa", async () => {
-      mockGetComisionActiva.mockResolvedValue(null);
-      await POST(makeRequest(validBody));
-      expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
-    });
-  });
-
-  // ── Sincronización de grupos desde planilla ────────────────
-
-  describe("sincronización de grupos desde planilla", () => {
-    it("llama a intentarSincronizarGrupos con el github y la comisión activa tras un registro exitoso", async () => {
-      const comision = await mockGetComisionActiva();
-      await POST(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
-        "juangarcia",
-        comision
-      );
-    });
-
-    it("no incluye gruposSync en el body cuando el wrapper completa sin throwear", async () => {
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBeUndefined();
-    });
-
-    it("responde 200 con gruposSync='error' cuando el wrapper throwea (el alta se preserva, el flag en DB dispara retry)", async () => {
-      mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
-
-      const response = await POST(makeRequest(validBody));
-      const json = await response.json();
-
-      expect(response.status).toBe(200);
-      expect(json.gruposSync).toBe("error");
-      // El alta no se deshace por un fallo en el hook accesorio
-      expect(mockMarcarRegistroConfirmado).toHaveBeenCalledOnce();
-    });
-
-    it("no intenta sincronizar si el registro no se confirmó (ej. Sheets falló)", async () => {
-      mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: false, error: "boom" });
-      await POST(makeRequest(validBody));
-      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    it("no llama al servicio si la validación github↔sesión falla antes", async () => {
+      await POST(makeRequest({ ...validBody, githubUsername: "attacker" }));
+      expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/api/registro/route.test.ts
+++ b/src/app/api/registro/route.test.ts
@@ -140,6 +140,18 @@ describe("POST /api/registro", () => {
     expect(response.status).toBe(409);
   });
 
+  it("devuelve 400 si el body no es un objeto", async () => {
+    const response = await POST(
+      new Request("http://localhost/api/registro", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify("cadena"),
+      })
+    );
+    expect(response.status).toBe(400);
+    expect(mockConfirmarYProcesarAlumno).not.toHaveBeenCalled();
+  });
+
   it("devuelve 500 si algo tira un error inesperado", async () => {
     mockConfirmarYProcesarAlumno.mockRejectedValue(new Error("boom"));
     const response = await POST(makeRequest(validBody));

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -9,7 +9,13 @@ import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 export async function POST(req: Request) {
   try {
     const user = await requireUser();
-    const body = (await req.json()) as RegistroInput;
+    const body = await req.json();
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
+        { status: 400 }
+      );
+    }
 
     // Si el form envió un githubUsername distinto al de la sesión, devolvemos
     // error con `field` para que el form lo pinte inline y pueda ofrecer el
@@ -33,7 +39,7 @@ export async function POST(req: Request) {
     }
     body.githubUsername = user.githubUsername;
 
-    const resultado = await confirmarYProcesarAlumno(body);
+    const resultado = await confirmarYProcesarAlumno(body as RegistroInput);
     if (!resultado.ok) {
       return NextResponse.json(
         resultado.field

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -3,25 +3,8 @@ import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { Alumno } from "@/domain/entities";
 import { usernameCanonicoDe } from "@/types";
-import { agregarMiembroAGrupo } from "@/lib/googleGroups";
 import { internalServerError } from "@/lib/api-errors";
-import { confirmarDatosAlumno } from "@/lib/services/alumnoRegistro";
-import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
-import { logger } from "@/lib/logger";
-
-// Enmascara la parte local del email para no escupir PII a los logs,
-// preservando dominio y primeras 2 letras para que un admin pueda
-// reconocer al alumno (combinado con el githubUsername del log).
-function maskEmail(correo: string): string {
-  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
-}
-
-// Enmascara cualquier email embebido en un texto libre (p. ej. el
-// `message` de un error de googleapis, que suele citar el email del
-// miembro que se intentó agregar).
-function maskEmailsEnTexto(texto: string): string {
-  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
-}
+import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 export async function POST(req: Request) {
   try {
@@ -50,7 +33,7 @@ export async function POST(req: Request) {
     }
     body.githubUsername = user.githubUsername;
 
-    const resultado = await confirmarDatosAlumno(body);
+    const resultado = await confirmarYProcesarAlumno(body);
     if (!resultado.ok) {
       return NextResponse.json(
         resultado.field
@@ -60,36 +43,10 @@ export async function POST(req: Request) {
       );
     }
 
-    // Hooks accesorios: el alta ya está persistida. Cada uno puede fallar sin
-    // abortar el registro; la respuesta incluye un status por hook para que el
-    // form muestre el warning correspondiente.
-    const groupSubscription = await agregarMiembroAGrupo(body.email);
-    if (groupSubscription.status === "error") {
-      logger.error(
-        {
-          githubUsername: body.githubUsername,
-          maskedEmail: maskEmail(body.email),
-          err: maskEmailsEnTexto(groupSubscription.error),
-        },
-        "Error al suscribir al Google Group"
-      );
-    }
-
-    // Hook accesorio: el alta ya está persistida. Si el sync falla, el wrapper
-    // marca el flag en DB para disparar el retry automático en /perfil — solo
-    // degradamos la respuesta a `gruposSync: "error"` para que el form muestre
-    // el warning inmediato.
-    let gruposSyncFallida = false;
-    try {
-      await intentarSincronizarGrupos(body.githubUsername, resultado.comision);
-    } catch {
-      gruposSyncFallida = true;
-    }
-
     return NextResponse.json({
       ok: true,
-      groupSubscription: groupSubscription.status,
-      ...(gruposSyncFallida && { gruposSync: "error" }),
+      groupSubscription: resultado.hooks.groupSubscription,
+      ...(resultado.hooks.gruposSync === "error" && { gruposSync: "error" }),
     });
   } catch (error) {
     return internalServerError("POST /api/registro", error);

--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -3,19 +3,14 @@ import { requireUser } from "@/lib/session";
 import { type RegistroInput } from "@/lib/sheets";
 import { Alumno } from "@/domain/entities";
 import { usernameCanonicoDe } from "@/types";
-import { internalServerError } from "@/lib/api-errors";
+import { internalServerError, parseJsonObjectBody } from "@/lib/api-errors";
 import { confirmarYProcesarAlumno } from "@/lib/services/alumnoRegistro";
 
 export async function POST(req: Request) {
   try {
     const user = await requireUser();
-    const body = await req.json();
-    if (typeof body !== "object" || body === null || Array.isArray(body)) {
-      return NextResponse.json(
-        { error: "No pudimos leer los datos enviados. Volvé a intentar." },
-        { status: 400 }
-      );
-    }
+    const body = await parseJsonObjectBody(req);
+    if (body instanceof NextResponse) return body;
 
     // Si el form envió un githubUsername distinto al de la sesión, devolvemos
     // error con `field` para que el form lo pinte inline y pueda ofrecer el

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -9,6 +9,7 @@ const mockRequireUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockGetAssignments = vi.fn();
+const mockGetAssignmentsDeComision = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockGetGruposDeAlumno = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
@@ -21,6 +22,8 @@ vi.mock("@/lib/session", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAssignments: () => mockGetAssignments(),
+  getAssignmentsDeComision: (comisionId: string) =>
+    mockGetAssignmentsDeComision(comisionId),
   getEntregasDeUsuario: (username: string) => mockGetEntregaDeUsuario(username),
   getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
   getComisionActiva: () => mockGetComisionActiva(),
@@ -111,6 +114,7 @@ describe("Dashboard page", () => {
       throw new Error(`REDIRECT:${url}`);
     });
     mockGetAssignments.mockResolvedValue([]);
+    mockGetAssignmentsDeComision.mockResolvedValue([]);
     mockGetEntregaDeUsuario.mockResolvedValue(new Map());
     mockGetComisionActiva.mockResolvedValue({ id: "c1" });
     mockGetAlumnoByGithub.mockResolvedValue(null);
@@ -156,6 +160,21 @@ describe("Dashboard page", () => {
       expect(mockRedirect).not.toHaveBeenCalled();
     });
 
+    it("consulta assignments de la comisión activa para alumnos", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
+      mockGetAssignmentsDeComision.mockResolvedValue([makeAssignment({ titulo: "TP Vigente" })]);
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+
+      expect(mockGetAssignmentsDeComision).toHaveBeenCalledWith("c1");
+      expect(mockGetAssignments).not.toHaveBeenCalled();
+      expect(html).toContain("TP Vigente");
+    });
+
     it("no redirige si no hay comisión activa (deja pasar aunque no haya confirmado)", async () => {
       mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
       mockGetComisionActiva.mockResolvedValue(null);
@@ -164,6 +183,7 @@ describe("Dashboard page", () => {
       const element = await DashboardPage();
       expect(element).toBeDefined();
       expect(mockRedirect).not.toHaveBeenCalled();
+      expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
     });
 
     it("no redirige a /registro aunque no esté registrado si es admin", async () => {
@@ -173,6 +193,8 @@ describe("Dashboard page", () => {
       expect(element).toBeDefined();
       expect(mockRedirect).not.toHaveBeenCalled();
       expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+      expect(mockGetAssignments).toHaveBeenCalled();
+      expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
     });
   });
 
@@ -331,7 +353,7 @@ describe("Dashboard page", () => {
     });
 
     it("muestra 'Elegir grupo' cuando es grupal y el alumno no tiene grupo", async () => {
-      mockGetAssignments.mockResolvedValue([makeGrupalAssignment()]);
+      mockGetAssignmentsDeComision.mockResolvedValue([makeGrupalAssignment()]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(new Map());
 
@@ -342,7 +364,7 @@ describe("Dashboard page", () => {
     });
 
     it("el link 'Elegir grupo' apunta a la página del grupo del assignment", async () => {
-      mockGetAssignments.mockResolvedValue([makeGrupalAssignment({ id: "tp-g1" })]);
+      mockGetAssignmentsDeComision.mockResolvedValue([makeGrupalAssignment({ id: "tp-g1" })]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(new Map());
 
@@ -353,7 +375,7 @@ describe("Dashboard page", () => {
 
     it("muestra AcceptButton cuando es grupal y el alumno ya tiene grupo", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])
@@ -367,7 +389,7 @@ describe("Dashboard page", () => {
 
     it("muestra el nombre del grupo cuando el alumno ya tiene grupo sin entrega", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map());
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])
@@ -381,7 +403,7 @@ describe("Dashboard page", () => {
     it("muestra 'Ir al repo' cuando ya tiene entrega, aunque tenga grupo", async () => {
       const grupalAssignment = makeGrupalAssignment({ id: "tp-g1" });
       const entrega = makeEntrega({ repoUrl: "https://github.com/pdep/tp-g1" });
-      mockGetAssignments.mockResolvedValue([grupalAssignment]);
+      mockGetAssignmentsDeComision.mockResolvedValue([grupalAssignment]);
       mockGetEntregaDeUsuario.mockResolvedValue(new Map([["tp-g1", entrega]]));
       mockGetGruposDeAlumno.mockResolvedValue(
         new Map([["tp-g1", { nombre: "Los Lambdas" }]])

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import { requireUser } from "@/lib/session";
 import {
   getAssignments,
+  getAssignmentsDeComision,
   getEntregasDeUsuario,
   getAlumnoByGithub,
   getComisionActiva,
@@ -12,12 +13,14 @@ import type { Grupo } from "@/domain/entities";
 
 export default async function DashboardPage() {
   const user = await requireUser();
+  let comisionActivaId: string | null = null;
 
   if (!user.isAdmin) {
     const [alumno, comisionActiva] = await Promise.all([
       getAlumnoByGithub(user.githubUsername),
       getComisionActiva(),
     ]);
+    comisionActivaId = comisionActiva?.id ?? null;
     if (comisionActiva && (!alumno || alumno.necesitaConfirmarRegistroPara(comisionActiva))) {
       redirect("/registro");
     }
@@ -28,7 +31,11 @@ export default async function DashboardPage() {
     : getGruposDeAlumno(user.githubUsername);
 
   const [assignments, entregasMap, gruposMap] = await Promise.all([
-    getAssignments(),
+    user.isAdmin
+      ? getAssignments()
+      : comisionActivaId
+        ? getAssignmentsDeComision(comisionActivaId)
+        : Promise.resolve([]),
     getEntregasDeUsuario(user.githubUsername),
     gruposPromise,
   ]);

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -87,6 +87,7 @@ describe("Alumno.actualizarDatos", () => {
   });
 
   it("no pisa registroConfirmadoEn cuando el dato viene undefined", () => {
+    const comisionActual = fakeComision("activa");
     const comisionConfirmada = fakeComision("confirmada");
     const alumno = nuevoAlumno({ registroConfirmadoEn: comisionConfirmada });
 
@@ -96,12 +97,14 @@ describe("Alumno.actualizarDatos", () => {
       apellido: "García",
       githubUsername: "ana-garcia",
       email: "ana@example.com",
+      comision: comisionActual,
     });
 
     expect(alumno.registroConfirmadoEn).toBe(comisionConfirmada);
   });
 
   it("actualiza registroConfirmadoEn cuando el dato viene definido", () => {
+    const comisionActual = fakeComision("activa");
     const comisionNueva = fakeComision("nueva");
     const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("vieja") });
 
@@ -111,10 +114,33 @@ describe("Alumno.actualizarDatos", () => {
       apellido: "García",
       githubUsername: "ana-garcia",
       email: "ana@example.com",
+      comision: comisionActual,
       registroConfirmadoEn: comisionNueva,
     });
 
     expect(alumno.registroConfirmadoEn).toBe(comisionNueva);
+  });
+});
+
+describe("Alumno.aplicarRegistro", () => {
+  it("trimmea y normaliza los campos de registro sin tocar comisión", () => {
+    const comisionPrevia = fakeComision("c-previa");
+    const alumno = nuevoAlumno({ comision: comisionPrevia });
+
+    alumno.aplicarRegistro({
+      legajo: " 99999 ",
+      nombre: " Pedro ",
+      apellido: " Pérez ",
+      githubUsername: " @PedroPerez ",
+      email: " PEDRO@Example.COM ",
+    });
+
+    expect(alumno.legajo).toBe("99999");
+    expect(alumno.nombre).toBe("Pedro");
+    expect(alumno.apellido).toBe("Pérez");
+    expect(alumno.githubUsername).toBe("pedroperez");
+    expect(alumno.email).toBe("pedro@example.com");
+    expect(alumno.comision).toBe(comisionPrevia);
   });
 });
 

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { Alumno } from "./Alumno";
+import { Alumno, validateRegistro } from "./Alumno";
 import type { Comision } from "./Comision";
 
 function nuevoAlumno(overrides: Partial<Alumno> = {}): Alumno {
@@ -62,6 +62,76 @@ describe("Alumno.usernameCanonico", () => {
   });
 });
 
+describe("Alumno.actualizarDatos", () => {
+  it("trimmea y normaliza los datos del alumno", () => {
+    const alumno = new Alumno();
+    const comision = fakeComision("c1");
+
+    alumno.actualizarDatos({
+      legajo: " 12345 ",
+      nombre: " Ana ",
+      apellido: " García ",
+      githubUsername: " @AnaGarcia ",
+      email: " ANA@Example.COM ",
+      comision,
+    });
+
+    expect(alumno).toMatchObject({
+      legajo: "12345",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "anagarcia",
+      email: "ana@example.com",
+      comision,
+    });
+  });
+
+  it("no pisa registroConfirmadoEn cuando el dato viene undefined", () => {
+    const comisionConfirmada = fakeComision("confirmada");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: comisionConfirmada });
+
+    alumno.actualizarDatos({
+      legajo: "54321",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+    });
+
+    expect(alumno.registroConfirmadoEn).toBe(comisionConfirmada);
+  });
+
+  it("actualiza registroConfirmadoEn cuando el dato viene definido", () => {
+    const comisionNueva = fakeComision("nueva");
+    const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("vieja") });
+
+    alumno.actualizarDatos({
+      legajo: "54321",
+      nombre: "Ana",
+      apellido: "García",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+      registroConfirmadoEn: comisionNueva,
+    });
+
+    expect(alumno.registroConfirmadoEn).toBe(comisionNueva);
+  });
+});
+
+describe("Alumno.toRegistroInput", () => {
+  it("devuelve los campos que espera el registro de Sheets", () => {
+    const alumno = nuevoAlumno();
+
+    expect(alumno.toRegistroInput()).toEqual({
+      legajo: "12345",
+      apellido: "García",
+      nombre: "Ana",
+      githubUsername: "ana-garcia",
+      email: "ana@example.com",
+    });
+  });
+});
+
 describe("Alumno.confirmoRegistroEn", () => {
   it("devuelve true cuando registroConfirmadoEn apunta a la comision activa", () => {
     const comision = fakeComision("c1");
@@ -89,6 +159,17 @@ describe("Alumno.confirmoRegistroEn", () => {
   });
 });
 
+describe("Alumno.confirmarRegistroEn", () => {
+  it("marca la comisión en la que confirmó registro", () => {
+    const comision = fakeComision("c1");
+    const alumno = nuevoAlumno();
+
+    alumno.confirmarRegistroEn(comision);
+
+    expect(alumno.registroConfirmadoEn).toBe(comision);
+  });
+});
+
 describe("Alumno.necesitaConfirmarRegistroPara", () => {
   it("devuelve true cuando el alumno no confirmó para la comision activa", () => {
     const alumno = nuevoAlumno({ registroConfirmadoEn: fakeComision("c-antigua") });
@@ -105,6 +186,30 @@ describe("Alumno.necesitaConfirmarRegistroPara", () => {
 });
 
 describe("Alumno — predicados de sync", () => {
+  describe("transiciones de sync", () => {
+    it("prende y limpia el flag de sync de alumno", () => {
+      const fecha = new Date("2026-04-01T00:00:00Z");
+      const alumno = nuevoAlumno();
+
+      alumno.marcarSyncDeAlumnoFallido(fecha);
+      expect(alumno.alumnoSyncFallidoEn).toBe(fecha);
+
+      alumno.limpiarSyncDeAlumnoFallido();
+      expect(alumno.alumnoSyncFallidoEn).toBeNull();
+    });
+
+    it("prende y limpia el flag de sync de grupos", () => {
+      const fecha = new Date("2026-04-01T00:00:00Z");
+      const alumno = nuevoAlumno();
+
+      alumno.marcarSyncDeGruposFallido(fecha);
+      expect(alumno.gruposSyncFallidoEn).toBe(fecha);
+
+      alumno.limpiarSyncDeGruposFallido();
+      expect(alumno.gruposSyncFallidoEn).toBeNull();
+    });
+  });
+
   describe("tieneSyncDeAlumnoFallido", () => {
     it("devuelve false cuando el flag está limpio", () => {
       const alumno = nuevoAlumno({ alumnoSyncFallidoEn: null });
@@ -177,5 +282,40 @@ describe("Alumno — predicados de sync", () => {
         "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla."
       );
     });
+  });
+});
+
+describe("validateRegistro", () => {
+  const valid = {
+    legajo: "12345",
+    apellido: "García",
+    nombre: "Juan",
+    githubUsername: "juangarcia",
+    email: "juan@gmail.com",
+  };
+
+  it("acepta input válido", () => {
+    expect(validateRegistro(valid)).toBeNull();
+  });
+
+  it("mantiene los mensajes de error existentes", () => {
+    expect(validateRegistro({ ...valid, legajo: "" })).toBe(
+      "El legajo debe tener entre 4 y 8 dígitos"
+    );
+    expect(validateRegistro({ ...valid, apellido: "" })).toBe("El apellido es obligatorio");
+    expect(validateRegistro({ ...valid, nombre: "  " })).toBe("El nombre es obligatorio");
+    expect(validateRegistro({ ...valid, githubUsername: "" })).toBe(
+      "El usuario de GitHub es obligatorio"
+    );
+    expect(validateRegistro({ ...valid, githubUsername: "user name" })).toBe(
+      "El usuario de GitHub no tiene un formato válido"
+    );
+    expect(validateRegistro({ ...valid, email: "" })).toBe("El email no es válido");
+  });
+
+  it("rechaza github username que no es string", () => {
+    expect(validateRegistro({ ...valid, githubUsername: 123 as unknown as string })).toBe(
+      "El usuario de GitHub debe ser un texto"
+    );
   });
 });

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -318,4 +318,26 @@ describe("validateRegistro", () => {
       "El usuario de GitHub debe ser un texto"
     );
   });
+
+  it("no tira TypeError cuando legajo, apellido, nombre o email no son strings", () => {
+    expect(() =>
+      validateRegistro({ ...valid, legajo: 12345 as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, apellido: null as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, nombre: undefined as unknown as string })
+    ).not.toThrow();
+    expect(() =>
+      validateRegistro({ ...valid, email: 42 as unknown as string })
+    ).not.toThrow();
+  });
+
+  it("devuelve error de validación (no null) cuando legajo, apellido, nombre o email no son strings", () => {
+    expect(validateRegistro({ ...valid, legajo: 12345 as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, apellido: null as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, nombre: undefined as unknown as string })).not.toBeNull();
+    expect(validateRegistro({ ...valid, email: 42 as unknown as string })).not.toBeNull();
+  });
 });

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -12,7 +12,7 @@ export interface RegistroInput {
 }
 
 export interface AlumnoData extends RegistroInput {
-  comision?: Comision;
+  comision: Comision;
   registroConfirmadoEn?: Comision;
 }
 
@@ -70,8 +70,10 @@ export class Alumno {
   @Property({ type: 'string' })
   email!: string;
 
-  @ManyToOne(() => Comision, { nullable: true })
-  comision?: Comision;
+  // Todo alumno pertenece a exactamente una comisión. La FK es NOT NULL;
+  // borrar una comisión borra sus alumnos en cascada (on delete cascade).
+  @ManyToOne(() => Comision)
+  comision!: Comision;
 
   // Marca la comisión en la que el alumno confirmó sus datos por última vez.
   // Si no coincide con la comisión activa, se le pide re-confirmar en /registro.
@@ -98,12 +100,19 @@ export class Alumno {
     return `${this.apellido}, ${this.nombre}`;
   }
 
+  // Aplica solo los campos de RegistroInput (sin comisión ni confirmación).
+  // Usado por parseAlumnosRows en sheets.ts, donde los Alumno son transitorios
+  // (DTOs de planilla) y la comisión se inyecta en el call site de upsertAlumnos.
+  aplicarRegistro(input: RegistroInput): void {
+    this.legajo = input.legajo.trim();
+    this.nombre = input.nombre.trim();
+    this.apellido = input.apellido.trim();
+    this.githubUsername = Alumno.normalizarUsername(input.githubUsername);
+    this.email = Alumno.normalizarEmail(input.email);
+  }
+
   actualizarDatos(data: AlumnoData): void {
-    this.legajo = data.legajo.trim();
-    this.nombre = data.nombre.trim();
-    this.apellido = data.apellido.trim();
-    this.githubUsername = Alumno.normalizarUsername(data.githubUsername);
-    this.email = Alumno.normalizarEmail(data.email);
+    this.aplicarRegistro(data);
     this.comision = data.comision;
     if (data.registroConfirmadoEn !== undefined) {
       this.registroConfirmadoEn = data.registroConfirmadoEn;

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -27,16 +27,16 @@ export function isValidEmail(email: string): boolean {
 export function validateRegistro(input: RegistroInput): string | null {
   const { legajo, apellido, nombre, githubUsername, email } = input;
 
-  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
+  if (typeof legajo !== "string" || !legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
     return "El legajo debe tener entre 4 y 8 dígitos";
-  if (!apellido.trim()) return "El apellido es obligatorio";
-  if (!nombre.trim()) return "El nombre es obligatorio";
+  if (typeof apellido !== "string" || !apellido.trim()) return "El apellido es obligatorio";
+  if (typeof nombre !== "string" || !nombre.trim()) return "El nombre es obligatorio";
   if (typeof githubUsername !== "string")
     return "El usuario de GitHub debe ser un texto";
   if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
   if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
     return "El usuario de GitHub no tiene un formato válido";
-  if (!isValidEmail(email)) return "El email no es válido";
+  if (typeof email !== "string" || !isValidEmail(email)) return "El email no es válido";
   return null;
 }
 

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -3,6 +3,43 @@ import { randomUUID } from "crypto";
 import { Comision } from "./Comision";
 import { ALUMNO_LEGAJO_PATTERN, ALUMNO_EMAIL_PATTERN, normalizarGithubUsername } from "./domain-constants";
 
+export interface RegistroInput {
+  legajo: string;
+  apellido: string;
+  nombre: string;
+  githubUsername: string;
+  email: string;
+}
+
+export interface AlumnoData extends RegistroInput {
+  comision?: Comision;
+  registroConfirmadoEn?: Comision;
+}
+
+// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
+// Suficiente para detectar typos comunes sin sobre-complicar.
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export function isValidEmail(email: string): boolean {
+  return EMAIL_REGEX.test(email.trim());
+}
+
+export function validateRegistro(input: RegistroInput): string | null {
+  const { legajo, apellido, nombre, githubUsername, email } = input;
+
+  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
+    return "El legajo debe tener entre 4 y 8 dígitos";
+  if (!apellido.trim()) return "El apellido es obligatorio";
+  if (!nombre.trim()) return "El nombre es obligatorio";
+  if (typeof githubUsername !== "string")
+    return "El usuario de GitHub debe ser un texto";
+  if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
+  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
+    return "El usuario de GitHub no tiene un formato válido";
+  if (!isValidEmail(email)) return "El email no es válido";
+  return null;
+}
+
 @Entity()
 export class Alumno {
   static readonly LEGAJO_PATTERN = ALUMNO_LEGAJO_PATTERN;
@@ -61,6 +98,32 @@ export class Alumno {
     return `${this.apellido}, ${this.nombre}`;
   }
 
+  actualizarDatos(data: AlumnoData): void {
+    this.legajo = data.legajo.trim();
+    this.nombre = data.nombre.trim();
+    this.apellido = data.apellido.trim();
+    this.githubUsername = Alumno.normalizarUsername(data.githubUsername);
+    this.email = Alumno.normalizarEmail(data.email);
+    this.comision = data.comision;
+    if (data.registroConfirmadoEn !== undefined) {
+      this.registroConfirmadoEn = data.registroConfirmadoEn;
+    }
+  }
+
+  toRegistroInput(): RegistroInput {
+    return {
+      legajo: this.legajo,
+      apellido: this.apellido,
+      nombre: this.nombre,
+      githubUsername: this.githubUsername,
+      email: this.email,
+    };
+  }
+
+  confirmarRegistroEn(comision: Comision): void {
+    this.registroConfirmadoEn = comision;
+  }
+
   confirmoRegistroEn(comision: Comision | null): boolean {
     if (!comision) return false;
     return this.registroConfirmadoEn?.id === comision.id;
@@ -74,8 +137,24 @@ export class Alumno {
     return this.alumnoSyncFallidoEn !== null;
   }
 
+  marcarSyncDeAlumnoFallido(fecha = new Date()): void {
+    this.alumnoSyncFallidoEn = fecha;
+  }
+
+  limpiarSyncDeAlumnoFallido(): void {
+    this.alumnoSyncFallidoEn = null;
+  }
+
   tieneSyncDeGruposFallido(): boolean {
     return this.gruposSyncFallidoEn !== null;
+  }
+
+  marcarSyncDeGruposFallido(fecha = new Date()): void {
+    this.gruposSyncFallidoEn = fecha;
+  }
+
+  limpiarSyncDeGruposFallido(): void {
+    this.gruposSyncFallidoEn = null;
   }
 
   tieneSyncPendiente(): boolean {

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -211,3 +211,25 @@ describe("Assignment.cargarGruposCon", () => {
     expect(result).toBe(grupos);
   });
 });
+
+describe("Assignment.aplicarCamposExtra", () => {
+  it("IndividualAssignment ignora cualquier campo extra sin lanzar error", () => {
+    const individual = new IndividualAssignment();
+    expect(() => individual.aplicarCamposExtra({ maxIntegrantes: 5 })).not.toThrow();
+    expect(() => individual.aplicarCamposExtra({})).not.toThrow();
+  });
+
+  it("GrupalAssignment setea maxIntegrantes cuando viene en los datos", () => {
+    const grupal = new GrupalAssignment();
+    grupal.maxIntegrantes = 3;
+    grupal.aplicarCamposExtra({ maxIntegrantes: 6 });
+    expect(grupal.maxIntegrantes).toBe(6);
+  });
+
+  it("GrupalAssignment no modifica maxIntegrantes si no viene en los datos", () => {
+    const grupal = new GrupalAssignment();
+    grupal.maxIntegrantes = 3;
+    grupal.aplicarCamposExtra({});
+    expect(grupal.maxIntegrantes).toBe(3);
+  });
+});

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -107,6 +107,13 @@ export abstract class Assignment {
    */
   abstract extraFormDefaults(): Partial<{ maxIntegrantes: number }>;
 
+  /**
+   * Aplica los campos extra del form al subtipo (inverso de `extraFormDefaults()`).
+   * Individual: no-op. Grupal: setea `maxIntegrantes` si viene en `data`.
+   * Evita `instanceof GrupalAssignment` en la capa de repositorios.
+   */
+  abstract aplicarCamposExtra(data: Partial<{ maxIntegrantes: number }>): void;
+
   /** Nombre del repo template sin el prefijo de organización (ej. "org/repo" → "repo"). */
   nombreDelTemplate(): string {
     return this.templateRepo.includes("/")

--- a/src/domain/entities/Entrega.test.ts
+++ b/src/domain/entities/Entrega.test.ts
@@ -62,37 +62,3 @@ describe("Entrega.estadoRepo", () => {
     expect(entrega.estadoRepo()).toBe("sin-repo");
   });
 });
-
-describe("Entrega.matcheaQuery", () => {
-  it("devuelve true para query vacía (no filtra nada)", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"] });
-    expect(entrega.matcheaQuery("")).toBe(true);
-    expect(entrega.matcheaQuery("   ")).toBe(true);
-  });
-
-  it("devuelve true cuando la query coincide con un username", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia", "bob"] });
-    expect(entrega.matcheaQuery("ana")).toBe(true);
-  });
-
-  it("es case-insensitive en usernames", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["AnaGarcia"] });
-    expect(entrega.matcheaQuery("anagarcia")).toBe(true);
-    expect(entrega.matcheaQuery("ANAGARCIA")).toBe(true);
-  });
-
-  it("devuelve true cuando la query coincide con el repoName", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
-    expect(entrega.matcheaQuery("funcional")).toBe(true);
-  });
-
-  it("devuelve false cuando la query no coincide con ningún campo", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: "tp-funcional-ana" });
-    expect(entrega.matcheaQuery("logico")).toBe(false);
-  });
-
-  it("tolera repoName undefined sin explotar", () => {
-    const entrega = nuevaEntrega({ githubUsernames: ["ana"], repoName: undefined });
-    expect(entrega.matcheaQuery("algo")).toBe(false);
-  });
-});

--- a/src/domain/entities/Entrega.ts
+++ b/src/domain/entities/Entrega.ts
@@ -8,7 +8,6 @@ import { randomUUID } from "crypto";
 import { Alumno } from "./Alumno";
 import { Assignment } from "./Assignment";
 import { Grupo } from "./Grupo";
-import { matcheaEntregaQuery } from "@/lib/entrega-query";
 
 @Entity()
 export class Entrega {
@@ -58,9 +57,5 @@ export class Entrega {
     if (this.repoFueBorrado()) return "borrado";
     if (this.hasRepo()) return "activo";
     return "sin-repo";
-  }
-
-  matcheaQuery(rawQuery: string): boolean {
-    return matcheaEntregaQuery(this, rawQuery);
   }
 }

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -80,6 +80,10 @@ export class GrupalAssignment extends Assignment {
     return { maxIntegrantes: this.maxIntegrantes };
   }
 
+  aplicarCamposExtra(data: Partial<{ maxIntegrantes: number }>): void {
+    if (data.maxIntegrantes !== undefined) this.maxIntegrantes = data.maxIntegrantes;
+  }
+
   cargarGruposCon(loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
     return loader(this.id);
   }

--- a/src/domain/entities/IndividualAssignment.ts
+++ b/src/domain/entities/IndividualAssignment.ts
@@ -39,6 +39,10 @@ export class IndividualAssignment extends Assignment {
     return {};
   }
 
+  aplicarCamposExtra(_data: Partial<{ maxIntegrantes: number }>): void {
+    // Los assignments individuales no tienen campos extra.
+  }
+
   cargarGruposCon(_loader: (assignmentId: string) => Promise<Grupo[]>): Promise<Grupo[]> {
     return Promise.resolve([]);
   }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -1,4 +1,10 @@
-export { Alumno } from "./Alumno";
+export {
+  Alumno,
+  isValidEmail,
+  validateRegistro,
+  type AlumnoData,
+  type RegistroInput,
+} from "./Alumno";
 export { Comision } from "./Comision";
 export { Assignment } from "./Assignment";
 export type {

--- a/src/lib/api-errors.test.ts
+++ b/src/lib/api-errors.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from "vitest";
+import { NextResponse } from "next/server";
+import { parseJsonObjectBody } from "./api-errors";
+
+function makeRequest(body: unknown, contentType = "application/json"): Request {
+  return new Request("http://test.local/api/test", {
+    method: "POST",
+    headers: { "Content-Type": contentType },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("parseJsonObjectBody", () => {
+  it("devuelve el objeto cuando el body es un objeto plano válido", async () => {
+    const request = makeRequest({ legajo: "12345", nombre: "Juan" });
+    const result = await parseJsonObjectBody(request);
+    expect(result).not.toBeInstanceOf(NextResponse);
+    expect(result).toEqual({ legajo: "12345", nombre: "Juan" });
+  });
+
+  it("devuelve NextResponse 400 cuando el body es null JSON", async () => {
+    const request = makeRequest(null);
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+    const json = await response.json();
+    expect(json.error).toContain("No pudimos leer los datos enviados");
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un array JSON", async () => {
+    const request = makeRequest([1, 2, 3]);
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body no es JSON válido", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "esto-no-es-json",
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    // El bug original devolvía 500 porque req.json() tiraba excepción sin .catch().
+    // Con el helper, un body mal formado devuelve 400.
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un string JSON", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify("un string"),
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+
+  it("devuelve NextResponse 400 cuando el body es un número JSON", async () => {
+    const request = new Request("http://test.local/api/test", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(42),
+    });
+    const result = await parseJsonObjectBody(request);
+    expect(result).toBeInstanceOf(NextResponse);
+    const response = result as NextResponse;
+    expect(response.status).toBe(400);
+  });
+});

--- a/src/lib/api-errors.ts
+++ b/src/lib/api-errors.ts
@@ -1,6 +1,29 @@
 import { NextResponse } from "next/server";
 import { logger } from "./logger";
 
+/**
+ * Parsea el body de un request JSON y verifica que sea un objeto plano.
+ * Devuelve el objeto si es válido, o una `NextResponse` 400 si no lo es
+ * (body no-JSON, null, array). Usar `.catch()` internamente evita que un
+ * body mal formado propague una excepción y termine devolviendo 500.
+ *
+ * Patrón de uso:
+ *   const body = await parseJsonObjectBody(req);
+ *   if (body instanceof NextResponse) return body;
+ */
+export async function parseJsonObjectBody(
+  req: Request
+): Promise<Record<string, unknown> | NextResponse> {
+  const body = await req.json().catch(() => null);
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return NextResponse.json(
+      { error: "No pudimos leer los datos enviados. Volvé a intentar." },
+      { status: 400 }
+    );
+  }
+  return body as Record<string, unknown>;
+}
+
 // Loggea el error completo server-side y devuelve siempre un 500 con mensaje
 // genérico — evita filtrar detalles internos (stack traces, esquemas de DB,
 // mensajes de librerías de terceros) al cliente.

--- a/src/lib/assignment-schema.ts
+++ b/src/lib/assignment-schema.ts
@@ -32,5 +32,5 @@ export type AssignmentFormErrors =
   z.typeToFlattenedError<AssignmentFormData>["fieldErrors"];
 
 export type AssignmentFormState =
-  | { ok: false; errors: AssignmentFormErrors }
+  | { ok: false; errors: AssignmentFormErrors; formError?: string }
   | null;

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -5,6 +5,8 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 const mockMembersInsert = vi.fn();
 const mockJWT = vi.fn();
 
+const mockMembersDelete = vi.fn();
+
 vi.mock("googleapis", () => ({
   google: {
     auth: {
@@ -13,12 +15,15 @@ vi.mock("googleapis", () => ({
       },
     },
     admin: () => ({
-      members: { insert: (...args: unknown[]) => mockMembersInsert(...args) },
+      members: {
+        insert: (...args: unknown[]) => mockMembersInsert(...args),
+        delete: (...args: unknown[]) => mockMembersDelete(...args),
+      },
     }),
   },
 }));
 
-import { agregarMiembroAGrupo } from "./googleGroups";
+import { agregarMiembroAGrupo, quitarMiembroDeGrupo } from "./googleGroups";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -50,6 +55,7 @@ describe("agregarMiembroAGrupo", () => {
     process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
     process.env.GOOGLE_SERVICE_ACCOUNT_KEY = FAKE_SA_KEY;
     mockMembersInsert.mockResolvedValue({ data: {} });
+    mockMembersDelete.mockResolvedValue({ data: {} });
     mockJWT.mockReturnValue({});
   });
 
@@ -142,4 +148,62 @@ describe("agregarMiembroAGrupo", () => {
     expect(result).toEqual({ status: "error", error: "Sin permisos" });
   });
 
+});
+
+describe("quitarMiembroDeGrupo", () => {
+  const ENV_BACKUP = { ...process.env };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.GOOGLE_GROUP_EMAIL = "pdep@googlegroups.com";
+    process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL = "admin@utn.edu.ar";
+    process.env.GOOGLE_SERVICE_ACCOUNT_KEY = FAKE_SA_KEY;
+    mockMembersDelete.mockResolvedValue({ data: {} });
+    mockJWT.mockReturnValue({});
+  });
+
+  afterEach(() => {
+    process.env = { ...ENV_BACKUP };
+  });
+
+  it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL no está configurada", async () => {
+    delete process.env.GOOGLE_GROUP_EMAIL;
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "skipped" });
+    expect(mockMembersDelete).not.toHaveBeenCalled();
+  });
+
+  it("elimina el miembro del grupo (happy path)", async () => {
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "removed" });
+    expect(mockMembersDelete).toHaveBeenCalledWith(
+      { groupKey: "pdep@googlegroups.com", memberKey: "juan@gmail.com" },
+      expect.objectContaining({ signal: expect.any(AbortSignal) })
+    );
+  });
+
+  it("retorna 'not_member' cuando la API devuelve 404 en err.code", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(404, "notFound"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'not_member' cuando la API devuelve 404 en err.status", async () => {
+    const err = Object.assign(new Error("Not Found"), { status: 404 });
+    mockMembersDelete.mockRejectedValue(err);
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'not_member' cuando reason 'resourceNotFound' viene en err.errors", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(400, "resourceNotFound"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'error' con mensaje cuando la API falla con otro código", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(403, "forbidden", "Sin permisos"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "error", error: "Sin permisos" });
+  });
 });

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -206,4 +206,24 @@ describe("quitarMiembroDeGrupo", () => {
     const result = await quitarMiembroDeGrupo("juan@gmail.com");
     expect(result).toEqual({ status: "error", error: "Sin permisos" });
   });
+
+  it("retorna 'error' cuando el 404 indica que el grupo no existe (groupKey en el mensaje)", async () => {
+    mockMembersDelete.mockRejectedValue(gaxiosError(404, "notFound", "Resource Not Found: groupKey"));
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result.status).toBe("error");
+  });
+
+  it("retorna 'not_member' cuando el 404 indica que el miembro no estaba (memberKey en el mensaje)", async () => {
+    const err = gaxiosError(404, "notFound", "Resource Not Found: memberKey");
+    mockMembersDelete.mockRejectedValue(err);
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
+
+  it("retorna 'not_member' cuando el 404 no incluye marcador de groupKey ni memberKey (comportamiento defensivo)", async () => {
+    const err = Object.assign(new Error("Not Found"), { status: 404 });
+    mockMembersDelete.mockRejectedValue(err);
+    const result = await quitarMiembroDeGrupo("juan@gmail.com");
+    expect(result).toEqual({ status: "not_member" });
+  });
 });

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -114,6 +114,34 @@ function isNotFoundError(error: unknown): boolean {
   );
 }
 
+// Dentro de un 404 de members.delete, la API de Admin Directory distingue
+// grupo inexistente ("Resource Not Found: groupKey") de miembro ausente
+// ("Resource Not Found: memberKey"). Detectar el primero es importante porque
+// indica config rota (GOOGLE_GROUP_EMAIL inválido), no una baja idempotente.
+// Recolectamos todos los mensajes de error posibles y buscamos "groupKey".
+function esGrupoInexistente(error: unknown): boolean {
+  const apiError = error as {
+    message?: string;
+    errors?: { message?: string }[];
+    response?: { data?: { error?: { message?: string; errors?: { message?: string }[] } } };
+  };
+  const mensajes: string[] = [];
+  if (apiError.message) mensajes.push(apiError.message);
+  if (apiError.errors) {
+    for (const errorEntry of apiError.errors) {
+      if (errorEntry.message) mensajes.push(errorEntry.message);
+    }
+  }
+  const errorAnidado = apiError.response?.data?.error;
+  if (errorAnidado?.message) mensajes.push(errorAnidado.message);
+  if (errorAnidado?.errors) {
+    for (const errorEntry of errorAnidado.errors) {
+      if (errorEntry.message) mensajes.push(errorEntry.message);
+    }
+  }
+  return mensajes.some((mensaje) => mensaje.toLowerCase().includes("groupkey"));
+}
+
 export type QuitarMiembroResult =
   | { status: "removed" }
   | { status: "not_member" }
@@ -134,7 +162,13 @@ export async function quitarMiembroDeGrupo(
     );
     return { status: "removed" };
   } catch (error) {
-    if (isNotFoundError(error)) return { status: "not_member" };
+    if (isNotFoundError(error)) {
+      if (esGrupoInexistente(error)) {
+        const message = error instanceof Error ? error.message : "El grupo configurado no existe";
+        return { status: "error", error: message };
+      }
+      return { status: "not_member" };
+    }
     const message = error instanceof Error ? error.message : "Error al quitar del grupo";
     return { status: "error", error: message };
   }

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -86,3 +86,56 @@ export async function agregarMiembroAGrupo(
     return { status: "error", error: message };
   }
 }
+
+// ── Des-suscribir alumno del grupo ──────────────────────────
+
+// Detecta "el miembro no estaba en el grupo": la baja es idempotente, así que
+// un 404 (o reason notFound/resourceNotFound) lo tratamos como éxito silencioso.
+// Mismo enfoque defensivo que `isDuplicateError`: el status puede venir por
+// err.code, err.status o anidado en response.data.error.errors.
+function isNotFoundError(error: unknown): boolean {
+  const apiError = error as {
+    code?: number;
+    status?: number;
+    errors?: { reason?: string }[];
+    response?: { data?: { error?: { errors?: { reason?: string }[] } } };
+  };
+  if (apiError.code === 404 || apiError.status === 404) return true;
+  const hasNotFoundReason = (errors?: { reason?: string }[]) =>
+    Boolean(
+      errors?.some(
+        (errorEntry) =>
+          errorEntry.reason === "notFound" || errorEntry.reason === "resourceNotFound"
+      )
+    );
+  return (
+    hasNotFoundReason(apiError.errors) ||
+    hasNotFoundReason(apiError.response?.data?.error?.errors)
+  );
+}
+
+export type QuitarMiembroResult =
+  | { status: "removed" }
+  | { status: "not_member" }
+  | { status: "skipped" }
+  | { status: "error"; error: string };
+
+export async function quitarMiembroDeGrupo(
+  memberEmail: string
+): Promise<QuitarMiembroResult> {
+  const groupEmail = getGroupEmail();
+  if (!groupEmail) return { status: "skipped" };
+
+  try {
+    const admin = getDirectoryClient();
+    await admin.members.delete(
+      { groupKey: groupEmail, memberKey: memberEmail },
+      { signal: AbortSignal.timeout(10_000) }
+    );
+    return { status: "removed" };
+  } catch (error) {
+    if (isNotFoundError(error)) return { status: "not_member" };
+    const message = error instanceof Error ? error.message : "Error al quitar del grupo";
+    return { status: "error", error: message };
+  }
+}

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+describe("migrations", () => {
+  it("garantiza una única comisión activa con un índice único parcial", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260527120000_add_unique_active_comision_index.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('create unique index "comision_unica_activa_idx"');
+    expect(migration).toContain('on "comision" ("activa") where "activa" is true');
+    expect(migration).toContain('drop index if exists "comision_unica_activa_idx"');
+    expect(migration).toContain("hay mas de una comision activa");
+  });
+});

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -18,4 +18,22 @@ describe("migrations", () => {
     expect(migration).toContain('drop index if exists "comision_unica_activa_idx"');
     expect(migration).toContain("hay mas de una comision activa");
   });
+
+  it("garantiza unicidad de entregas por repo, alumno y grupo", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260528123000_unique_entrega_logica.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('create unique index "entrega_repo_name_unique_idx"');
+    expect(migration).toContain('create unique index "entrega_assignment_alumno_unique_idx"');
+    expect(migration).toContain('create unique index "entrega_assignment_grupo_unique_idx"');
+    expect(migration).toContain("hay repo_name duplicados");
+    expect(migration).toContain("hay entregas individuales duplicadas");
+    expect(migration).toContain("hay entregas grupales duplicadas");
+  });
 });

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -30,6 +30,8 @@ describe("migrations", () => {
     );
 
     expect(migration).toContain('create unique index "entrega_repo_name_unique_idx"');
+    expect(migration).toContain('on "entrega" (lower("repo_name"))');
+    expect(migration).toContain('group by lower("repo_name")');
     expect(migration).toContain('create unique index "entrega_assignment_alumno_unique_idx"');
     expect(migration).toContain('create unique index "entrega_assignment_grupo_unique_idx"');
     expect(migration).toContain("hay repo_name duplicados");

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -1,6 +1,8 @@
 import { getEM } from "@/lib/db";
-import { Alumno } from "@/domain/entities";
+import { Alumno, type AlumnoData } from "@/domain/entities";
 import type { Comision } from "@/domain/entities";
+
+export type { AlumnoData } from "@/domain/entities";
 
 // El legajo es la PK del alumno en la cursada: dos alumnos no pueden compartirlo.
 // La UNIQUE constraint de la DB ya lo garantiza, pero lanzamos este error antes
@@ -43,6 +45,20 @@ export async function getAlumnoByGithub(
   });
 }
 
+export async function getAlumnosByGithubUsernames(
+  githubUsernames: string[]
+): Promise<Alumno[]> {
+  const usernamesCanonicos = [
+    ...new Set(githubUsernames.map((username) => Alumno.normalizarUsername(username))),
+  ];
+  if (usernamesCanonicos.length === 0) return [];
+
+  const entityManager = await getEM();
+  return entityManager.find(Alumno, {
+    githubUsername: { $in: usernamesCanonicos },
+  });
+}
+
 export async function getAlumnoByLegajo(
   legajo: string
 ): Promise<Alumno | null> {
@@ -50,36 +66,11 @@ export async function getAlumnoByLegajo(
   return entityManager.findOne(Alumno, { legajo: legajo.trim() });
 }
 
-export interface AlumnoData {
-  legajo: string;
-  nombre: string;
-  apellido: string;
-  githubUsername: string;
-  email: string;
-  comision?: Comision;
-  registroConfirmadoEn?: Comision;
-}
-
-// Copia los campos de `data` sobre `alumno`. Para `registroConfirmadoEn`
-// se ignora `undefined` para no pisar un valor ya confirmado cuando el caller
-// (ej. sync desde Sheets) no trae ese dato.
-function applyAlumnoData(alumno: Alumno, data: AlumnoData): void {
-  alumno.legajo = data.legajo.trim();
-  alumno.nombre = data.nombre.trim();
-  alumno.apellido = data.apellido.trim();
-  alumno.githubUsername = Alumno.normalizarUsername(data.githubUsername);
-  alumno.email = Alumno.normalizarEmail(data.email);
-  alumno.comision = data.comision;
-  if (data.registroConfirmadoEn !== undefined) {
-    alumno.registroConfirmadoEn = data.registroConfirmadoEn;
-  }
-}
-
 export async function createAlumno(data: AlumnoData): Promise<Alumno> {
   await assertLegajoLibreOPropio(data.legajo, data.githubUsername);
   const entityManager = await getEM();
   const alumno = new Alumno();
-  applyAlumnoData(alumno, data);
+  alumno.actualizarDatos(data);
   entityManager.persist(alumno);
   await entityManager.flush();
   return alumno;
@@ -94,7 +85,7 @@ export async function upsertAlumno(data: AlumnoData): Promise<Alumno> {
   });
 
   if (existing) {
-    applyAlumnoData(existing, data);
+    existing.actualizarDatos(data);
     await entityManager.flush();
     return existing;
   }
@@ -115,7 +106,7 @@ export async function marcarRegistroConfirmado(
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.registroConfirmadoEn = comision;
+  alumno.confirmarRegistroEn(comision);
   await entityManager.flush();
 }
 
@@ -125,7 +116,7 @@ export async function marcarGruposSyncFallido(githubUsername: string): Promise<v
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.gruposSyncFallidoEn = new Date();
+  alumno.marcarSyncDeGruposFallido();
   await entityManager.flush();
 }
 
@@ -137,7 +128,7 @@ export async function marcarGruposSyncOk(githubUsername: string): Promise<void> 
   // Solo flusheamos si había algo prendido — evita un UPDATE por cada sync
   // exitosa del happy path.
   if (!alumno || !alumno.gruposSyncFallidoEn) return;
-  alumno.gruposSyncFallidoEn = null;
+  alumno.limpiarSyncDeGruposFallido();
   await entityManager.flush();
 }
 
@@ -147,7 +138,7 @@ export async function marcarAlumnoSyncFallido(githubUsername: string): Promise<v
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno) return;
-  alumno.alumnoSyncFallidoEn = new Date();
+  alumno.marcarSyncDeAlumnoFallido();
   await entityManager.flush();
 }
 
@@ -157,7 +148,7 @@ export async function marcarAlumnoSyncOk(githubUsername: string): Promise<void> 
     githubUsername: Alumno.normalizarUsername(githubUsername),
   });
   if (!alumno || !alumno.alumnoSyncFallidoEn) return;
-  alumno.alumnoSyncFallidoEn = null;
+  alumno.limpiarSyncDeAlumnoFallido();
   await entityManager.flush();
 }
 
@@ -219,10 +210,10 @@ export async function upsertAlumnos(dataList: AlumnoData[]): Promise<number> {
     const key = Alumno.normalizarUsername(data.githubUsername);
     const existing = existentesPorGithub.get(key);
     if (existing) {
-      applyAlumnoData(existing, data);
+      existing.actualizarDatos(data);
     } else {
       const alumno = new Alumno();
-      applyAlumnoData(alumno, data);
+      alumno.actualizarDatos(data);
       entityManager.persist(alumno);
       // Si el batch trae otra fila con el mismo github (typo o fila duplicada
       // en la planilla), debe reutilizar esta instancia — sin esto, el UNIQUE

--- a/src/lib/repositories/AssignmentRepository.test.ts
+++ b/src/lib/repositories/AssignmentRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEm = {
+  find: vi.fn(),
+  findOne: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import {
+  ComisionActivaRequeridaError,
+  createAssignment,
+  getAssignment,
+  getAssignments,
+  getAssignmentsDeComision,
+} from "./AssignmentRepository";
+import { Assignment, Comision } from "@/domain/entities";
+
+const assignmentData = {
+  titulo: "Kata Funcional",
+  slug: "",
+  descripcion: "",
+  templateRepo: "kata-template",
+  tipo: "individual" as const,
+  paradigma: "funcional",
+  deadline: "",
+};
+
+describe("AssignmentRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.find.mockResolvedValue([]);
+    mockEm.findOne.mockResolvedValue(new Comision(2026, "sheet-1"));
+    mockEm.flush.mockResolvedValue(undefined);
+  });
+
+  describe("getAssignmentsDeComision", () => {
+    it("busca assignments por comisión ordenados por fecha descendente", async () => {
+      await getAssignmentsDeComision("c1");
+
+      expect(mockEm.find).toHaveBeenCalledWith(
+        Assignment,
+        { comision: { id: "c1" } },
+        { orderBy: { createdAt: "DESC" } }
+      );
+    });
+  });
+
+  describe("getAssignments", () => {
+    it("popula comisión y ordena por fecha descendente", async () => {
+      await getAssignments();
+
+      expect(mockEm.find).toHaveBeenCalledWith(
+        Assignment,
+        {},
+        { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
+      );
+    });
+  });
+
+  describe("getAssignment", () => {
+    it("popula la comisión asociada", async () => {
+      await getAssignment("a1");
+
+      expect(mockEm.findOne).toHaveBeenCalledWith(
+        Assignment,
+        { id: "a1" },
+        { populate: ["comision"] }
+      );
+    });
+  });
+
+  describe("createAssignment", () => {
+    it("asocia el assignment a la comisión activa", async () => {
+      const comision = new Comision(2026, "sheet-1");
+      mockEm.findOne.mockResolvedValueOnce(comision);
+
+      const assignment = await createAssignment(assignmentData);
+
+      expect(mockEm.findOne).toHaveBeenCalledWith(Comision, { activa: true });
+      expect(assignment.comision).toBe(comision);
+      expect(mockEm.persist).toHaveBeenCalledWith(assignment);
+      expect(mockEm.flush).toHaveBeenCalled();
+    });
+
+    it("falla si no hay comisión activa", async () => {
+      mockEm.findOne.mockResolvedValueOnce(null);
+
+      await expect(createAssignment(assignmentData)).rejects.toBeInstanceOf(
+        ComisionActivaRequeridaError
+      );
+
+      expect(mockEm.persist).not.toHaveBeenCalled();
+      expect(mockEm.flush).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -52,13 +52,8 @@ export async function createAssignment(
 
   let assignment: Assignment;
 
-  if (data.tipo === "grupal") {
-    const grupal = new GrupalAssignment();
-    grupal.maxIntegrantes = data.maxIntegrantes!;
-    assignment = grupal;
-  } else {
-    assignment = new IndividualAssignment();
-  }
+  assignment = data.tipo === "grupal" ? new GrupalAssignment() : new IndividualAssignment();
+  assignment.aplicarCamposExtra(data);
 
   assignment.titulo = data.titulo;
   assignment.slug = slug;
@@ -91,9 +86,7 @@ export async function updateAssignment(
   if (data.deadline !== undefined)
     assignment.deadline = data.deadline ? new Date(data.deadline) : undefined;
 
-  if (assignment instanceof GrupalAssignment && data.maxIntegrantes !== undefined) {
-    assignment.maxIntegrantes = data.maxIntegrantes;
-  }
+  assignment.aplicarCamposExtra(data);
 
   await entityManager.flush();
   return assignment;

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -1,6 +1,7 @@
 import { getEM, deleteEntity } from "@/lib/db";
 import {
   Assignment,
+  Comision,
   IndividualAssignment,
   GrupalAssignment,
 } from "@/domain/entities";
@@ -8,20 +9,45 @@ import type { AssignmentFormData } from "@/lib/assignment-schema";
 import { slugify } from "@/lib/naming";
 import type { Paradigma } from "@/types";
 
+export class ComisionActivaRequeridaError extends Error {
+  constructor() {
+    super("Necesitás una comisión activa para crear assignments.");
+    this.name = "ComisionActivaRequeridaError";
+  }
+}
+
 export async function getAssignments(): Promise<Assignment[]> {
   const entityManager = await getEM();
-  return entityManager.find(Assignment, {}, { orderBy: { createdAt: "DESC" } });
+  return entityManager.find(
+    Assignment,
+    {},
+    { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
+  );
+}
+
+export async function getAssignmentsDeComision(
+  comisionId: string
+): Promise<Assignment[]> {
+  const entityManager = await getEM();
+  return entityManager.find(
+    Assignment,
+    { comision: { id: comisionId } },
+    { orderBy: { createdAt: "DESC" } }
+  );
 }
 
 export async function getAssignment(id: string): Promise<Assignment | null> {
   const entityManager = await getEM();
-  return entityManager.findOne(Assignment, { id });
+  return entityManager.findOne(Assignment, { id }, { populate: ["comision"] });
 }
 
 export async function createAssignment(
   data: AssignmentFormData
 ): Promise<Assignment> {
   const entityManager = await getEM();
+  const comisionActiva = await entityManager.findOne(Comision, { activa: true });
+  if (!comisionActiva) throw new ComisionActivaRequeridaError();
+
   const slug = data.slug || slugify(data.titulo);
 
   let assignment: Assignment;
@@ -39,6 +65,7 @@ export async function createAssignment(
   assignment.descripcion = data.descripcion;
   assignment.templateRepo = data.templateRepo;
   assignment.paradigma = data.paradigma as Paradigma;
+  assignment.comision = comisionActiva;
   if (data.deadline) assignment.deadline = new Date(data.deadline);
 
   entityManager.persist(assignment);

--- a/src/lib/repositories/ComisionRepository.test.ts
+++ b/src/lib/repositories/ComisionRepository.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockTx = {
+  findOne: vi.fn(),
+  nativeUpdate: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+const mockEm = {
+  findOne: vi.fn(),
+  nativeUpdate: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+  transactional: vi.fn(async (callback: (transaction: typeof mockTx) => Promise<unknown>) =>
+    callback(mockTx)
+  ),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import {
+  createComision,
+  updateComision,
+  ComisionActivaDuplicadaError,
+} from "./ComisionRepository";
+import { Comision } from "@/domain/entities";
+
+function uniqueActiveComisionError(): Error {
+  return Object.assign(
+    new Error('duplicate key value violates unique constraint "comision_unica_activa_idx"'),
+    { code: "23505" }
+  );
+}
+
+describe("ComisionRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.transactional.mockImplementation(
+      async (callback: (transaction: typeof mockTx) => Promise<unknown>) =>
+        callback(mockTx)
+    );
+  });
+
+  describe("createComision", () => {
+    it("crea sin transacción cuando no se marca como activa", async () => {
+      const comision = await createComision({
+        anio: 2026,
+        spreadsheetId: "sheet-1",
+        activa: false,
+      });
+
+      expect(mockEm.transactional).not.toHaveBeenCalled();
+      expect(mockEm.nativeUpdate).not.toHaveBeenCalled();
+      expect(mockEm.persist).toHaveBeenCalledWith(comision);
+      expect(mockEm.flush).toHaveBeenCalled();
+      expect(comision.activa).toBe(false);
+    });
+
+    it("si activa=true, desactiva las demás y persiste dentro de una transacción", async () => {
+      const comision = await createComision({
+        anio: 2026,
+        spreadsheetId: "sheet-1",
+        activa: true,
+      });
+
+      expect(mockEm.transactional).toHaveBeenCalledOnce();
+      expect(mockTx.nativeUpdate).toHaveBeenCalledWith(Comision, {}, { activa: false });
+      expect(mockTx.persist).toHaveBeenCalledWith(comision);
+      expect(mockTx.flush).toHaveBeenCalled();
+      expect(comision.activa).toBe(true);
+    });
+
+    it("traduce la violación del índice único de comisión activa", async () => {
+      mockTx.flush.mockRejectedValueOnce(uniqueActiveComisionError());
+
+      await expect(
+        createComision({ anio: 2026, spreadsheetId: "sheet-1", activa: true })
+      ).rejects.toBeInstanceOf(ComisionActivaDuplicadaError);
+    });
+  });
+
+  describe("updateComision", () => {
+    it("actualiza sin transacción cuando no se marca como activa", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      mockEm.findOne.mockResolvedValueOnce(comision);
+
+      const result = await updateComision("c1", {
+        anio: 2026,
+        spreadsheetId: "sheet-new",
+        activa: false,
+      });
+
+      expect(result).toBe(comision);
+      expect(mockEm.transactional).not.toHaveBeenCalled();
+      expect(mockEm.nativeUpdate).not.toHaveBeenCalled();
+      expect(mockEm.flush).toHaveBeenCalled();
+      expect(comision.anio).toBe(2026);
+      expect(comision.spreadsheetId).toBe("sheet-new");
+      expect(comision.activa).toBe(false);
+    });
+
+    it("si activa=true, desactiva las demás y actualiza dentro de una transacción", async () => {
+      const comision = new Comision(2025, "sheet-old");
+      mockTx.findOne.mockResolvedValueOnce(comision);
+
+      const result = await updateComision("c1", {
+        anio: 2026,
+        spreadsheetId: "sheet-new",
+        activa: true,
+      });
+
+      expect(result).toBe(comision);
+      expect(mockEm.transactional).toHaveBeenCalledOnce();
+      expect(mockTx.findOne).toHaveBeenCalledWith(Comision, { id: "c1" });
+      expect(mockTx.nativeUpdate).toHaveBeenCalledWith(
+        Comision,
+        { id: { $ne: "c1" } },
+        { activa: false }
+      );
+      expect(mockTx.flush).toHaveBeenCalled();
+      expect(comision.anio).toBe(2026);
+      expect(comision.spreadsheetId).toBe("sheet-new");
+      expect(comision.activa).toBe(true);
+    });
+
+    it("traduce la violación del índice único de comisión activa", async () => {
+      mockTx.findOne.mockResolvedValueOnce(new Comision(2025, "sheet-old"));
+      mockTx.flush.mockRejectedValueOnce(uniqueActiveComisionError());
+
+      await expect(
+        updateComision("c1", { anio: 2026, spreadsheetId: "sheet-1", activa: true })
+      ).rejects.toBeInstanceOf(ComisionActivaDuplicadaError);
+    });
+  });
+});

--- a/src/lib/repositories/ComisionRepository.ts
+++ b/src/lib/repositories/ComisionRepository.ts
@@ -2,11 +2,43 @@ import { getEM, deleteEntity } from "@/lib/db";
 import { Comision } from "@/domain/entities";
 import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
 
+export class ComisionActivaDuplicadaError extends Error {
+  constructor() {
+    super("Ya existe otra comisión activa.");
+    this.name = "ComisionActivaDuplicadaError";
+  }
+}
+
 export interface ComisionFormData {
   anio: number;
   spreadsheetId: string;
   activa: boolean;
   columnConfig?: ColumnConfig;
+}
+
+function esViolacionDeComisionActivaUnica(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const cause = error.cause;
+  const code =
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  const message = `${error.message} ${
+    cause instanceof Error ? cause.message : ""
+  }`;
+  return code === "23505" && message.includes("comision_unica_activa_idx");
+}
+
+async function traducirErrorDeComisionActiva<T>(
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (esViolacionDeComisionActivaUnica(error)) {
+      throw new ComisionActivaDuplicadaError();
+    }
+    throw error;
+  }
 }
 
 export async function getComisiones(): Promise<Comision[]> {
@@ -27,17 +59,29 @@ export async function getComisionActiva(): Promise<Comision | null> {
 export async function createComision(data: ComisionFormData): Promise<Comision> {
   const entityManager = await getEM();
 
-  if (data.activa) {
-    await entityManager.nativeUpdate(Comision, {}, { activa: false });
-  }
+  return traducirErrorDeComisionActiva(async () => {
+    if (!data.activa) {
+      const comision = new Comision(data.anio, data.spreadsheetId);
+      comision.activa = false;
+      comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
 
-  const comision = new Comision(data.anio, data.spreadsheetId);
-  comision.activa = data.activa;
-  comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
+      entityManager.persist(comision);
+      await entityManager.flush();
+      return comision;
+    }
 
-  entityManager.persist(comision);
-  await entityManager.flush();
-  return comision;
+    return entityManager.transactional(async (transaction) => {
+      await transaction.nativeUpdate(Comision, {}, { activa: false });
+
+      const comision = new Comision(data.anio, data.spreadsheetId);
+      comision.activa = true;
+      comision.columnConfig = data.columnConfig ?? { ...DEFAULT_COLUMN_CONFIG };
+
+      transaction.persist(comision);
+      await transaction.flush();
+      return comision;
+    });
+  });
 }
 
 export async function updateComision(
@@ -45,20 +89,36 @@ export async function updateComision(
   data: Partial<ComisionFormData>
 ): Promise<Comision | null> {
   const entityManager = await getEM();
-  const comision = await entityManager.findOne(Comision, { id });
-  if (!comision) return null;
 
-  if (data.activa) {
-    await entityManager.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
-  }
+  return traducirErrorDeComisionActiva(async () => {
+    if (!data.activa) {
+      const comision = await entityManager.findOne(Comision, { id });
+      if (!comision) return null;
 
-  if (data.anio !== undefined) comision.anio = data.anio;
-  if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
-  if (data.activa !== undefined) comision.activa = data.activa;
-  if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
+      if (data.anio !== undefined) comision.anio = data.anio;
+      if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
+      if (data.activa !== undefined) comision.activa = data.activa;
+      if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
 
-  await entityManager.flush();
-  return comision;
+      await entityManager.flush();
+      return comision;
+    }
+
+    return entityManager.transactional(async (transaction) => {
+      const comision = await transaction.findOne(Comision, { id });
+      if (!comision) return null;
+
+      await transaction.nativeUpdate(Comision, { id: { $ne: id } }, { activa: false });
+
+      if (data.anio !== undefined) comision.anio = data.anio;
+      if (data.spreadsheetId !== undefined) comision.spreadsheetId = data.spreadsheetId;
+      comision.activa = true;
+      if (data.columnConfig !== undefined) comision.columnConfig = data.columnConfig;
+
+      await transaction.flush();
+      return comision;
+    });
+  });
 }
 
 export async function deleteComision(id: string): Promise<void> {

--- a/src/lib/repositories/ComisionRepository.ts
+++ b/src/lib/repositories/ComisionRepository.ts
@@ -1,6 +1,7 @@
 import { getEM, deleteEntity } from "@/lib/db";
 import { Comision } from "@/domain/entities";
 import { type ColumnConfig, DEFAULT_COLUMN_CONFIG } from "@/types";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 
 export class ComisionActivaDuplicadaError extends Error {
   constructor() {
@@ -18,14 +19,11 @@ export interface ComisionFormData {
 
 function esViolacionDeComisionActivaUnica(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  const cause = error.cause;
-  const code =
-    (error as NodeJS.ErrnoException).code ??
-    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  const code = extractDbErrorCode(error);
   const message = `${error.message} ${
-    cause instanceof Error ? cause.message : ""
+    error.cause instanceof Error ? error.cause.message : ""
   }`;
-  return code === "23505" && message.includes("comision_unica_activa_idx");
+  return code === UNIQUE_VIOLATION && message.includes("comision_unica_activa_idx");
 }
 
 async function traducirErrorDeComisionActiva<T>(

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockEm = {
+  find: vi.fn(),
+  findOne: vi.fn(),
+  findOneOrFail: vi.fn(),
+  getReference: vi.fn(),
+  persist: vi.fn(),
+  flush: vi.fn(),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import { Alumno, Assignment, Entrega, Grupo } from "@/domain/entities";
+import {
+  createEntrega,
+  createOrGetEntrega,
+  getEntregaLogica,
+} from "./EntregaRepository";
+
+describe("EntregaRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.find.mockResolvedValue([]);
+    mockEm.findOne.mockResolvedValue(null);
+    mockEm.findOneOrFail.mockResolvedValue({ id: "a1" });
+    mockEm.getReference.mockImplementation((Entity: unknown, id: string) => ({ Entity, id }));
+    mockEm.flush.mockResolvedValue(undefined);
+  });
+
+  it("crea una entrega individual asociando alumnoId", async () => {
+    await createEntrega({
+      assignmentId: "a1",
+      repoName: "kata-juan",
+      repoUrl: "https://github.com/org/kata-juan",
+      githubUsernames: ["juan"],
+      alumnoId: "alumno-1",
+    });
+
+    const entrega = mockEm.persist.mock.calls[0][0] as Entrega;
+    expect(mockEm.findOneOrFail).toHaveBeenCalledWith(Assignment, { id: "a1" });
+    expect(mockEm.getReference).toHaveBeenCalledWith(Alumno, "alumno-1");
+    expect(entrega.alumno).toEqual({ Entity: Alumno, id: "alumno-1" });
+    expect(entrega.grupo).toBeUndefined();
+  });
+
+  it("crea una entrega grupal asociando grupoId", async () => {
+    await createEntrega({
+      assignmentId: "a1",
+      repoName: "kata-los-lambdas",
+      repoUrl: "https://github.com/org/kata-los-lambdas",
+      githubUsernames: ["juan", "maria"],
+      grupoId: "g1",
+    });
+
+    const entrega = mockEm.persist.mock.calls[0][0] as Entrega;
+    expect(mockEm.getReference).toHaveBeenCalledWith(Grupo, "g1");
+    expect(entrega.grupo).toEqual({ Entity: Grupo, id: "g1" });
+    expect(entrega.alumno).toBeUndefined();
+  });
+
+  it("busca entrega lógica individual por assignment y alumno", async () => {
+    await getEntregaLogica({ assignmentId: "a1", alumnoId: "alumno-1" });
+
+    expect(mockEm.findOne).toHaveBeenCalledWith(
+      Entrega,
+      { assignment: { id: "a1" }, alumno: { id: "alumno-1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  });
+
+  it("busca entrega lógica grupal por assignment y grupo", async () => {
+    await getEntregaLogica({ assignmentId: "a1", grupoId: "g1" });
+
+    expect(mockEm.findOne).toHaveBeenCalledWith(
+      Entrega,
+      { assignment: { id: "a1" }, grupo: { id: "g1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  });
+
+  it("createOrGetEntrega devuelve existente por repoName sin insertar", async () => {
+    const existing = new Entrega();
+    mockEm.findOne.mockResolvedValueOnce(existing);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(existing);
+
+    expect(mockEm.persist).not.toHaveBeenCalled();
+  });
+
+  it("createOrGetEntrega reconsulta y devuelve existente ante violación única", async () => {
+    const existing = new Entrega();
+    const duplicate = new Error("duplicate key value violates unique constraint");
+    (duplicate as NodeJS.ErrnoException).code = "23505";
+
+    mockEm.findOne
+      .mockResolvedValueOnce(null) // repo lookup inicial
+      .mockResolvedValueOnce(null) // lógica lookup inicial
+      .mockResolvedValueOnce(existing); // repo lookup tras duplicate
+    mockEm.flush.mockRejectedValueOnce(duplicate);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(existing);
+  });
+});

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -83,6 +83,7 @@ describe("EntregaRepository", () => {
 
   it("createOrGetEntrega devuelve existente por repoName sin insertar", async () => {
     const existing = new Entrega();
+    existing.assignment = { id: "a1" } as Assignment;
     mockEm.findOne.mockResolvedValueOnce(existing);
 
     await expect(
@@ -98,8 +99,37 @@ describe("EntregaRepository", () => {
     expect(mockEm.persist).not.toHaveBeenCalled();
   });
 
+  it("createOrGetEntrega ignora repoName existente de otro assignment y busca por entrega lógica", async () => {
+    const repoMatch = new Entrega();
+    repoMatch.assignment = { id: "otro-assignment" } as Assignment;
+    const logicalMatch = new Entrega();
+    logicalMatch.assignment = { id: "a1" } as Assignment;
+    mockEm.findOne
+      .mockResolvedValueOnce(repoMatch)
+      .mockResolvedValueOnce(logicalMatch);
+
+    await expect(
+      createOrGetEntrega({
+        assignmentId: "a1",
+        repoName: "kata-juan",
+        repoUrl: "https://github.com/org/kata-juan",
+        githubUsernames: ["juan"],
+        alumnoId: "alumno-1",
+      })
+    ).resolves.toBe(logicalMatch);
+
+    expect(mockEm.findOne).toHaveBeenNthCalledWith(
+      2,
+      Entrega,
+      { assignment: { id: "a1" }, alumno: { id: "alumno-1" } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+    expect(mockEm.persist).not.toHaveBeenCalled();
+  });
+
   it("createOrGetEntrega reconsulta y devuelve existente ante violación única", async () => {
     const existing = new Entrega();
+    existing.assignment = { id: "a1" } as Assignment;
     const duplicate = new Error("duplicate key value violates unique constraint");
     (duplicate as NodeJS.ErrnoException).code = "23505";
 

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -1,4 +1,5 @@
 import { getEM } from "@/lib/db";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 import { Alumno, Assignment, Grupo, Entrega } from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
@@ -141,11 +142,8 @@ export async function createEntrega(data: {
 
 function isUniqueViolation(error: unknown): boolean {
   if (!(error instanceof Error)) return false;
-  const cause = error.cause;
-  const code =
-    (error as NodeJS.ErrnoException).code ??
-    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
-  return code === "23505" || /unique constraint|duplicate key/i.test(error.message);
+  const code = extractDbErrorCode(error);
+  return code === UNIQUE_VIOLATION || /unique constraint|duplicate key/i.test(error.message);
 }
 
 async function findExistingEntrega(data: {

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -1,5 +1,5 @@
 import { getEM } from "@/lib/db";
-import { Assignment, Grupo, Entrega } from "@/domain/entities";
+import { Alumno, Assignment, Grupo, Entrega } from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
   const entityManager = await getEM();
@@ -37,6 +37,38 @@ export async function getEntregaDeUsuario(
       )
     ) ?? null
   );
+}
+
+export async function getEntregaByRepoName(repoName: string): Promise<Entrega | null> {
+  const entityManager = await getEM();
+  return entityManager.findOne(
+    Entrega,
+    { repoName },
+    { populate: ["assignment", "grupo", "alumno"] }
+  );
+}
+
+export async function getEntregaLogica(data: {
+  assignmentId: string;
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega | null> {
+  const entityManager = await getEM();
+  if (data.grupoId) {
+    return entityManager.findOne(
+      Entrega,
+      { assignment: { id: data.assignmentId }, grupo: { id: data.grupoId } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  }
+  if (data.alumnoId) {
+    return entityManager.findOne(
+      Entrega,
+      { assignment: { id: data.assignmentId }, alumno: { id: data.alumnoId } },
+      { populate: ["assignment", "grupo", "alumno"] }
+    );
+  }
+  return null;
 }
 
 // Devuelve el conteo de entregas por assignmentId en una sola query.
@@ -81,6 +113,7 @@ export async function createEntrega(data: {
   repoName: string;
   repoUrl: string;
   githubUsernames: string[];
+  alumnoId?: string;
   grupoId?: string;
 }): Promise<Entrega> {
   const entityManager = await getEM();
@@ -93,6 +126,10 @@ export async function createEntrega(data: {
   entrega.repoUrl = data.repoUrl;
   entrega.githubUsernames = data.githubUsernames;
 
+  if (data.alumnoId) {
+    entrega.alumno = entityManager.getReference(Alumno, data.alumnoId);
+  }
+
   if (data.grupoId) {
     entrega.grupo = entityManager.getReference(Grupo, data.grupoId);
   }
@@ -100,4 +137,50 @@ export async function createEntrega(data: {
   entityManager.persist(entrega);
   await entityManager.flush();
   return entrega;
+}
+
+function isUniqueViolation(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const cause = error.cause;
+  const code =
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object" ? (cause as NodeJS.ErrnoException).code : undefined);
+  return code === "23505" || /unique constraint|duplicate key/i.test(error.message);
+}
+
+async function findExistingEntrega(data: {
+  assignmentId: string;
+  repoName: string;
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega | null> {
+  return (
+    (await getEntregaByRepoName(data.repoName)) ??
+    (await getEntregaLogica({
+      assignmentId: data.assignmentId,
+      alumnoId: data.alumnoId,
+      grupoId: data.grupoId,
+    }))
+  );
+}
+
+export async function createOrGetEntrega(data: {
+  assignmentId: string;
+  repoName: string;
+  repoUrl: string;
+  githubUsernames: string[];
+  alumnoId?: string;
+  grupoId?: string;
+}): Promise<Entrega> {
+  const existing = await findExistingEntrega(data);
+  if (existing) return existing;
+
+  try {
+    return await createEntrega(data);
+  } catch (error) {
+    if (!isUniqueViolation(error)) throw error;
+    const reconciled = await findExistingEntrega(data);
+    if (reconciled) return reconciled;
+    throw error;
+  }
 }

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -154,14 +154,14 @@ async function findExistingEntrega(data: {
   alumnoId?: string;
   grupoId?: string;
 }): Promise<Entrega | null> {
-  return (
-    (await getEntregaByRepoName(data.repoName)) ??
-    (await getEntregaLogica({
-      assignmentId: data.assignmentId,
-      alumnoId: data.alumnoId,
-      grupoId: data.grupoId,
-    }))
-  );
+  const entrega = await getEntregaByRepoName(data.repoName);
+  if (entrega?.assignment?.id === data.assignmentId) return entrega;
+
+  return getEntregaLogica({
+    assignmentId: data.assignmentId,
+    alumnoId: data.alumnoId,
+    grupoId: data.grupoId,
+  });
 }
 
 export async function createOrGetEntrega(data: {

--- a/src/lib/repositories/db-errors.test.ts
+++ b/src/lib/repositories/db-errors.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
+
+describe("extractDbErrorCode", () => {
+  it("devuelve undefined si el error no es una instancia de Error", () => {
+    expect(extractDbErrorCode("string-error")).toBeUndefined();
+    expect(extractDbErrorCode(null)).toBeUndefined();
+    expect(extractDbErrorCode(42)).toBeUndefined();
+    expect(extractDbErrorCode(undefined)).toBeUndefined();
+  });
+
+  it("extrae el código directamente de error.code", () => {
+    const error = Object.assign(new Error("unique violation"), { code: "23505" });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("extrae el código desde error.cause.code cuando error.code no existe", () => {
+    const cause = Object.assign(new Error("inner"), { code: "23505" });
+    const error = new Error("outer", { cause });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("prefiere error.code sobre cause.code si ambos existen", () => {
+    const cause = Object.assign(new Error("inner"), { code: "12345" });
+    const error = Object.assign(new Error("outer", { cause }), { code: "23505" });
+    expect(extractDbErrorCode(error)).toBe("23505");
+  });
+
+  it("devuelve undefined si ni error.code ni cause.code están presentes", () => {
+    const error = new Error("sin code");
+    expect(extractDbErrorCode(error)).toBeUndefined();
+  });
+
+  it("devuelve undefined si cause no es un objeto", () => {
+    const error = Object.assign(new Error("outer"), { cause: "string-cause" });
+    expect(extractDbErrorCode(error)).toBeUndefined();
+  });
+});
+
+describe("UNIQUE_VIOLATION", () => {
+  it("es el código de violación de unicidad de Postgres", () => {
+    expect(UNIQUE_VIOLATION).toBe("23505");
+  });
+});

--- a/src/lib/repositories/db-errors.ts
+++ b/src/lib/repositories/db-errors.ts
@@ -1,0 +1,25 @@
+/**
+ * Constante y helper compartidos para detectar errores del driver de Postgres.
+ * Cada repositorio define su propio predicado específico (qué constraint viola)
+ * y llama a `extractDbErrorCode` para obtener el código de error sin duplicar
+ * la lógica de introspección de `error.cause`.
+ */
+
+export const UNIQUE_VIOLATION = "23505";
+
+/**
+ * Extrae el código de error del driver de Postgres desde un error desconocido.
+ * El driver puede colocar el código directamente en `error.code` o anidado
+ * en `error.cause.code` — esta función los unifica.
+ * Devuelve `undefined` si el error no es una instancia de `Error`.
+ */
+export function extractDbErrorCode(error: unknown): string | undefined {
+  if (!(error instanceof Error)) return undefined;
+  const cause = error.cause;
+  return (
+    (error as NodeJS.ErrnoException).code ??
+    (cause && typeof cause === "object"
+      ? (cause as NodeJS.ErrnoException).code
+      : undefined)
+  );
+}

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -32,9 +32,12 @@ export {
   getEntregas,
   getEntregasDeUsuario,
   getEntregaDeUsuario,
+  getEntregaByRepoName,
+  getEntregaLogica,
   getEntregaCountsByAssignment,
   getActiveRepoCountsByAssignment,
   createEntrega,
+  createOrGetEntrega,
   clearReposDeAssignment,
 } from "./EntregaRepository";
 

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -19,11 +19,13 @@ export type { AlumnoData } from "./AlumnoRepository";
 
 export {
   getAssignments,
+  getAssignmentsDeComision,
   getAssignment,
   createAssignment,
   updateAssignment,
   deleteAssignment,
   setInscripcionesCerradas,
+  ComisionActivaRequeridaError,
 } from "./AssignmentRepository";
 
 export {

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -1,6 +1,7 @@
 export {
   getAlumnos,
   getAlumnoByGithub,
+  getAlumnosByGithubUsernames,
   getAlumnoByLegajo,
   createAlumno,
   upsertAlumno,

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -53,5 +53,6 @@ export {
   createComision,
   updateComision,
   deleteComision,
+  ComisionActivaDuplicadaError,
 } from "./ComisionRepository";
 export type { ComisionFormData } from "./ComisionRepository";

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { PdepUser } from "@/types";
+import {
+  Alumno,
+  Entrega,
+  GrupalAssignment,
+  IndividualAssignment,
+  type Assignment,
+} from "@/domain/entities";
+
+const mockGetAssignment = vi.fn();
+const mockGetEntregaDeUsuario = vi.fn();
+const mockGetGrupoDeAlumno = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockCreateOrGetEntrega = vi.fn();
+const mockCrearEntrega = vi.fn();
+const mockRepoExists = vi.fn();
+const mockAddCollaborators = vi.fn();
+
+vi.mock("@/lib/repositories", () => ({
+  getAssignment: (id: string) => mockGetAssignment(id),
+  getEntregaDeUsuario: (assignmentId: string, username: string) =>
+    mockGetEntregaDeUsuario(assignmentId, username),
+  getGrupoDeAlumnoEnAssignment: (assignmentId: string, username: string) =>
+    mockGetGrupoDeAlumno(assignmentId, username),
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  createOrGetEntrega: (data: unknown) => mockCreateOrGetEntrega(data),
+}));
+
+vi.mock("@/lib/github", () => ({
+  crearEntrega: (opts: unknown) => mockCrearEntrega(opts),
+  repoExists: (repoName: string) => mockRepoExists(repoName),
+  addCollaborators: (repoName: string, usernames: string[]) =>
+    mockAddCollaborators(repoName, usernames),
+}));
+
+import {
+  aceptarAssignment,
+  AlumnoNoRegistradoError,
+  AssignmentNoEncontradoError,
+} from "./aceptarAssignment";
+
+function makeUser(overrides?: Partial<PdepUser>): PdepUser {
+  return {
+    githubUsername: "juangarcia",
+    name: "Juan García",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+function makeAssignment(overrides?: Partial<IndividualAssignment & GrupalAssignment>): Assignment {
+  const assignment: Assignment =
+    overrides?.tipo === "grupal"
+      ? Object.assign(new GrupalAssignment(), { maxIntegrantes: 4 })
+      : new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.titulo = "Kata Funcional";
+  assignment.descripcion = "";
+  assignment.templateRepo = "pdep-mn-utn/kata-template";
+  assignment.paradigma = "funcional";
+  assignment.slug = "kata-funcional";
+  assignment.createdAt = new Date("2026-01-01");
+  return Object.assign(assignment, overrides);
+}
+
+function makeAlumno(overrides?: Partial<Alumno>): Alumno {
+  const alumno = new Alumno();
+  alumno.id = "alumno-1";
+  alumno.githubUsername = "juangarcia";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "García";
+  alumno.email = "juan@example.com";
+  return Object.assign(alumno, overrides);
+}
+
+function makeEntrega(overrides?: Partial<Entrega>): Entrega {
+  const entrega = new Entrega();
+  entrega.id = "e1";
+  entrega.repoName = "kata-funcional-juangarcia";
+  entrega.repoUrl = "https://github.com/pdep-mn-utn/kata-funcional-juangarcia";
+  entrega.githubUsernames = ["juangarcia"];
+  entrega.createdAt = new Date();
+  return Object.assign(entrega, overrides);
+}
+
+function makeGrupo(githubUsernames: string[], id = "los-lambdas") {
+  return {
+    id,
+    usernamesDeMiembros: () => githubUsernames,
+  };
+}
+
+describe("aceptarAssignment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAssignment.mockResolvedValue(makeAssignment());
+    mockGetEntregaDeUsuario.mockResolvedValue(null);
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockRepoExists.mockResolvedValue(false);
+    mockCrearEntrega.mockResolvedValue({
+      repoName: "kata-funcional-juangarcia",
+      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
+    });
+    mockCreateOrGetEntrega.mockResolvedValue(makeEntrega());
+  });
+
+  it("devuelve la entrega existente sin tocar GitHub", async () => {
+    const entrega = makeEntrega();
+    mockGetEntregaDeUsuario.mockResolvedValue(entrega);
+
+    await expect(aceptarAssignment("a1", makeUser())).resolves.toBe(entrega);
+
+    expect(mockRepoExists).not.toHaveBeenCalled();
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+    expect(mockCreateOrGetEntrega).not.toHaveBeenCalled();
+  });
+
+  it("falla con error de dominio si el assignment no existe", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AssignmentNoEncontradoError
+    );
+  });
+
+  it("crea repo y entrega individual con alumnoId", async () => {
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockCrearEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        templateRepo: "kata-template",
+        slug: "kata-funcional",
+        usernames: ["juangarcia"],
+      })
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: "a1",
+        alumnoId: "alumno-1",
+        grupoId: undefined,
+        repoName: "kata-funcional-juangarcia",
+      })
+    );
+  });
+
+  it("falla si el alumno individual no existe en DB", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AlumnoNoRegistradoError
+    );
+
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+  });
+
+  it("crea entrega grupal con grupoId y todos los miembros", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment({ tipo: "grupal" }));
+    mockGetGrupoDeAlumno.mockResolvedValue(makeGrupo(["juangarcia", "mariaperez"]));
+    mockCrearEntrega.mockResolvedValue({
+      repoName: "kata-funcional-los-lambdas",
+      repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-los-lambdas",
+    });
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        assignmentId: "a1",
+        alumnoId: undefined,
+        grupoId: "los-lambdas",
+        githubUsernames: ["juangarcia", "mariaperez"],
+      })
+    );
+  });
+
+  it("reconcilia cuando el repo ya existe en GitHub", async () => {
+    mockRepoExists.mockResolvedValue(true);
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+    expect(mockAddCollaborators).toHaveBeenCalledWith(
+      "kata-funcional-juangarcia",
+      ["juangarcia"]
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoName: "kata-funcional-juangarcia",
+        repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
+      })
+    );
+  });
+
+  it("si crearEntrega falla pero el repo apareció, reconcilia la entrega local", async () => {
+    mockRepoExists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(true);
+    mockCrearEntrega.mockRejectedValue(new Error("name already exists"));
+
+    await aceptarAssignment("a1", makeUser());
+
+    expect(mockAddCollaborators).toHaveBeenCalledWith(
+      "kata-funcional-juangarcia",
+      ["juangarcia"]
+    );
+    expect(mockCreateOrGetEntrega).toHaveBeenCalled();
+  });
+
+  it("propaga el error de GitHub si el repo no existe después del fallo", async () => {
+    mockRepoExists
+      .mockResolvedValueOnce(false)
+      .mockResolvedValueOnce(false);
+    mockCrearEntrega.mockRejectedValue(new Error("GitHub caído"));
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toThrow("GitHub caído");
+  });
+});

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -1,0 +1,81 @@
+import { Entrega, type ParticipantesResueltos } from "@/domain/entities";
+import type { PdepUser } from "@/types";
+import {
+  getAlumnoByGithub,
+  getAssignment,
+  getEntregaDeUsuario,
+  getGrupoDeAlumnoEnAssignment,
+  createOrGetEntrega,
+} from "@/lib/repositories";
+import { addCollaborators, crearEntrega, repoExists } from "@/lib/github";
+import { buildRepoName } from "@/lib/naming";
+
+export class AssignmentNoEncontradoError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Assignment no encontrado");
+    this.name = "AssignmentNoEncontradoError";
+  }
+}
+
+export class AlumnoNoRegistradoError extends Error {
+  constructor(public readonly githubUsername: string) {
+    super("Completá tu registro antes de aceptar este assignment.");
+    this.name = "AlumnoNoRegistradoError";
+  }
+}
+
+function repoUrlFor(repoName: string): string {
+  const org = process.env.GITHUB_ORG ?? "pdep-mn-utn";
+  return `https://github.com/${org}/${repoName}`;
+}
+
+export async function aceptarAssignment(
+  assignmentId: string,
+  user: PdepUser
+): Promise<Entrega> {
+  const assignment = await getAssignment(assignmentId);
+  if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
+
+  const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
+  if (existente) return existente;
+
+  const participantes: ParticipantesResueltos = await assignment.resolverParticipantesPara(
+    user,
+    getGrupoDeAlumnoEnAssignment
+  );
+
+  const { usernames, grupoId } = participantes;
+  const alumno = grupoId ? null : await getAlumnoByGithub(user.githubUsername);
+  if (!grupoId && !alumno) throw new AlumnoNoRegistradoError(user.githubUsername);
+
+  const repoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
+  const createLocalEntrega = (createdRepoName: string, repoUrl: string) =>
+    createOrGetEntrega({
+      assignmentId: assignment.id,
+      repoName: createdRepoName,
+      repoUrl,
+      githubUsernames: usernames,
+      alumnoId: alumno?.id,
+      grupoId,
+    });
+
+  if (await repoExists(repoName)) {
+    await addCollaborators(repoName, usernames);
+    return createLocalEntrega(repoName, repoUrlFor(repoName));
+  }
+
+  try {
+    const resultado = await crearEntrega({
+      templateRepo: assignment.nombreDelTemplate(),
+      slug: assignment.slug,
+      usernames,
+      grupoId,
+      descripcion: `${assignment.titulo} — PdeP`,
+    });
+    return createLocalEntrega(resultado.repoName, resultado.repoUrl);
+  } catch (error) {
+    if (!(await repoExists(repoName))) throw error;
+    await addCollaborators(repoName, usernames);
+    return createLocalEntrega(repoName, repoUrlFor(repoName));
+  }
+}

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -3,9 +3,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockGetComisionActiva = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
 const mockUpsertAlumno = vi.fn();
 const mockMarcarRegistroConfirmado = vi.fn();
 const mockUpsertarAlumnoEnSheets = vi.fn();
+const mockEjecutarHooksPostConfirmacion = vi.fn();
 
 const { FakeLegajoConflictError } = vi.hoisted(() => {
   class FakeLegajoConflictError extends Error {
@@ -24,10 +26,17 @@ const { FakeLegajoConflictError } = vi.hoisted(() => {
 
 vi.mock("@/lib/repositories", () => ({
   getComisionActiva: () => mockGetComisionActiva(),
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
   upsertAlumno: (data: unknown) => mockUpsertAlumno(data),
   marcarRegistroConfirmado: (...args: unknown[]) =>
     mockMarcarRegistroConfirmado(...args),
   LegajoConflictError: FakeLegajoConflictError,
+}));
+
+vi.mock("./hooksPostConfirmacion", () => ({
+  ejecutarHooksPostConfirmacion: (...args: unknown[]) =>
+    mockEjecutarHooksPostConfirmacion(...args),
+  HOOKS_CONFIRMACION_ALUMNO: [],
 }));
 
 // Para `validateRegistro` usamos la implementación real: es pura y testearla
@@ -41,7 +50,7 @@ vi.mock("@/lib/sheets", async () => {
   };
 });
 
-import { confirmarDatosAlumno } from "./alumnoRegistro";
+import { confirmarDatosAlumno, confirmarYProcesarAlumno } from "./alumnoRegistro";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -73,9 +82,11 @@ describe("confirmarDatosAlumno", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockGetAlumnoByGithub.mockResolvedValue(null);
     mockUpsertAlumno.mockResolvedValue(undefined);
     mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
     mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({});
   });
 
   it("devuelve { ok: true, comision } cuando todo el flujo funciona", async () => {
@@ -225,5 +236,75 @@ describe("confirmarDatosAlumno", () => {
   it("deja propagar errores inesperados del upsert en DB (no-LegajoConflictError)", async () => {
     mockUpsertAlumno.mockRejectedValue(new Error("conexión caída"));
     await expect(confirmarDatosAlumno(validInput)).rejects.toThrow("conexión caída");
+  });
+});
+
+// ── confirmarYProcesarAlumno ─────────────────────────────────
+
+describe("confirmarYProcesarAlumno", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetComisionActiva.mockResolvedValue(comisionActiva);
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    mockUpsertAlumno.mockResolvedValue(undefined);
+    mockMarcarRegistroConfirmado.mockResolvedValue(undefined);
+    mockUpsertarAlumnoEnSheets.mockResolvedValue({ ok: true });
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({ groupSubscription: "added", gruposSync: "ok" });
+  });
+
+  it("propaga el resultado { ok: false } cuando confirmarDatosAlumno falla", async () => {
+    mockGetComisionActiva.mockResolvedValue(null);
+    const resultado = await confirmarYProcesarAlumno(validInput);
+    expect(resultado).toMatchObject({ ok: false, status: 409 });
+    expect(mockEjecutarHooksPostConfirmacion).not.toHaveBeenCalled();
+  });
+
+  it("devuelve { ok: true, comision, hooks } cuando todo funciona", async () => {
+    const resultado = await confirmarYProcesarAlumno(validInput);
+    expect(resultado).toEqual({
+      ok: true,
+      comision: comisionActiva,
+      hooks: { groupSubscription: "added", gruposSync: "ok" },
+    });
+  });
+
+  it("ejecuta los hooks pasando el contexto del alumno", async () => {
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: validInput.githubUsername,
+        email: validInput.email,
+        comision: comisionActiva,
+      }),
+      expect.any(Array)
+    );
+  });
+
+  it("pasa emailPrevio: undefined cuando el alumno no existe en DB antes de confirmar", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({ emailPrevio: undefined }),
+      expect.any(Array)
+    );
+  });
+
+  it("pasa el email previo del alumno existente para que el hook lo des-suscriba si cambió", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
+    await confirmarYProcesarAlumno(validInput);
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({ emailPrevio: "viejo@gmail.com" }),
+      expect.any(Array)
+    );
+  });
+
+  it("lee el email previo ANTES de confirmar (upsertAlumno pisa el email en DB)", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
+    await confirmarYProcesarAlumno(validInput);
+    const ordenLlamadas = [
+      mockGetAlumnoByGithub.mock.invocationCallOrder[0],
+      mockUpsertAlumno.mock.invocationCallOrder[0],
+    ];
+    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
   });
 });

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -1,12 +1,19 @@
-import { upsertarAlumnoEnSheets, validateRegistro, type RegistroInput } from "@/lib/sheets";
+import { validateRegistro, type RegistroInput } from "@/domain/entities";
+import { upsertarAlumnoEnSheets } from "@/lib/sheets";
 import {
   getComisionActiva,
+  getAlumnoByGithub,
   upsertAlumno,
   marcarRegistroConfirmado,
   LegajoConflictError,
 } from "@/lib/repositories";
 import { Comision } from "@/domain/entities";
 import { logger } from "@/lib/logger";
+import {
+  ejecutarHooksPostConfirmacion,
+  HOOKS_CONFIRMACION_ALUMNO,
+  type ResultadoHooks,
+} from "./hooksPostConfirmacion";
 
 /**
  * Resultado de `confirmarDatosAlumno` — discriminated union con el status HTTP
@@ -28,9 +35,9 @@ export type ResultadoConfirmacion =
  * valida los datos del alumno, persiste en DB (DB-primero para atomicidad
  * sobre legajo↔github) y refleja en la planilla.
  *
- * El handler es quien agrega lo específico: registro hace la validación de
- * coherencia github↔sesión antes de llamar, y después de un resultado OK
- * dispara los hooks accesorios (Google Groups, sync de grupos desde planilla).
+ * El handler agrega lo específico de HTTP, como la validación de coherencia
+ * github↔sesión. El flujo de aplicación `confirmarYProcesarAlumno` encadena los
+ * hooks accesorios después de una confirmación OK.
  */
 export async function confirmarDatosAlumno(
   input: RegistroInput
@@ -103,4 +110,45 @@ export async function confirmarDatosAlumno(
   }
 
   return { ok: true, comision: comisionActiva };
+}
+
+export type ResultadoConfirmacionConHooks =
+  | { ok: true; comision: Comision; hooks: ResultadoHooks }
+  | {
+      ok: false;
+      status: 400 | 409;
+      error: string;
+      field?: "legajo" | "githubUsername";
+    };
+
+/**
+ * Orquesta el evento completo "alumno confirmado/actualizado" para los flujos de
+ * un único alumno (registro y perfil): confirma los datos y dispara los hooks
+ * accesorios (Google Groups + sync de grupos). Captura el email previo ANTES de
+ * confirmar para que, si cambió, el hook de Google Groups des-suscriba la
+ * dirección vieja. La ruta sólo valida entrada, llama acá y traduce el resultado
+ * a HTTP.
+ */
+export async function confirmarYProcesarAlumno(
+  input: RegistroInput
+): Promise<ResultadoConfirmacionConHooks> {
+  // El email previo se lee antes de confirmar: `upsertAlumno` (dentro de
+  // `confirmarDatosAlumno`) pisa el email en la DB, así que después ya no
+  // tendríamos la dirección vieja para des-suscribirla del grupo.
+  const emailPrevio = (await getAlumnoByGithub(input.githubUsername))?.email;
+
+  const resultado = await confirmarDatosAlumno(input);
+  if (!resultado.ok) return resultado;
+
+  const hooks = await ejecutarHooksPostConfirmacion(
+    {
+      githubUsername: input.githubUsername,
+      email: input.email,
+      comision: resultado.comision,
+      emailPrevio,
+    },
+    HOOKS_CONFIRMACION_ALUMNO
+  );
+
+  return { ok: true, comision: resultado.comision, hooks };
 }

--- a/src/lib/services/hooksPostConfirmacion.test.ts
+++ b/src/lib/services/hooksPostConfirmacion.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockAgregarMiembroAGrupo = vi.fn();
+const mockQuitarMiembroDeGrupo = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
+
+vi.mock("@/lib/googleGroups", () => ({
+  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
+  quitarMiembroDeGrupo: (...args: unknown[]) => mockQuitarMiembroDeGrupo(...args),
+}));
+
+vi.mock("./intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
+}));
+
+import {
+  hookGoogleGroups,
+  hookGruposSync,
+  ejecutarHooksPostConfirmacion,
+  HOOKS_CONFIRMACION_ALUMNO,
+  HOOKS_IMPORTACION_ALUMNO,
+  type ContextoAlumno,
+} from "./hooksPostConfirmacion";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeCtx(overrides: Partial<ContextoAlumno> = {}): ContextoAlumno {
+  return {
+    githubUsername: "juangarcia",
+    email: "juan@gmail.com",
+    comision: { id: "c1" } as never,
+    ...overrides,
+  };
+}
+
+// ── hookGoogleGroups ─────────────────────────────────────────
+
+describe("hookGoogleGroups", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "removed" });
+  });
+
+  it("devuelve el status de la suscripción del email actual", async () => {
+    const resultado = await hookGoogleGroups(makeCtx());
+    expect(resultado).toEqual({ groupSubscription: "added" });
+  });
+
+  it("pasa el email del contexto a agregarMiembroAGrupo", async () => {
+    await hookGoogleGroups(makeCtx({ email: "nueva@utn.edu.ar" }));
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("nueva@utn.edu.ar");
+  });
+
+  it("loguea (con email enmascarado) cuando la suscripción falla", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "Sin permisos" });
+
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com" }));
+
+    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
+    expect(loggedPayload).not.toContain("juan@gmail.com");
+    expect(loggedPayload).toContain("@gmail.com");
+    expect(loggedPayload).toContain("juangarcia");
+    errorSpy.mockRestore();
+  });
+
+  it("devuelve groupSubscription:'error' cuando la suscripción falla (sin throwear)", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    const resultado = await hookGoogleGroups(makeCtx());
+    expect(resultado).toEqual({ groupSubscription: "error" });
+  });
+
+  it("no intenta quitar el email previo cuando no hay emailPrevio", async () => {
+    await hookGoogleGroups(makeCtx({ emailPrevio: undefined }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no intenta quitar el email previo cuando el email no cambió", async () => {
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "juan@gmail.com" }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no intenta quitar el email previo cuando la normalización coincide (case, espacios)", async () => {
+    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "  JUAN@GMAIL.COM  " }));
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("quita el email previo cuando el email cambió", async () => {
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
+  });
+
+  it("quita el email previo cuando el email actual ya estaba suscripto", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
+  });
+
+  it("no quita el email previo si falló la suscripción del email actual", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no quita el email previo si la suscripción del email actual fue skipeada", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
+  });
+
+  it("no degrada groupSubscription cuando la baja del email previo falla", async () => {
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+    const resultado = await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+    expect(resultado).toEqual({ groupSubscription: "added" });
+  });
+
+  it("loguea (con email enmascarado) cuando la baja del email previo falla", async () => {
+    const { logger } = await import("@/lib/logger");
+    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+
+    await hookGoogleGroups(
+      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+    );
+
+    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
+    expect(loggedPayload).not.toContain("viejo@gmail.com");
+    expect(loggedPayload).toContain("@gmail.com");
+    errorSpy.mockRestore();
+  });
+});
+
+// ── hookGruposSync ───────────────────────────────────────────
+
+describe("hookGruposSync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("devuelve gruposSync:'ok' cuando el wrapper resuelve sin error", async () => {
+    const resultado = await hookGruposSync(makeCtx());
+    expect(resultado).toEqual({ gruposSync: "ok" });
+  });
+
+  it("devuelve gruposSync:'error' (sin throwear) cuando el wrapper lanza", async () => {
+    mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
+    const resultado = await hookGruposSync(makeCtx());
+    expect(resultado).toEqual({ gruposSync: "error" });
+  });
+
+  it("pasa githubUsername y comision a intentarSincronizarGrupos", async () => {
+    const comision = { id: "c2" } as never;
+    await hookGruposSync(makeCtx({ githubUsername: "anagarcia", comision }));
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("anagarcia", comision);
+  });
+});
+
+// ── ejecutarHooksPostConfirmacion ────────────────────────────
+
+describe("ejecutarHooksPostConfirmacion", () => {
+  it("devuelve resultado vacío cuando la lista de hooks está vacía", async () => {
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), []);
+    expect(resultado).toEqual({});
+  });
+
+  it("mergea los slices de resultado de múltiples hooks", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [
+      hookGoogleGroups,
+      hookGruposSync,
+    ]);
+
+    expect(resultado).toEqual({ groupSubscription: "added", gruposSync: "ok" });
+  });
+
+  it("el slice de un hook posterior pisa el anterior si comparten clave", async () => {
+    const hookA = vi.fn().mockResolvedValue({ groupSubscription: "added" });
+    const hookB = vi.fn().mockResolvedValue({ groupSubscription: "already_member" });
+
+    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [hookA, hookB]);
+
+    expect(resultado).toEqual({ groupSubscription: "already_member" });
+  });
+});
+
+// ── Políticas por origen ─────────────────────────────────────
+
+describe("HOOKS_CONFIRMACION_ALUMNO (registro y perfil)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+  });
+
+  it("corre Google Groups y sync de grupos", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_CONFIRMACION_ALUMNO);
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledOnce();
+  });
+});
+
+describe("HOOKS_IMPORTACION_ALUMNO (importación admin)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+  });
+
+  it("corre Google Groups", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
+  });
+
+  // La sync de grupos NO se hace inline en la importación: queda en la action
+  // dedicada `sincronizarGruposDeLaComision` (lectura única de la hoja, UI propia).
+  it("NO corre sync de grupos (queda delegado a sincronizarGruposDeLaComision)", async () => {
+    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/hooksPostConfirmacion.ts
+++ b/src/lib/services/hooksPostConfirmacion.ts
@@ -1,0 +1,131 @@
+import {
+  agregarMiembroAGrupo,
+  quitarMiembroDeGrupo,
+  type AgregarMiembroResult,
+} from "@/lib/googleGroups";
+import { intentarSincronizarGrupos } from "./intentarSincronizarGrupos";
+import { logger } from "@/lib/logger";
+import { Alumno, type Comision } from "@/domain/entities";
+
+/**
+ * Contexto del evento "alumno confirmado/actualizado". `emailPrevio` es el email
+ * que el alumno tenía en la DB antes de esta confirmación; se usa para des-suscribir
+ * del Google Group la dirección vieja cuando el email cambió. En un alta nueva
+ * (registro de un alumno inexistente) o en la importación no hay previo, así que
+ * sólo se suscribe la dirección actual.
+ */
+export type ContextoAlumno = {
+  githubUsername: string;
+  email: string;
+  comision: Comision;
+  emailPrevio?: string;
+};
+
+export type ResultadoHooks = {
+  groupSubscription?: AgregarMiembroResult["status"];
+  gruposSync?: "ok" | "error";
+};
+
+export type HookPostConfirmacion = (ctx: ContextoAlumno) => Promise<ResultadoHooks>;
+
+// Enmascara la parte local del email para no escupir PII a los logs,
+// preservando dominio y primeras 2 letras para que un admin pueda
+// reconocer al alumno (combinado con el githubUsername del log).
+function maskEmail(correo: string): string {
+  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
+}
+
+// Enmascara cualquier email embebido en un texto libre (p. ej. el `message` de
+// un error de googleapis, que suele citar el email del miembro afectado).
+function maskEmailsEnTexto(texto: string): string {
+  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
+}
+
+/**
+ * Suscribe al alumno al Google Group con su email actual y, si el email cambió
+ * respecto al previo, des-suscribe la dirección vieja sólo cuando el alta nueva
+ * quedó asegurada. La baja es best-effort: se loguea pero no degrada la
+ * respuesta. El status devuelto refleja la suscripción del email actual, no la
+ * baja del viejo.
+ */
+export const hookGoogleGroups: HookPostConfirmacion = async ({
+  githubUsername,
+  email,
+  emailPrevio,
+}) => {
+  const suscripcion = await agregarMiembroAGrupo(email);
+  if (suscripcion.status === "error") {
+    logger.error(
+      {
+        githubUsername,
+        maskedEmail: maskEmail(email),
+        err: maskEmailsEnTexto(suscripcion.error),
+      },
+      "Error al suscribir al Google Group"
+    );
+  }
+
+  const puedeQuitarEmailPrevio =
+    suscripcion.status === "added" || suscripcion.status === "already_member";
+  if (
+    puedeQuitarEmailPrevio &&
+    emailPrevio &&
+    Alumno.normalizarEmail(emailPrevio) !== Alumno.normalizarEmail(email)
+  ) {
+    const baja = await quitarMiembroDeGrupo(emailPrevio);
+    if (baja.status === "error") {
+      logger.error(
+        {
+          githubUsername,
+          maskedEmail: maskEmail(emailPrevio),
+          err: maskEmailsEnTexto(baja.error),
+        },
+        "Error al des-suscribir el email anterior del Google Group"
+      );
+    }
+  }
+
+  return { groupSubscription: suscripcion.status };
+};
+
+/**
+ * Sincroniza los grupos del alumno desde la planilla. El wrapper
+ * `intentarSincronizarGrupos` ya loguea y marca el flag en DB para disparar el
+ * retry automático en `/perfil`; acá sólo traducimos el throw a una respuesta
+ * degradada para el warning inmediato.
+ */
+export const hookGruposSync: HookPostConfirmacion = async ({ githubUsername, comision }) => {
+  try {
+    await intentarSincronizarGrupos(githubUsername, comision);
+    return { gruposSync: "ok" };
+  } catch {
+    return { gruposSync: "error" };
+  }
+};
+
+/**
+ * Corre la lista de hooks accesorios del origen y mergea sus resultados. Cada
+ * hook es auto-contenido (corre, loguea, degrada); el runner no ramifica por
+ * origen — cada flujo declara qué hooks corre vía la lista que pasa.
+ */
+export async function ejecutarHooksPostConfirmacion(
+  ctx: ContextoAlumno,
+  hooks: HookPostConfirmacion[]
+): Promise<ResultadoHooks> {
+  let resultado: ResultadoHooks = {};
+  for (const hook of hooks) {
+    resultado = { ...resultado, ...(await hook(ctx)) };
+  }
+  return resultado;
+}
+
+// Política por origen: qué hooks corre cada flujo del evento "alumno confirmado".
+export const HOOKS_CONFIRMACION_ALUMNO: HookPostConfirmacion[] = [
+  hookGoogleGroups,
+  hookGruposSync,
+];
+
+// La importación admin suscribe al grupo pero NO sincroniza grupos inline: eso
+// queda en la action dedicada `sincronizarGruposDeLaComision` (lectura única de
+// la hoja, UI de progreso propia).
+export const HOOKS_IMPORTACION_ALUMNO: HookPostConfirmacion[] = [hookGoogleGroups];

--- a/src/lib/services/importarAlumnosDeComision.test.ts
+++ b/src/lib/services/importarAlumnosDeComision.test.ts
@@ -144,6 +144,19 @@ describe("importarAlumnosDeComision", () => {
     );
   });
 
+  it("no duplica el prefijo cuando getAlumnos ya incluye 'No se pudo leer la planilla'", async () => {
+    mockGetAlumnos.mockRejectedValue(
+      new Error("No se pudo leer la planilla de alumnos: timeout")
+    );
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      "No se pudo leer la planilla de alumnos: timeout"
+    );
+    await expect(importarAlumnosDeComision(comision as never)).rejects.not.toThrow(
+      "No se pudo leer la planilla: No se pudo leer la planilla"
+    );
+  });
+
   it("propaga errores de upsertAlumnos", async () => {
     const error = new Error("legajo duplicado");
     mockUpsertAlumnos.mockRejectedValue(error);

--- a/src/lib/services/importarAlumnosDeComision.test.ts
+++ b/src/lib/services/importarAlumnosDeComision.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockGetAlumnos = vi.fn();
+const mockGetAlumnosByGithubUsernames = vi.fn();
+const mockUpsertAlumnos = vi.fn();
+const mockEjecutarHooksPostConfirmacion = vi.fn();
+const mockIntentarSincronizarGrupos = vi.fn();
+
+vi.mock("@/lib/sheets", () => ({
+  getAlumnos: (...args: unknown[]) => mockGetAlumnos(...args),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnosByGithubUsernames: (...args: unknown[]) =>
+    mockGetAlumnosByGithubUsernames(...args),
+  upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
+}));
+
+vi.mock("./hooksPostConfirmacion", () => ({
+  ejecutarHooksPostConfirmacion: (...args: unknown[]) =>
+    mockEjecutarHooksPostConfirmacion(...args),
+  HOOKS_IMPORTACION_ALUMNO: ["google-groups-hook"],
+}));
+
+vi.mock("./intentarSincronizarGrupos", () => ({
+  intentarSincronizarGrupos: (...args: unknown[]) =>
+    mockIntentarSincronizarGrupos(...args),
+}));
+
+import {
+  importarAlumnosDeComision,
+  LecturaPlanillaAlumnosError,
+} from "./importarAlumnosDeComision";
+
+describe("importarAlumnosDeComision", () => {
+  const comision = { id: "c1", spreadsheetId: "sheet-abc", columnConfig: {} };
+  const alumnos = [
+    {
+      legajo: "111",
+      nombre: "Ana",
+      apellido: "López",
+      githubUsername: "Ana",
+      email: "ana-nuevo@b.com",
+    },
+    {
+      legajo: "222",
+      nombre: "Beto",
+      apellido: "Ruiz",
+      githubUsername: "beto",
+      email: "beto@b.com",
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAlumnos.mockResolvedValue(alumnos);
+    mockGetAlumnosByGithubUsernames.mockResolvedValue([]);
+    mockUpsertAlumnos.mockResolvedValue(2);
+    mockEjecutarHooksPostConfirmacion.mockResolvedValue({ groupSubscription: "added" });
+  });
+
+  it("lee alumnos desde la planilla configurada de la comisión", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnos).toHaveBeenCalledWith("sheet-abc", {});
+  });
+
+  it("captura emails previos antes de upsertAlumnos", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnosByGithubUsernames.mock.invocationCallOrder[0]).toBeLessThan(
+      mockUpsertAlumnos.mock.invocationCallOrder[0]
+    );
+  });
+
+  it("busca alumnos previos por githubUsername en batch", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockGetAlumnosByGithubUsernames).toHaveBeenCalledWith(["Ana", "beto"]);
+  });
+
+  it("persiste los alumnos con la comisión incluida", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockUpsertAlumnos).toHaveBeenCalledWith(
+      alumnos.map((alumno) => ({ ...alumno, comision }))
+    );
+  });
+
+  it("pasa emailPrevio al hook cuando el alumno ya existía", async () => {
+    mockGetAlumnosByGithubUsernames.mockResolvedValue([
+      { githubUsername: "ana", usernameCanonico: "ana", email: "ana-viejo@b.com" },
+    ]);
+
+    await importarAlumnosDeComision(comision as never);
+
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: "Ana",
+        email: "ana-nuevo@b.com",
+        emailPrevio: "ana-viejo@b.com",
+      }),
+      ["google-groups-hook"]
+    );
+  });
+
+  it("pasa emailPrevio undefined cuando el alumno no existía", async () => {
+    await importarAlumnosDeComision(comision as never);
+
+    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubUsername: "Ana",
+        email: "ana-nuevo@b.com",
+        emailPrevio: undefined,
+      }),
+      ["google-groups-hook"]
+    );
+  });
+
+  it("cuenta conErrorDeGrupo cuando falla alguna suscripción", async () => {
+    mockEjecutarHooksPostConfirmacion
+      .mockResolvedValueOnce({ groupSubscription: "error" })
+      .mockResolvedValueOnce({ groupSubscription: "added" });
+
+    const result = await importarAlumnosDeComision(comision as never);
+
+    expect(result).toEqual({ sincronizados: 2, conErrorDeGrupo: 1 });
+  });
+
+  it("no ejecuta sync de grupos inline", async () => {
+    await importarAlumnosDeComision(comision as never);
+    expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+  });
+
+  it("envuelve errores de lectura de Sheets", async () => {
+    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      LecturaPlanillaAlumnosError
+    );
+  });
+
+  it("preserva el mensaje actual para errores de lectura de Sheets", async () => {
+    mockGetAlumnos.mockRejectedValue(new Error("acceso denegado"));
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toThrow(
+      "No se pudo leer la planilla: acceso denegado"
+    );
+  });
+
+  it("propaga errores de upsertAlumnos", async () => {
+    const error = new Error("legajo duplicado");
+    mockUpsertAlumnos.mockRejectedValue(error);
+
+    await expect(importarAlumnosDeComision(comision as never)).rejects.toBe(error);
+  });
+});

--- a/src/lib/services/importarAlumnosDeComision.ts
+++ b/src/lib/services/importarAlumnosDeComision.ts
@@ -17,7 +17,10 @@ export type ResultadoImportacionAlumnos = {
 export class LecturaPlanillaAlumnosError extends Error {
   constructor(cause: unknown) {
     const message = cause instanceof Error ? cause.message : "Error desconocido";
-    super(`No se pudo leer la planilla: ${message}`, { cause });
+    const fullMessage = message.startsWith("No se pudo leer la planilla")
+      ? message
+      : `No se pudo leer la planilla: ${message}`;
+    super(fullMessage, { cause });
     this.name = "LecturaPlanillaAlumnosError";
   }
 }

--- a/src/lib/services/importarAlumnosDeComision.ts
+++ b/src/lib/services/importarAlumnosDeComision.ts
@@ -1,0 +1,67 @@
+import { Alumno, type Comision } from "@/domain/entities";
+import {
+  getAlumnosByGithubUsernames,
+  upsertAlumnos,
+} from "@/lib/repositories";
+import { getAlumnos } from "@/lib/sheets";
+import {
+  ejecutarHooksPostConfirmacion,
+  HOOKS_IMPORTACION_ALUMNO,
+} from "./hooksPostConfirmacion";
+
+export type ResultadoImportacionAlumnos = {
+  sincronizados: number;
+  conErrorDeGrupo: number;
+};
+
+export class LecturaPlanillaAlumnosError extends Error {
+  constructor(cause: unknown) {
+    const message = cause instanceof Error ? cause.message : "Error desconocido";
+    super(`No se pudo leer la planilla: ${message}`, { cause });
+    this.name = "LecturaPlanillaAlumnosError";
+  }
+}
+
+/**
+ * Caso de uso de importación admin: lee alumnos desde Sheets, persiste el bulk
+ * upsert y dispara los hooks accesorios de importación. Captura emails previos
+ * antes del flush para que Google Groups pueda des-suscribir direcciones viejas.
+ */
+export async function importarAlumnosDeComision(
+  comision: Comision
+): Promise<ResultadoImportacionAlumnos> {
+  let alumnos;
+  try {
+    alumnos = await getAlumnos(comision.spreadsheetId, comision.columnConfig);
+  } catch (error) {
+    throw new LecturaPlanillaAlumnosError(error);
+  }
+
+  const existentes = await getAlumnosByGithubUsernames(
+    alumnos.map((alumno) => alumno.githubUsername)
+  );
+  const emailPrevioPorGithub = new Map(
+    existentes.map((alumno) => [alumno.usernameCanonico, alumno.email])
+  );
+
+  const sincronizados = await upsertAlumnos(
+    alumnos.map((alumno) => ({ ...alumno, comision }))
+  );
+
+  let conErrorDeGrupo = 0;
+  for (const alumno of alumnos) {
+    const githubUsername = Alumno.normalizarUsername(alumno.githubUsername);
+    const { groupSubscription } = await ejecutarHooksPostConfirmacion(
+      {
+        githubUsername: alumno.githubUsername,
+        email: alumno.email,
+        comision,
+        emailPrevio: emailPrevioPorGithub.get(githubUsername),
+      },
+      HOOKS_IMPORTACION_ALUMNO
+    );
+    if (groupSubscription === "error") conErrorDeGrupo++;
+  }
+
+  return { sincronizados, conErrorDeGrupo };
+}

--- a/src/lib/services/verificarConsistenciaAlumno.test.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import type { Alumno } from "@/domain/entities";
+import { Alumno } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -31,15 +31,14 @@ const comision = {
 } as unknown as Parameters<typeof verificarConsistenciaAlumno>[1];
 
 function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
-  return {
-    id: "uuid-1",
-    legajo: "12345",
-    nombre: "Juan",
-    apellido: "Garcia",
-    githubUsername: "juangarcia",
-    email: "juan@example.com",
-    ...overrides,
-  } as Alumno;
+  const alumno = new Alumno();
+  alumno.id = "uuid-1";
+  alumno.legajo = "12345";
+  alumno.nombre = "Juan";
+  alumno.apellido = "Garcia";
+  alumno.githubUsername = "juangarcia";
+  alumno.email = "juan@example.com";
+  return Object.assign(alumno, overrides);
 }
 
 // ── Tests ────────────────────────────────────────────────────

--- a/src/lib/services/verificarConsistenciaAlumno.ts
+++ b/src/lib/services/verificarConsistenciaAlumno.ts
@@ -32,13 +32,7 @@ export async function verificarConsistenciaAlumno(
 
   try {
     const resultado = await upsertarAlumnoEnSheets(
-      {
-        legajo: alumno.legajo,
-        apellido: alumno.apellido,
-        nombre: alumno.nombre,
-        githubUsername: alumno.githubUsername,
-        email: alumno.email,
-      },
+      alumno.toRegistroInput(),
       comision.spreadsheetId,
       comision.columnConfig
     );

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -78,7 +78,7 @@ export function parseAlumnosRows(
     .filter((row) => row[config.legajo] && row[config.githubUsername])
     .map((row) => {
       const alumno = new Alumno();
-      alumno.actualizarDatos({
+      alumno.aplicarRegistro({
         legajo: norm(row[config.legajo]),
         apellido: norm(row[config.apellido]),
         nombre: norm(row[config.nombre]),

--- a/src/lib/sheets.ts
+++ b/src/lib/sheets.ts
@@ -1,5 +1,10 @@
 import { google } from "googleapis";
-import { Alumno } from "@/domain/entities";
+import {
+  Alumno,
+  isValidEmail,
+  validateRegistro,
+  type RegistroInput,
+} from "@/domain/entities";
 import {
   type ColumnConfig,
   DEFAULT_COLUMN_CONFIG,
@@ -7,6 +12,9 @@ import {
   type Paradigma,
   PARADIGMAS,
 } from "@/types";
+
+export { isValidEmail, validateRegistro };
+export type { RegistroInput };
 
 // ── Auth con service account ────────────────────────────────
 
@@ -70,11 +78,13 @@ export function parseAlumnosRows(
     .filter((row) => row[config.legajo] && row[config.githubUsername])
     .map((row) => {
       const alumno = new Alumno();
-      alumno.legajo = norm(row[config.legajo]);
-      alumno.apellido = norm(row[config.apellido]);
-      alumno.nombre = norm(row[config.nombre]);
-      alumno.githubUsername = Alumno.normalizarUsername(row[config.githubUsername]);
-      alumno.email = norm(row[config.email]);
+      alumno.actualizarDatos({
+        legajo: norm(row[config.legajo]),
+        apellido: norm(row[config.apellido]),
+        nombre: norm(row[config.nombre]),
+        githubUsername: norm(row[config.githubUsername]),
+        email: norm(row[config.email]),
+      });
       return alumno;
     });
 }
@@ -140,40 +150,6 @@ async function findAlumnoRowIndex(
   );
   if (rowIndex === -1) return null;
   return config.headerRows + 1 + rowIndex;
-}
-
-// ── Registro de alumno ──────────────────────────────────────
-
-export interface RegistroInput {
-  legajo: string;
-  apellido: string;
-  nombre: string;
-  githubUsername: string;
-  email: string;
-}
-
-// Regex de email RFC-lite: una arroba, algún dominio, un punto después.
-// Suficiente para detectar typos comunes sin sobre-complicar.
-const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-export function isValidEmail(email: string): boolean {
-  return EMAIL_REGEX.test(email.trim());
-}
-
-export function validateRegistro(input: RegistroInput): string | null {
-  const { legajo, apellido, nombre, githubUsername, email } = input;
-
-  if (!legajo || !new RegExp(`^${Alumno.LEGAJO_PATTERN}$`).test(legajo.trim()))
-    return "El legajo debe tener entre 4 y 8 dígitos";
-  if (!apellido.trim()) return "El apellido es obligatorio";
-  if (!nombre.trim()) return "El nombre es obligatorio";
-  if (typeof githubUsername !== "string")
-    return "El usuario de GitHub debe ser un texto";
-  if (!githubUsername.trim()) return "El usuario de GitHub es obligatorio";
-  if (!/^[a-zA-Z0-9](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/.test(githubUsername.trim()))
-    return "El usuario de GitHub no tiene un formato válido";
-  if (!isValidEmail(email)) return "El email no es válido";
-  return null;
 }
 
 // ── Upsert de alumno en la planilla ─────────────────────────


### PR DESCRIPTION
## Summary

- Consistencia entre DB y planilla de Google Sheets: fuente de verdad en DB, sincronización desde planilla, panel admin de grupos
- Asociar assignments a la comisión activa; idempotencia en aceptación de assignments y entregas
- Unique constraint en comisión activa
- Remover dependencia de `Entrega` en helpers de `lib`
- Unificar hooks post-confirmación de alumno: nuevo módulo `hooksPostConfirmacion`, servicio `confirmarYProcesarAlumno`, caso de uso `importarAlumnosDeComision`; registro y perfil quedan uniformes (suscripción/des-suscripción a Google Groups)
- Refactor OO: eliminar `typeof`/`instanceof` dispersos, extraer helpers compartidos (`parseJsonObjectBody`, `extractDbErrorCode`), método polimórfico `aplicarCamposExtra` en `Assignment`
- Fix: atributo `inert` acepta boolean en React types actuales

## Test plan

- [ ] Registro de alumno nuevo: verifica suscripción al Google Group y confirmación correcta
- [ ] Actualización de perfil con cambio de email: verifica des-suscripción del email anterior y suscripción del nuevo
- [ ] Importación de alumnos desde planilla: verifica sincronización y hooks aplicados
- [ ] Aceptar un assignment ya aceptado: debe ser idempotente (sin error)
- [ ] Entregar una entrega ya entregada: debe ser idempotente
- [ ] Crear dos comisiones activas para el mismo grupo: debe fallar por constraint único
- [ ] Assignments nuevos quedan asociados a la comisión activa correcta
- [ ] Panel admin de grupos: refleja estado de DB

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Se muestra la "Comisión" de cada assignment (año y etiqueta Activa/Histórica) en la UI; dashboard carga assignments por comisión cuando aplica.
  * Sincronización de alumnos informa además el conteo de casos con error de grupo ("sin grupo") en el botón/resultado.

* **Bug Fixes**
  * Se evita crear entregas duplicadas reutilizando entregas existentes.
  * Validación/creación protegida: ahora solo puede haber una comisión activa; migraciones evitan conflictos.

* **Tests**
  * Cobertura ampliada para comisiones, entregas, importación/sincronización y migraciones.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Juancete/Pdep-Classroom/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->