### PR TITLE
Corregir build roto: tipado de body en registro/route.ts + typecheck en tests

### DIFF
--- a/src/app/api/registro/route.ts
+++ b/src/app/api/registro/route.ts
@@ -32,9 +32,10 @@ export async function POST(req: Request) {
         { status: 400 }
       );
     }
-    body.githubUsername = user.githubUsername;
-
-    const resultado = await confirmarYProcesarAlumno(body as RegistroInput);
+    const resultado = await confirmarYProcesarAlumno({
+      ...(body as Omit<RegistroInput, "githubUsername">),
+      githubUsername: user.githubUsername,
+    });
     if (!resultado.ok) {
       return NextResponse.json(
         resultado.field

--- a/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
+++ b/src/app/assignments/[id]/grupo/grupo-selector.test.tsx
@@ -21,6 +21,7 @@ function makeGrupo(overrides: Partial<GrupoResumen> = {}): GrupoResumen {
     paradigma: "objetos",
     maxIntegrantes: 3,
     estaLleno: false,
+    etiquetaCupo: "1/3 integrantes",
     miembros: ["bob"],
     ...overrides,
   };

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi } from "vitest";
 import { IndividualAssignment } from "./IndividualAssignment";
 import { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
+import type { Assignment } from "./Assignment";
 import { Alumno } from "./Alumno";
 import type { Grupo } from "./Grupo";
 
@@ -44,16 +45,15 @@ describe("IndividualAssignment", () => {
 
   it("resolverParticipantesPara devuelve solo al usuario que acepta", async () => {
     const individual = new IndividualAssignment();
-    const participantes = await individual.resolverParticipantesPara(
-      { githubUsername: "ana" },
-      vi.fn()
-    );
+    const participantes = await individual.resolverParticipantesPara({ githubUsername: "ana" });
     expect(participantes.usernames).toEqual(["ana"]);
     expect(participantes.grupoId).toBeUndefined();
   });
 
   it("resolverParticipantesPara ignora la lambda de buscar grupo", async () => {
-    const individual = new IndividualAssignment();
+    // Se tipea como Assignment (contrato base) para poder pasar el segundo argumento
+    // y verificar que la implementación individual no lo invoca.
+    const individual: Assignment = new IndividualAssignment();
     const buscar = vi.fn();
     await individual.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
     expect(buscar).not.toHaveBeenCalled();


### PR DESCRIPTION
## Problema

El build de `next build` fallaba en master por una regresión del PR #40: el refactor que extrajo
`parseJsonObjectBody` cambió el tipo de `body` de `any` a `Record<string, unknown>`, y el cast
directo `body as RegistroInput` en `registro/route.ts` ya no compila (TS requiere pasar por
`unknown`).

## Cambios

**`src/app/api/registro/route.ts`**
Eliminada la mutación `body.githubUsername = user.githubUsername` y reemplazada la llamada a
`confirmarYProcesarAlumno` por el spread `{ ...(body as Omit<RegistroInput,'githubUsername'>),
githubUsername }`, alineando con el patrón que ya usa `perfil/route.ts`. Sin cambio de
comportamiento.

**`src/domain/entities/Assignment.test.ts`**
Las dos llamadas a `individual.resolverParticipantesPara` pasaban 2 argumentos cuando el
override de `IndividualAssignment` acepta 1. El test que verifica el "ignora la lambda" ahora
tipifica la variable como `Assignment` (contrato base) para poder pasar el segundo argumento.

**`src/app/assignments/[id]/grupo/grupo-selector.test.tsx`**
`GrupoResumen.etiquetaCupo` es `string` requerido; el fixture `makeGrupo` no lo incluía.

## Verificación

- `npx tsc --noEmit` → 0 errores
- `npm run build` → compila sin errores de tipos
- `npm run test:run` → 75 suites, 923 tests, todos verdes