### PR TITLE
Persistir y reintentar membresías de Google Groups

### DIFF
--- a/migrations/Migration20260610120000_add_google_group_state_to_alumno.ts
+++ b/migrations/Migration20260610120000_add_google_group_state_to_alumno.ts
@@ -1,0 +1,29 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260610120000_add_google_group_state_to_alumno extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      alter table "alumno"
+        add column "google_group_estado" text
+          check ("google_group_estado" in ('pendiente', 'sincronizado', 'fallido', 'omitido'))
+          not null default 'pendiente',
+        add column "google_group_email_sincronizado" varchar(255) null,
+        add column "google_group_emails_pendientes_baja" text[] not null default '{}',
+        add column "google_group_ultimo_error" text null,
+        add column "google_group_ultimo_intento_en" timestamptz null,
+        add column "google_group_sincronizado_en" timestamptz null;
+    `);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`
+      alter table "alumno"
+        drop column "google_group_estado",
+        drop column "google_group_email_sincronizado",
+        drop column "google_group_emails_pendientes_baja",
+        drop column "google_group_ultimo_error",
+        drop column "google_group_ultimo_intento_en",
+        drop column "google_group_sincronizado_en";
+    `);
+  }
+}

--- a/src/app/admin/comisiones/[id]/edit/page.test.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.test.tsx
@@ -11,6 +11,8 @@ const mockGetAlumnos = vi.fn();
 const mockGetSheetNames = vi.fn();
 const mockRedirect = vi.fn();
 const mockGetAlumnosConGruposSyncPendiente = vi.fn();
+const mockGetAlumnosConGoogleGroupPendiente = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -21,6 +23,12 @@ vi.mock("@/lib/repositories", () => ({
   countAlumnos: () => mockCountAlumnos(),
   getAlumnosConGruposSyncPendiente: (...args: unknown[]) =>
     mockGetAlumnosConGruposSyncPendiente(...args),
+  getAlumnosConGoogleGroupPendiente: (...args: unknown[]) =>
+    mockGetAlumnosConGoogleGroupPendiente(...args),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
 }));
 
 vi.mock("@/lib/sheets", () => ({
@@ -53,6 +61,18 @@ vi.mock("../../sync-grupos-button", () => ({
       "button",
       { "data-testid": "sync-grupos-button", "data-comision-id": comisionId },
       "Resincronizar grupos"
+    ),
+}));
+
+vi.mock("../../sync-google-groups-button", () => ({
+  SyncGoogleGroupsButton: ({ comisionId }: { comisionId: string }) =>
+    React.createElement(
+      "button",
+      {
+        "data-testid": "sync-google-groups-button",
+        "data-comision-id": comisionId,
+      },
+      "Reintentar Google Groups"
     ),
 }));
 
@@ -104,6 +124,8 @@ describe("Edit Comision page", () => {
     mockGetAlumnos.mockResolvedValue([]);
     mockCountAlumnos.mockResolvedValue(0);
     mockGetAlumnosConGruposSyncPendiente.mockResolvedValue([]);
+    mockGetAlumnosConGoogleGroupPendiente.mockResolvedValue([]);
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
     mockGetSheetNames.mockResolvedValue(["Alumnos", "Grupos"]);
   });
 
@@ -300,6 +322,45 @@ describe("Edit Comision page", () => {
         await EditComisionPage({ params: { id: "c1" } }) as React.ReactElement
       );
       expect(html).not.toContain("Grupos pendientes");
+    });
+  });
+
+  describe("membresías de Google Groups pendientes", () => {
+    it("muestra badge, lista y retry cuando la integración está habilitada", async () => {
+      mockIsGoogleGroupsConfigured.mockReturnValue(true);
+      mockGetComision.mockResolvedValue(makeComision());
+      mockGetAlumnosConGoogleGroupPendiente.mockResolvedValue([
+        {
+          githubUsername: "ana",
+          nombreCompleto: "García, Ana",
+          googleGroupUltimoError: "Sin permisos para anxxxxxx@utn.edu.ar",
+          googleGroupUltimoIntentoEn: new Date("2026-06-10T12:00:00Z"),
+        },
+      ]);
+
+      const html = renderToStaticMarkup(
+        (await EditComisionPage({
+          params: { id: "c1" },
+        })) as React.ReactElement
+      );
+
+      expect(html).toContain("Google Groups pendientes");
+      expect(html).toContain("García, Ana");
+      expect(html).toContain("Sin permisos");
+      expect(html).toContain('data-testid="sync-google-groups-button"');
+    });
+
+    it("no consulta ni muestra pendientes cuando la integración está desactivada", async () => {
+      mockGetComision.mockResolvedValue(makeComision());
+
+      const html = renderToStaticMarkup(
+        (await EditComisionPage({
+          params: { id: "c1" },
+        })) as React.ReactElement
+      );
+
+      expect(mockGetAlumnosConGoogleGroupPendiente).not.toHaveBeenCalled();
+      expect(html).not.toContain("Google Groups pendientes");
     });
   });
 });

--- a/src/app/admin/comisiones/[id]/edit/page.tsx
+++ b/src/app/admin/comisiones/[id]/edit/page.tsx
@@ -3,6 +3,7 @@ import {
   getComision,
   countAlumnos,
   getAlumnosConGruposSyncPendiente,
+  getAlumnosConGoogleGroupPendiente,
 } from "@/lib/repositories";
 import type { Alumno } from "@/domain/entities";
 import { getAlumnos, getSheetNames } from "@/lib/sheets";
@@ -11,6 +12,8 @@ import { ComisionForm } from "../../comision-form";
 import { actualizarComision } from "../../actions";
 import { SyncButton } from "../../sync-button";
 import { SyncGruposButton } from "../../sync-grupos-button";
+import { SyncGoogleGroupsButton } from "../../sync-google-groups-button";
+import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
 
 export default async function EditComisionPage({
   params,
@@ -23,18 +26,31 @@ export default async function EditComisionPage({
   if (!comision) redirect("/admin/comisiones");
 
   // Comparar counts en paralelo; si alguno falla no rompemos la página
-  const [countSheet, countDB, pendientesGrupos, sheetNames] = await Promise.all([
+  const googleGroupsConfigurado = isGoogleGroupsConfigured();
+  const [
+    countSheet,
+    countDB,
+    pendientesGrupos,
+    pendientesGoogleGroup,
+    sheetNames,
+  ] = await Promise.all([
     getAlumnos(comision.spreadsheetId, comision.columnConfig)
       .then((alumnos) => alumnos.length)
       .catch(() => null),
     countAlumnos().catch(() => null),
     getAlumnosConGruposSyncPendiente(comision.id).catch(() => [] as unknown[]),
+    googleGroupsConfigurado
+      ? getAlumnosConGoogleGroupPendiente(comision.id, true).catch(
+          () => [] as unknown[]
+        )
+      : Promise.resolve([] as unknown[]),
     getSheetNames(comision.spreadsheetId).catch(() => null),
   ]);
 
   const desynced =
     countSheet !== null && countDB !== null && countSheet !== countDB;
   const cantPendientesGrupos = pendientesGrupos.length;
+  const cantPendientesGoogleGroup = pendientesGoogleGroup.length;
 
   return (
     <div className="max-w-xl">
@@ -64,6 +80,18 @@ export default async function EditComisionPage({
             <SyncGruposButton comisionId={comision.id} />
           </>
         )}
+        {cantPendientesGoogleGroup > 0 && (
+          <>
+            <span
+              title="Alumnos cuya membresía del Google Group requiere reintento"
+              className="inline-flex items-center gap-1.5 text-xs font-medium bg-red-100 text-red-700 border border-red-200 px-2.5 py-1 rounded-full"
+            >
+              <span className="h-1.5 w-1.5 rounded-full bg-red-500" />
+              Google Groups pendientes · {cantPendientesGoogleGroup}
+            </span>
+            <SyncGoogleGroupsButton comisionId={comision.id} />
+          </>
+        )}
       </div>
 
       {cantPendientesGrupos > 0 && (
@@ -79,6 +107,37 @@ export default async function EditComisionPage({
               <li key={alumno.githubUsername} className="text-xs text-red-700">
                 {alumno.nombreCompleto}{" "}
                 <span className="text-red-400">@{alumno.githubUsername}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {cantPendientesGoogleGroup > 0 && (
+        <div
+          className="bg-red-50 border border-red-200 rounded-lg p-4 mb-6"
+          data-testid="pendientes-google-group-lista"
+        >
+          <p className="text-xs font-semibold text-red-700 mb-2">
+            Alumnos con membresía de Google Groups pendiente:
+          </p>
+          <ul className="space-y-1">
+            {(pendientesGoogleGroup as Alumno[]).map((alumno) => (
+              <li key={alumno.githubUsername} className="text-xs text-red-700">
+                {alumno.nombreCompleto}{" "}
+                <span className="text-red-400">@{alumno.githubUsername}</span>
+                {alumno.googleGroupUltimoIntentoEn && (
+                  <span className="text-red-400">
+                    {" "}
+                    · último intento{" "}
+                    {alumno.googleGroupUltimoIntentoEn.toLocaleString("es-AR")}
+                  </span>
+                )}
+                {alumno.googleGroupUltimoError && (
+                  <span className="block text-red-600">
+                    {alumno.googleGroupUltimoError}
+                  </span>
+                )}
               </li>
             ))}
           </ul>

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -11,6 +11,9 @@ const mockGetAsignacionesGrupos = vi.fn();
 const mockGetAlumnosByComision = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
 const mockImportarAlumnosDeComision = vi.fn();
+const mockGetAlumnosConGoogleGroupPendiente = vi.fn();
+const mockIntentarSincronizarGoogleGroup = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   requireAdmin: () => mockRequireAdmin(),
@@ -43,6 +46,8 @@ vi.mock("@/lib/repositories", () => ({
   getComision: (...args: unknown[]) => mockGetComision(...args),
   getAlumnosByComision: (...args: unknown[]) =>
     mockGetAlumnosByComision(...args),
+  getAlumnosConGoogleGroupPendiente: (...args: unknown[]) =>
+    mockGetAlumnosConGoogleGroupPendiente(...args),
   LegajoConflictError: FakeLegajoConflictError,
   ComisionActivaDuplicadaError: FakeComisionActivaDuplicadaError,
 }));
@@ -50,6 +55,15 @@ vi.mock("@/lib/repositories", () => ({
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
   intentarSincronizarGrupos: (...args: unknown[]) =>
     mockIntentarSincronizarGrupos(...args),
+}));
+
+vi.mock("@/lib/services/intentarSincronizarGoogleGroup", () => ({
+  intentarSincronizarGoogleGroup: (...args: unknown[]) =>
+    mockIntentarSincronizarGoogleGroup(...args),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
 }));
 
 const { FakeLecturaPlanillaAlumnosError } = vi.hoisted(() => {
@@ -86,6 +100,7 @@ import {
   actualizarComision,
   sincronizarAlumnos,
   sincronizarGruposDeLaComision,
+  sincronizarGoogleGroupsDeLaComision,
 } from "./actions";
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -480,5 +495,61 @@ describe("sincronizarGruposDeLaComision", () => {
     await expect(
       sincronizarGruposDeLaComision({ status: "idle" }, makeFd())
     ).rejects.toThrow("forbidden");
+  });
+});
+
+describe("sincronizarGoogleGroupsDeLaComision", () => {
+  function makeFd(): FormData {
+    return makeFormData({ comisionId: "c1" });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue(undefined);
+    mockGetComision.mockResolvedValue({ id: "c1" });
+    mockGetAlumnosConGoogleGroupPendiente.mockResolvedValue([]);
+    mockIsGoogleGroupsConfigured.mockReturnValue(true);
+  });
+
+  it("requiere admin", async () => {
+    mockRequireAdmin.mockRejectedValue(new Error("forbidden"));
+    await expect(
+      sincronizarGoogleGroupsDeLaComision({ status: "idle" }, makeFd())
+    ).rejects.toThrow("forbidden");
+  });
+
+  it("devuelve error si la comisión no existe", async () => {
+    mockGetComision.mockResolvedValue(null);
+    await expect(
+      sincronizarGoogleGroupsDeLaComision({ status: "idle" }, makeFd())
+    ).resolves.toEqual({
+      status: "error",
+      message: "Comisión no encontrada",
+    });
+  });
+
+  it("procesa solo pendientes y agrega los resultados", async () => {
+    mockGetAlumnosConGoogleGroupPendiente.mockResolvedValue([
+      { githubUsername: "ana" },
+      { githubUsername: "bruno" },
+      { githubUsername: "cintia" },
+    ]);
+    mockIntentarSincronizarGoogleGroup
+      .mockResolvedValueOnce({ status: "added" })
+      .mockResolvedValueOnce({ status: "skipped" })
+      .mockResolvedValueOnce({ status: "error", error: "boom" });
+
+    await expect(
+      sincronizarGoogleGroupsDeLaComision({ status: "idle" }, makeFd())
+    ).resolves.toEqual({
+      status: "ok",
+      sincronizados: 1,
+      omitidos: 1,
+      aunConError: 1,
+    });
+    expect(mockGetAlumnosConGoogleGroupPendiente).toHaveBeenCalledWith(
+      "c1",
+      true
+    );
   });
 });

--- a/src/app/admin/comisiones/actions.test.ts
+++ b/src/app/admin/comisiones/actions.test.ts
@@ -552,4 +552,41 @@ describe("sincronizarGoogleGroupsDeLaComision", () => {
       true
     );
   });
+
+  it("continúa con el lote cuando un alumno lanza una excepción", async () => {
+    mockGetAlumnosConGoogleGroupPendiente.mockResolvedValue([
+      { githubUsername: "ana" },
+      { githubUsername: "bruno" },
+    ]);
+    mockIntentarSincronizarGoogleGroup
+      .mockRejectedValueOnce(new Error("error inesperado"))
+      .mockResolvedValueOnce({ status: "added" });
+
+    await expect(
+      sincronizarGoogleGroupsDeLaComision({ status: "idle" }, makeFd())
+    ).resolves.toEqual({
+      status: "ok",
+      sincronizados: 1,
+      omitidos: 0,
+      aunConError: 1,
+    });
+    expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledTimes(2);
+  });
+
+  it("no incluye omitidos cuando la integración está desactivada", async () => {
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
+
+    await expect(
+      sincronizarGoogleGroupsDeLaComision({ status: "idle" }, makeFd())
+    ).resolves.toEqual({
+      status: "ok",
+      sincronizados: 0,
+      omitidos: 0,
+      aunConError: 0,
+    });
+    expect(mockGetAlumnosConGoogleGroupPendiente).toHaveBeenCalledWith(
+      "c1",
+      false
+    );
+  });
 });

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -318,17 +318,21 @@ export async function sincronizarGoogleGroupsDeLaComision(
   let aunConError = 0;
 
   for (const alumno of alumnos) {
-    const resultado = await intentarSincronizarGoogleGroup(
-      alumno.githubUsername
-    );
-    if (
-      resultado.status === "added" ||
-      resultado.status === "already_member"
-    ) {
-      sincronizados++;
-    } else if (resultado.status === "skipped") {
-      omitidos++;
-    } else {
+    try {
+      const resultado = await intentarSincronizarGoogleGroup(
+        alumno.githubUsername
+      );
+      if (
+        resultado.status === "added" ||
+        resultado.status === "already_member"
+      ) {
+        sincronizados++;
+      } else if (resultado.status === "skipped") {
+        omitidos++;
+      } else {
+        aunConError++;
+      }
+    } catch {
       aunConError++;
     }
   }

--- a/src/app/admin/comisiones/actions.ts
+++ b/src/app/admin/comisiones/actions.ts
@@ -7,6 +7,7 @@ import {
   getComision,
   LegajoConflictError,
   getAlumnosByComision,
+  getAlumnosConGoogleGroupPendiente,
   ComisionActivaDuplicadaError,
 } from "@/lib/repositories";
 import { getAsignacionesGrupos, getSheetNames, type AsignacionGrupoRow } from "@/lib/sheets";
@@ -19,6 +20,8 @@ import { redirect } from "next/navigation";
 import { revalidatePath } from "next/cache";
 import { z } from "zod";
 import { DEFAULT_COLUMN_CONFIG, type GruposColumnConfig } from "@/types";
+import { intentarSincronizarGoogleGroup } from "@/lib/services/intentarSincronizarGoogleGroup";
+import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
 
 export type ComisionFormState =
   | { ok: false; errors: Record<string, string[] | undefined> }
@@ -284,4 +287,53 @@ export async function sincronizarGruposDeLaComision(
   revalidatePath("/admin/comisiones");
   revalidatePath(`/admin/comisiones/${id}/edit`);
   return { status: "ok", sincronizados, aunConError };
+}
+
+export type SyncGoogleGroupState =
+  | { status: "idle" }
+  | {
+      status: "ok";
+      sincronizados: number;
+      omitidos: number;
+      aunConError: number;
+    }
+  | { status: "error"; message: string };
+
+export async function sincronizarGoogleGroupsDeLaComision(
+  _prevState: SyncGoogleGroupState,
+  formData: FormData
+): Promise<SyncGoogleGroupState> {
+  await requireAdmin();
+
+  const id = formData.get("comisionId") as string;
+  const comision = await getComision(id);
+  if (!comision) return { status: "error", message: "Comisión no encontrada" };
+
+  const alumnos = await getAlumnosConGoogleGroupPendiente(
+    id,
+    isGoogleGroupsConfigured()
+  );
+  let sincronizados = 0;
+  let omitidos = 0;
+  let aunConError = 0;
+
+  for (const alumno of alumnos) {
+    const resultado = await intentarSincronizarGoogleGroup(
+      alumno.githubUsername
+    );
+    if (
+      resultado.status === "added" ||
+      resultado.status === "already_member"
+    ) {
+      sincronizados++;
+    } else if (resultado.status === "skipped") {
+      omitidos++;
+    } else {
+      aunConError++;
+    }
+  }
+
+  revalidatePath(`/admin/comisiones/${id}/edit`);
+  revalidatePath("/perfil");
+  return { status: "ok", sincronizados, omitidos, aunConError };
 }

--- a/src/app/admin/comisiones/sync-google-groups-button.tsx
+++ b/src/app/admin/comisiones/sync-google-groups-button.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useFormState, useFormStatus } from "react-dom";
+import {
+  sincronizarGoogleGroupsDeLaComision,
+  type SyncGoogleGroupState,
+} from "./actions";
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+  return (
+    <button
+      type="submit"
+      disabled={pending}
+      className="inline-flex items-center gap-1.5 text-xs font-medium bg-amber-500 hover:bg-amber-600 text-white px-2.5 py-1 rounded-full transition-colors disabled:opacity-60"
+    >
+      {pending ? "Reintentando…" : "Reintentar Google Groups"}
+    </button>
+  );
+}
+
+export function SyncGoogleGroupsButton({
+  comisionId,
+}: {
+  comisionId: string;
+}) {
+  const [state, action] = useFormState<SyncGoogleGroupState, FormData>(
+    sincronizarGoogleGroupsDeLaComision,
+    { status: "idle" }
+  );
+
+  return (
+    <form action={action} className="flex items-center gap-2">
+      <input type="hidden" name="comisionId" value={comisionId} />
+      <SubmitButton />
+      {state.status === "ok" && (
+        <span className="text-xs font-medium text-green-700">
+          {state.sincronizados} sincronizados
+          {state.omitidos > 0 && (
+            <span className="text-gray-500"> · {state.omitidos} omitidos</span>
+          )}
+          {state.aunConError > 0 && (
+            <span className="text-red-600">
+              {" "}
+              · {state.aunConError} aún con error
+            </span>
+          )}
+        </span>
+      )}
+      {state.status === "error" && (
+        <span className="text-xs text-red-600">{state.message}</span>
+      )}
+    </form>
+  );
+}

--- a/src/app/components/SyncPendingBanner.test.tsx
+++ b/src/app/components/SyncPendingBanner.test.tsx
@@ -6,6 +6,7 @@ import { Alumno } from "@/domain/entities";
 
 const mockGetCurrentUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getCurrentUser: () => mockGetCurrentUser(),
@@ -13,6 +14,10 @@ vi.mock("@/lib/session", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
 }));
 
 import { SyncPendingBanner } from "./SyncPendingBanner";
@@ -38,6 +43,7 @@ function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
 describe("SyncPendingBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
   });
 
   it("no renderiza nada si no hay usuario logueado", async () => {
@@ -126,5 +132,22 @@ describe("SyncPendingBanner", () => {
 
     expect(html).toContain("tus datos");
     expect(html).toContain("grupo de TP");
+  });
+
+  it("muestra una membresía de Google Groups pendiente cuando está habilitada", async () => {
+    mockIsGoogleGroupsConfigured.mockReturnValue(true);
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "juangarcia",
+      isAdmin: false,
+    });
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ googleGroupEstado: "fallido" })
+    );
+
+    const html = renderToStaticMarkup(
+      (await SyncPendingBanner()) as React.ReactElement
+    );
+    expect(html).toContain("suscripción al grupo de Google");
+    expect(html).toContain('href="/perfil"');
   });
 });

--- a/src/app/components/SyncPendingBanner.tsx
+++ b/src/app/components/SyncPendingBanner.tsx
@@ -1,16 +1,15 @@
 import Link from "next/link";
 import { getCurrentUser } from "@/lib/session";
 import { getAlumnoByGithub } from "@/lib/repositories";
+import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
 
 /**
  * Banner global que avisa al alumno que algo en la sincronización con la
- * planilla quedó en error. Es persistente: mientras `gruposSyncFallidoEn` o
- * `alumnoSyncFallidoEn` estén prendidos, se muestra en todas las páginas
- * logueadas.
+ * planilla o Google Groups quedó en error. Es persistente mientras alguno de
+ * los estados de sincronización requiera atención.
  *
- * Los flags se limpian cuando un reintento de sync funciona (events.signIn,
- * /api/registro, /api/perfil, import admin, o reintento manual desde /perfil).
- * Cuando eso pasa, este banner desaparece en el próximo render.
+ * Los estados se limpian cuando un reintento funciona. Cuando eso pasa, este
+ * banner desaparece en el próximo render.
  */
 export async function SyncPendingBanner() {
   const user = await getCurrentUser();
@@ -19,9 +18,10 @@ export async function SyncPendingBanner() {
   const alumno = await getAlumnoByGithub(user.githubUsername);
   if (!alumno) return null;
 
-  if (!alumno.tieneSyncPendiente()) return null;
+  const googleGroupsConfigurado = isGoogleGroupsConfigured();
+  if (!alumno.tieneSyncPendiente(googleGroupsConfigurado)) return null;
 
-  const mensaje = alumno.mensajeDeSyncPendiente();
+  const mensaje = alumno.mensajeDeSyncPendiente(googleGroupsConfigurado);
 
   return (
     <div

--- a/src/app/layout.test.tsx
+++ b/src/app/layout.test.tsx
@@ -5,9 +5,19 @@ import type { PdepUser } from "@/types";
 // ── Mocks ────────────────────────────────────────────────────
 
 const mockGetCurrentUser = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
 }));
 
 vi.mock("next/link", () => ({
@@ -21,8 +31,16 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("./logout-button", () => ({
-  UserMenu: ({ username }: { username: string }) => (
-    <div data-testid="user-menu">{username}</div>
+  UserMenu: ({
+    username,
+    hasPendingSync,
+  }: {
+    username: string;
+    hasPendingSync?: boolean;
+  }) => (
+    <div data-testid="user-menu" data-pending={String(hasPendingSync)}>
+      {username}
+    </div>
   ),
 }));
 
@@ -43,7 +61,11 @@ function makeUser(overrides: Partial<PdepUser> = {}): PdepUser {
 // ── Nav ──────────────────────────────────────────────────────
 
 describe("Nav", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
+  });
 
   it("muestra el nombre de la app", async () => {
     mockGetCurrentUser.mockResolvedValue(null);
@@ -85,6 +107,17 @@ describe("Nav", () => {
     mockGetCurrentUser.mockResolvedValue(makeUser({ githubUsername: "pepelopez" }));
     const html = renderToStaticMarkup(await Nav());
     expect(html).toContain("pepelopez");
+  });
+
+  it("pasa el estado pendiente al menú del alumno", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser());
+    mockIsGoogleGroupsConfigured.mockReturnValue(true);
+    mockGetAlumnoByGithub.mockResolvedValue({
+      tieneSyncPendiente: () => true,
+    });
+
+    const html = renderToStaticMarkup(await Nav());
+    expect(html).toContain('data-pending="true"');
   });
 });
 

--- a/src/app/logout-button.test.tsx
+++ b/src/app/logout-button.test.tsx
@@ -75,4 +75,27 @@ describe("UserMenu", () => {
     await openMenu("juangarcia");
     expect(screen.getByRole("menuitem", { name: "Editar perfil" })).toBeInTheDocument();
   });
+
+  it("señala en el avatar y en Editar perfil cuando hay una acción pendiente", async () => {
+    render(
+      <UserMenu
+        username="juangarcia"
+        image=""
+        hasPendingSync
+      />
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: /acción pendiente en tu perfil/i,
+    });
+    expect(trigger).toBeInTheDocument();
+
+    const user = userEvent.setup();
+    await user.click(trigger);
+    expect(
+      screen.getByRole("menuitem", {
+        name: /Editar perfil, acción pendiente/i,
+      })
+    ).toHaveAttribute("href", "/perfil");
+  });
 });

--- a/src/app/logout-button.tsx
+++ b/src/app/logout-button.tsx
@@ -8,9 +8,15 @@ interface Props {
   username: string;
   image: string;
   isAdmin?: boolean;
+  hasPendingSync?: boolean;
 }
 
-export function UserMenu({ username, image, isAdmin = false }: Props) {
+export function UserMenu({
+  username,
+  image,
+  isAdmin = false,
+  hasPendingSync = false,
+}: Props) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 
@@ -36,13 +42,24 @@ export function UserMenu({ username, image, isAdmin = false }: Props) {
     <div ref={ref} className="relative">
       <button
         type="button"
-        className="flex items-center gap-2 cursor-pointer"
+        className="relative flex items-center gap-2 cursor-pointer"
         aria-haspopup="menu"
         aria-expanded={open}
+        aria-label={
+          hasPendingSync
+            ? `${username}, hay una acción pendiente en tu perfil`
+            : username
+        }
         onClick={() => setOpen((previous) => !previous)}
       >
         {/* eslint-disable-next-line @next/next/no-img-element */}
         <img src={image} alt="" className="w-7 h-7 rounded-full" />
+        {hasPendingSync && (
+          <span
+            className="absolute -top-0.5 left-5 h-2.5 w-2.5 rounded-full bg-amber-400 ring-2 ring-pdep-900"
+            aria-hidden="true"
+          />
+        )}
         <span className="font-mono text-xs text-pdep-200">{username}</span>
       </button>
 
@@ -56,9 +73,22 @@ export function UserMenu({ username, image, isAdmin = false }: Props) {
               href="/perfil"
               role="menuitem"
               onClick={() => setOpen(false)}
-              className="block px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
+              className="flex items-center justify-between gap-3 px-4 py-2 text-sm text-pdep-200 hover:text-white hover:bg-pdep-700 transition-colors"
             >
-              Editar perfil
+              <span>
+                Editar perfil
+                {hasPendingSync && (
+                  <span className="sr-only">, acción pendiente</span>
+                )}
+              </span>
+              {hasPendingSync && (
+                <span
+                  className="text-xs font-semibold text-amber-300"
+                  aria-hidden="true"
+                >
+                  !
+                </span>
+              )}
             </Link>
           )}
           <button

--- a/src/app/nav-menu.test.tsx
+++ b/src/app/nav-menu.test.tsx
@@ -1,0 +1,38 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+
+vi.mock("next-auth/react", () => ({
+  signOut: vi.fn(),
+}));
+
+vi.mock("./logout-button", () => ({
+  UserMenu: () => <div data-testid="user-menu" />,
+}));
+
+import { NavMenu } from "./nav-menu";
+
+describe("NavMenu", () => {
+  it("señala la acción pendiente antes de abrir el menú mobile", async () => {
+    render(
+      <NavMenu
+        links={[]}
+        username="juangarcia"
+        image=""
+        isAdmin={false}
+        hasPendingSync
+      />
+    );
+
+    const trigger = screen.getByRole("button", {
+      name: /acción pendiente en tu perfil/i,
+    });
+    const user = userEvent.setup();
+    await user.click(trigger);
+
+    expect(
+      screen.getByRole("link", {
+        name: /Editar perfil, acción pendiente/i,
+      })
+    ).toHaveAttribute("href", "/perfil");
+  });
+});

--- a/src/app/nav-menu.tsx
+++ b/src/app/nav-menu.tsx
@@ -15,9 +15,16 @@ interface Props {
   username: string;
   image: string;
   isAdmin: boolean;
+  hasPendingSync?: boolean;
 }
 
-export function NavMenu({ links, username, image, isAdmin }: Props) {
+export function NavMenu({
+  links,
+  username,
+  image,
+  isAdmin,
+  hasPendingSync = false,
+}: Props) {
   const [open, setOpen] = useState(false);
 
   useEffect(() => {
@@ -76,13 +83,22 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
             {link.label}
           </Link>
         ))}
-        <UserMenu username={username} image={image} isAdmin={isAdmin} />
+        <UserMenu
+          username={username}
+          image={image}
+          isAdmin={isAdmin}
+          hasPendingSync={hasPendingSync}
+        />
       </div>
 
       <button
         type="button"
-        className="md:hidden p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
-        aria-label="Abrir menú"
+        className="md:hidden relative p-2 -mr-2 text-pdep-200 hover:text-white transition-colors"
+        aria-label={
+          hasPendingSync
+            ? "Abrir menú, hay una acción pendiente en tu perfil"
+            : "Abrir menú"
+        }
         aria-expanded={open}
         aria-controls="mobile-drawer"
         onClick={() => setOpen(true)}
@@ -101,6 +117,12 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
             d="M3.75 6.75h16.5M3.75 12h16.5M3.75 17.25h16.5"
           />
         </svg>
+        {hasPendingSync && (
+          <span
+            className="absolute top-1 right-1 h-2.5 w-2.5 rounded-full bg-amber-400 ring-2 ring-pdep-900"
+            aria-hidden="true"
+          />
+        )}
       </button>
 
       <div
@@ -169,9 +191,23 @@ export function NavMenu({ links, username, image, isAdmin }: Props) {
             <Link
               href="/perfil"
               onClick={() => setOpen(false)}
-              className="px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
+              className="flex items-center justify-between gap-3 px-4 py-3 text-pdep-200 hover:bg-pdep-800 hover:text-white transition-colors"
             >
-              Editar perfil
+              <span>
+                Editar perfil
+                {hasPendingSync && (
+                  <span className="sr-only">, acción pendiente</span>
+                )}
+              </span>
+              {hasPendingSync && (
+                <span
+                  className="inline-flex items-center gap-1 text-xs font-medium text-amber-300"
+                  aria-hidden="true"
+                >
+                  <span>!</span>
+                  Pendiente
+                </span>
+              )}
             </Link>
           )}
           <button

--- a/src/app/nav.tsx
+++ b/src/app/nav.tsx
@@ -1,9 +1,18 @@
 import { getCurrentUser } from "@/lib/session";
+import { getAlumnoByGithub } from "@/lib/repositories";
+import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
 import Link from "next/link";
 import { NavMenu, type NavLink } from "./nav-menu";
 
 export async function Nav() {
   const user = await getCurrentUser();
+  const alumno =
+    user && !user.isAdmin
+      ? await getAlumnoByGithub(user.githubUsername).catch(() => null)
+      : null;
+  const hasPendingSync = Boolean(
+    alumno?.tieneSyncPendiente(isGoogleGroupsConfigured())
+  );
 
   const links: NavLink[] = user
     ? [
@@ -32,6 +41,7 @@ export async function Nav() {
             username={user.githubUsername}
             image={user.image}
             isAdmin={user.isAdmin}
+            hasPendingSync={hasPendingSync}
           />
         )}
       </div>

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -250,5 +250,21 @@ describe("Perfil page", () => {
 
       expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
     });
+
+    it("no inicia Google Groups si falla antes getComisionActiva", async () => {
+      mockIsGoogleGroupsConfigured.mockReturnValue(true);
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({
+          gruposSyncFallidoEn: new Date("2026-04-01"),
+          googleGroupEstado: "fallido",
+        })
+      );
+      mockGetComisionActiva.mockRejectedValue(new Error("DB caída"));
+
+      await expect(PerfilPage()).resolves.toBeDefined();
+
+      expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
+      expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -10,6 +10,8 @@ const mockGetAlumnoByGithub = vi.fn();
 const mockGetComisionActiva = vi.fn();
 const mockVerificarConsistenciaAlumno = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
+const mockIntentarSincronizarGoogleGroup = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
 const mockRedirect = vi.fn().mockImplementation((url: string) => {
   throw new Error(`REDIRECT:${url}`);
 });
@@ -31,6 +33,15 @@ vi.mock("@/lib/services/verificarConsistenciaAlumno", () => ({
 vi.mock("@/lib/services/intentarSincronizarGrupos", () => ({
   intentarSincronizarGrupos: (...args: unknown[]) =>
     mockIntentarSincronizarGrupos(...args),
+}));
+
+vi.mock("@/lib/services/intentarSincronizarGoogleGroup", () => ({
+  intentarSincronizarGoogleGroup: (...args: unknown[]) =>
+    mockIntentarSincronizarGoogleGroup(...args),
+}));
+
+vi.mock("@/lib/googleGroups", () => ({
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -88,6 +99,8 @@ describe("Perfil page", () => {
     mockGetComisionActiva.mockResolvedValue(comisionActiva);
     mockVerificarConsistenciaAlumno.mockResolvedValue(undefined);
     mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
+    mockIntentarSincronizarGoogleGroup.mockResolvedValue({ status: "added" });
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
     mockRedirect.mockImplementation((url: string) => {
       throw new Error(`REDIRECT:${url}`);
     });
@@ -152,6 +165,7 @@ describe("Perfil page", () => {
       await PerfilPage();
       expect(mockVerificarConsistenciaAlumno).not.toHaveBeenCalled();
       expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
+      expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
     });
 
     it("llama a verificarConsistenciaAlumno si alumnoSyncFallidoEn está prendido", async () => {
@@ -212,6 +226,29 @@ describe("Perfil page", () => {
       mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
 
       await expect(PerfilPage()).resolves.toBeDefined();
+    });
+
+    it("reintenta Google Groups cuando está configurado y pendiente", async () => {
+      mockIsGoogleGroupsConfigured.mockReturnValue(true);
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ googleGroupEstado: "fallido" })
+      );
+
+      await PerfilPage();
+
+      expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledWith(
+        "juangarcia"
+      );
+    });
+
+    it("no presenta omitido como pendiente mientras la integración está desactivada", async () => {
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ googleGroupEstado: "omitido" })
+      );
+
+      await PerfilPage();
+
+      expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/app/perfil/page.test.tsx
+++ b/src/app/perfil/page.test.tsx
@@ -251,7 +251,7 @@ describe("Perfil page", () => {
       expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
     });
 
-    it("no inicia Google Groups si falla antes getComisionActiva", async () => {
+    it("reintenta Google Groups aunque falle getComisionActiva", async () => {
       mockIsGoogleGroupsConfigured.mockReturnValue(true);
       mockGetAlumnoByGithub.mockResolvedValue(
         makeAlumno({
@@ -263,7 +263,9 @@ describe("Perfil page", () => {
 
       await expect(PerfilPage()).resolves.toBeDefined();
 
-      expect(mockIntentarSincronizarGoogleGroup).not.toHaveBeenCalled();
+      expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledWith(
+        "juangarcia"
+      );
       expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
     });
   });

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -27,9 +27,6 @@ export default async function PerfilPage() {
   if (alumno.tieneSyncPendiente(googleGroupsConfigurado)) {
     try {
       const tareas: Promise<unknown>[] = [];
-      if (alumno.tieneGoogleGroupPendiente(googleGroupsConfigurado)) {
-        tareas.push(intentarSincronizarGoogleGroup(githubUsername));
-      }
       if (
         alumno.tieneSyncDeAlumnoFallido() ||
         alumno.tieneSyncDeGruposFallido()
@@ -47,6 +44,9 @@ export default async function PerfilPage() {
             );
           }
         }
+      }
+      if (alumno.tieneGoogleGroupPendiente(googleGroupsConfigurado)) {
+        tareas.push(intentarSincronizarGoogleGroup(githubUsername));
       }
       await Promise.allSettled(tareas);
     } catch {

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -4,6 +4,8 @@ import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
 import { verificarConsistenciaAlumno } from "@/lib/services/verificarConsistenciaAlumno";
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
+import { intentarSincronizarGoogleGroup } from "@/lib/services/intentarSincronizarGoogleGroup";
+import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
 import type { PdepUser } from "@/types";
 
 export default async function PerfilPage() {
@@ -18,17 +20,35 @@ export default async function PerfilPage() {
 
   // Reintento on-demand: si alguno de los flags de sync está prendido,
   // el alumno probablemente entró acá específicamente para resolverlo.
-  // Las dos llamadas son independientes y se invocan solo si su flag está activo.
+  // Las sincronizaciones son independientes y se invocan solo si su estado
+  // persistido indica que necesitan reintento.
   // Protegemos defensivamente: una excepción inesperada no debe romper el render.
-  if (alumno.tieneSyncPendiente()) {
+  const googleGroupsConfigurado = isGoogleGroupsConfigured();
+  if (alumno.tieneSyncPendiente(googleGroupsConfigurado)) {
     try {
-      const comisionActiva = await getComisionActiva();
-      if (comisionActiva) {
-        const tareas: Promise<unknown>[] = [];
-        if (alumno.tieneSyncDeAlumnoFallido()) tareas.push(verificarConsistenciaAlumno(githubUsername, comisionActiva));
-        if (alumno.tieneSyncDeGruposFallido()) tareas.push(intentarSincronizarGrupos(githubUsername, comisionActiva));
-        await Promise.allSettled(tareas);
+      const tareas: Promise<unknown>[] = [];
+      if (alumno.tieneGoogleGroupPendiente(googleGroupsConfigurado)) {
+        tareas.push(intentarSincronizarGoogleGroup(githubUsername));
       }
+      if (
+        alumno.tieneSyncDeAlumnoFallido() ||
+        alumno.tieneSyncDeGruposFallido()
+      ) {
+        const comisionActiva = await getComisionActiva();
+        if (comisionActiva) {
+          if (alumno.tieneSyncDeAlumnoFallido()) {
+            tareas.push(
+              verificarConsistenciaAlumno(githubUsername, comisionActiva)
+            );
+          }
+          if (alumno.tieneSyncDeGruposFallido()) {
+            tareas.push(
+              intentarSincronizarGrupos(githubUsername, comisionActiva)
+            );
+          }
+        }
+      }
+      await Promise.allSettled(tareas);
     } catch {
       // Flags persistentes en DB se encargan del banner.
     }

--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -25,33 +25,41 @@ export default async function PerfilPage() {
   // Protegemos defensivamente: una excepción inesperada no debe romper el render.
   const googleGroupsConfigurado = isGoogleGroupsConfigured();
   if (alumno.tieneSyncPendiente(googleGroupsConfigurado)) {
-    try {
-      const tareas: Promise<unknown>[] = [];
-      if (
-        alumno.tieneSyncDeAlumnoFallido() ||
-        alumno.tieneSyncDeGruposFallido()
-      ) {
-        const comisionActiva = await getComisionActiva();
-        if (comisionActiva) {
+    const tareas: Promise<unknown>[] = [];
+    if (
+      alumno.tieneSyncDeAlumnoFallido() ||
+      alumno.tieneSyncDeGruposFallido()
+    ) {
+      tareas.push(
+        (async () => {
+          const comisionActiva = await getComisionActiva();
+          if (!comisionActiva) return;
+
+          const tareasDeComision: Promise<unknown>[] = [];
           if (alumno.tieneSyncDeAlumnoFallido()) {
-            tareas.push(
-              verificarConsistenciaAlumno(githubUsername, comisionActiva)
+            tareasDeComision.push(
+              verificarConsistenciaAlumno(
+                githubUsername,
+                comisionActiva
+              )
             );
           }
           if (alumno.tieneSyncDeGruposFallido()) {
-            tareas.push(
-              intentarSincronizarGrupos(githubUsername, comisionActiva)
+            tareasDeComision.push(
+              intentarSincronizarGrupos(
+                githubUsername,
+                comisionActiva
+              )
             );
           }
-        }
-      }
-      if (alumno.tieneGoogleGroupPendiente(googleGroupsConfigurado)) {
-        tareas.push(intentarSincronizarGoogleGroup(githubUsername));
-      }
-      await Promise.allSettled(tareas);
-    } catch {
-      // Flags persistentes en DB se encargan del banner.
+          await Promise.allSettled(tareasDeComision);
+        })()
+      );
     }
+    if (alumno.tieneGoogleGroupPendiente(googleGroupsConfigurado)) {
+      tareas.push(intentarSincronizarGoogleGroup(githubUsername));
+    }
+    await Promise.allSettled(tareas);
   }
 
   return (

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -311,6 +311,47 @@ describe("Alumno — predicados de sync", () => {
   });
 });
 
+describe("estado de Google Groups", () => {
+  it("solo se considera pendiente cuando la integración está habilitada", () => {
+    const alumno = nuevoAlumno({ googleGroupEstado: "fallido" });
+    expect(alumno.tieneGoogleGroupPendiente(false)).toBe(false);
+    expect(alumno.tieneGoogleGroupPendiente(true)).toBe(true);
+  });
+
+  it("acumula emails anteriores para darlos de baja", () => {
+    const alumno = nuevoAlumno({
+      googleGroupEmailSincronizado: "primero@gmail.com",
+    });
+
+    alumno.registrarEmailAgregadoAGoogleGroup("segundo@gmail.com");
+    alumno.registrarEmailAgregadoAGoogleGroup("tercero@gmail.com");
+
+    expect(alumno.googleGroupEmailSincronizado).toBe("tercero@gmail.com");
+    expect(alumno.googleGroupEmailsPendientesBaja).toEqual([
+      "primero@gmail.com",
+      "segundo@gmail.com",
+    ]);
+  });
+
+  it("marca pendiente cuando cambia el email persistido", () => {
+    const alumno = nuevoAlumno({
+      email: "viejo@gmail.com",
+      googleGroupEstado: "sincronizado",
+    });
+
+    alumno.actualizarDatos({
+      legajo: alumno.legajo,
+      apellido: alumno.apellido,
+      nombre: alumno.nombre,
+      githubUsername: alumno.githubUsername,
+      email: "nuevo@gmail.com",
+      comision: alumno.comision,
+    });
+
+    expect(alumno.googleGroupEstado).toBe("pendiente");
+  });
+});
+
 describe("validateRegistro", () => {
   const valid = {
     legajo: "12345",

--- a/src/domain/entities/Alumno.test.ts
+++ b/src/domain/entities/Alumno.test.ts
@@ -333,6 +333,18 @@ describe("estado de Google Groups", () => {
     ]);
   });
 
+  it("no deja el email activo pendiente de baja en una secuencia A→B→A", () => {
+    const alumno = nuevoAlumno({
+      googleGroupEmailSincronizado: "a@gmail.com",
+    });
+
+    alumno.registrarEmailAgregadoAGoogleGroup("b@gmail.com");
+    alumno.registrarEmailAgregadoAGoogleGroup("a@gmail.com");
+
+    expect(alumno.googleGroupEmailSincronizado).toBe("a@gmail.com");
+    expect(alumno.googleGroupEmailsPendientesBaja).toEqual(["b@gmail.com"]);
+  });
+
   it("marca pendiente cuando cambia el email persistido", () => {
     const alumno = nuevoAlumno({
       email: "viejo@gmail.com",

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -217,6 +217,10 @@ export class Alumno {
   registrarEmailAgregadoAGoogleGroup(email: string): void {
     const emailNormalizado = Alumno.normalizarEmail(email);
     const anterior = this.googleGroupEmailSincronizado;
+    this.googleGroupEmailsPendientesBaja =
+      this.googleGroupEmailsPendientesBaja.filter(
+        (pendiente) => pendiente !== emailNormalizado
+      );
     if (
       anterior &&
       anterior !== emailNormalizado &&

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -1,4 +1,4 @@
-import { Entity, ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
+import { Entity, Enum, ManyToOne, PrimaryKey, Property } from "@mikro-orm/core";
 import { randomUUID } from "crypto";
 import { Comision } from "./Comision";
 import { ALUMNO_LEGAJO_PATTERN, ALUMNO_EMAIL_PATTERN, normalizarGithubUsername } from "./domain-constants";
@@ -15,6 +15,12 @@ export interface AlumnoData extends RegistroInput {
   comision: Comision;
   registroConfirmadoEn?: Comision;
 }
+
+export type EstadoGoogleGroup =
+  | "pendiente"
+  | "sincronizado"
+  | "fallido"
+  | "omitido";
 
 // Regex de email RFC-lite: una arroba, algún dominio, un punto después.
 // Suficiente para detectar typos comunes sin sobre-complicar.
@@ -92,6 +98,24 @@ export class Alumno {
   @Property({ type: 'datetime', nullable: true })
   alumnoSyncFallidoEn: Date | null = null;
 
+  @Enum({ items: ["pendiente", "sincronizado", "fallido", "omitido"] })
+  googleGroupEstado: EstadoGoogleGroup = "pendiente";
+
+  @Property({ type: "string", nullable: true })
+  googleGroupEmailSincronizado: string | null = null;
+
+  @Property({ type: "array" })
+  googleGroupEmailsPendientesBaja: string[] = [];
+
+  @Property({ type: "text", nullable: true })
+  googleGroupUltimoError: string | null = null;
+
+  @Property({ type: "datetime", nullable: true })
+  googleGroupUltimoIntentoEn: Date | null = null;
+
+  @Property({ type: "datetime", nullable: true })
+  googleGroupSincronizadoEn: Date | null = null;
+
   get usernameCanonico(): string {
     return Alumno.normalizarUsername(this.githubUsername);
   }
@@ -112,10 +136,16 @@ export class Alumno {
   }
 
   actualizarDatos(data: AlumnoData): void {
+    const emailAnterior = this.email
+      ? Alumno.normalizarEmail(this.email)
+      : null;
     this.aplicarRegistro(data);
     this.comision = data.comision;
     if (data.registroConfirmadoEn !== undefined) {
       this.registroConfirmadoEn = data.registroConfirmadoEn;
+    }
+    if (emailAnterior && emailAnterior !== this.email) {
+      this.marcarGoogleGroupPendiente();
     }
   }
 
@@ -166,11 +196,82 @@ export class Alumno {
     this.gruposSyncFallidoEn = null;
   }
 
-  tieneSyncPendiente(): boolean {
-    return this.tieneSyncDeAlumnoFallido() || this.tieneSyncDeGruposFallido();
+  tieneGoogleGroupPendiente(integracionHabilitada: boolean): boolean {
+    if (!integracionHabilitada) return false;
+    return (
+      this.googleGroupEstado === "pendiente" ||
+      this.googleGroupEstado === "fallido" ||
+      this.googleGroupEstado === "omitido"
+    );
   }
 
-  mensajeDeSyncPendiente(): string {
+  marcarGoogleGroupPendiente(): void {
+    this.googleGroupEstado = "pendiente";
+    this.googleGroupUltimoError = null;
+  }
+
+  registrarIntentoGoogleGroup(fecha = new Date()): void {
+    this.googleGroupUltimoIntentoEn = fecha;
+  }
+
+  registrarEmailAgregadoAGoogleGroup(email: string): void {
+    const emailNormalizado = Alumno.normalizarEmail(email);
+    const anterior = this.googleGroupEmailSincronizado;
+    if (
+      anterior &&
+      anterior !== emailNormalizado &&
+      !this.googleGroupEmailsPendientesBaja.includes(anterior)
+    ) {
+      this.googleGroupEmailsPendientesBaja.push(anterior);
+    }
+    this.googleGroupEmailSincronizado = emailNormalizado;
+  }
+
+  registrarBajaGoogleGroup(email: string): void {
+    const emailNormalizado = Alumno.normalizarEmail(email);
+    this.googleGroupEmailsPendientesBaja =
+      this.googleGroupEmailsPendientesBaja.filter(
+        (pendiente) => pendiente !== emailNormalizado
+      );
+  }
+
+  marcarGoogleGroupSincronizado(fecha = new Date()): void {
+    this.googleGroupEstado = "sincronizado";
+    this.googleGroupUltimoError = null;
+    this.googleGroupSincronizadoEn = fecha;
+  }
+
+  marcarGoogleGroupFallido(error: string): void {
+    this.googleGroupEstado = "fallido";
+    this.googleGroupUltimoError = error;
+  }
+
+  marcarGoogleGroupOmitido(): void {
+    this.googleGroupEstado = "omitido";
+    this.googleGroupUltimoError = null;
+  }
+
+  tieneSyncPendiente(integracionGoogleHabilitada = false): boolean {
+    return (
+      this.tieneSyncDeAlumnoFallido() ||
+      this.tieneSyncDeGruposFallido() ||
+      this.tieneGoogleGroupPendiente(integracionGoogleHabilitada)
+    );
+  }
+
+  mensajeDeSyncPendiente(integracionGoogleHabilitada = false): string {
+    const googleGroupPendiente = this.tieneGoogleGroupPendiente(
+      integracionGoogleHabilitada
+    );
+    if (
+      googleGroupPendiente &&
+      (this.tieneSyncDeGruposFallido() || this.tieneSyncDeAlumnoFallido())
+    ) {
+      return "Hay sincronizaciones pendientes de tus datos y de tu suscripción al grupo de Google.";
+    }
+    if (googleGroupPendiente) {
+      return "No pudimos completar tu suscripción al grupo de Google.";
+    }
     if (this.tieneSyncDeGruposFallido() && this.tieneSyncDeAlumnoFallido()) {
       return "No pudimos sincronizar tus datos ni asignarte a tu grupo de TP desde la planilla.";
     }

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -4,6 +4,7 @@ export {
   validateRegistro,
   type AlumnoData,
   type RegistroInput,
+  type EstadoGoogleGroup,
 } from "./Alumno";
 export { Comision } from "./Comision";
 export { Assignment } from "./Assignment";

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -23,7 +23,11 @@ vi.mock("googleapis", () => ({
   },
 }));
 
-import { agregarMiembroAGrupo, quitarMiembroDeGrupo } from "./googleGroups";
+import {
+  agregarMiembroAGrupo,
+  isGoogleGroupsConfigured,
+  quitarMiembroDeGrupo,
+} from "./googleGroups";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -68,6 +72,12 @@ describe("agregarMiembroAGrupo", () => {
     const result = await agregarMiembroAGrupo("juan@gmail.com");
     expect(result).toEqual({ status: "skipped" });
     expect(mockMembersInsert).not.toHaveBeenCalled();
+  });
+
+  it("considera habilitada la integración solo con grupo y admin configurados", () => {
+    expect(isGoogleGroupsConfigured()).toBe(true);
+    delete process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL;
+    expect(isGoogleGroupsConfigured()).toBe(false);
   });
 
   it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL está vacío", async () => {

--- a/src/lib/googleGroups.test.ts
+++ b/src/lib/googleGroups.test.ts
@@ -80,6 +80,11 @@ describe("agregarMiembroAGrupo", () => {
     expect(isGoogleGroupsConfigured()).toBe(false);
   });
 
+  it("considera desactivada la integración sin service account key", () => {
+    delete process.env.GOOGLE_SERVICE_ACCOUNT_KEY;
+    expect(isGoogleGroupsConfigured()).toBe(false);
+  });
+
   it("retorna 'skipped' cuando GOOGLE_GROUP_EMAIL está vacío", async () => {
     process.env.GOOGLE_GROUP_EMAIL = "   ";
     const result = await agregarMiembroAGrupo("juan@gmail.com");

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -10,6 +10,10 @@ function getAdminSubject(): string | null {
   return process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim() || null;
 }
 
+export function isGoogleGroupsConfigured(): boolean {
+  return Boolean(getGroupEmail() && getAdminSubject());
+}
+
 // ── Cliente de Admin Directory API ──────────────────────────
 // Agregar miembros a un Google Group requiere Domain-Wide Delegation:
 // el service account impersona a un admin del workspace.

--- a/src/lib/googleGroups.ts
+++ b/src/lib/googleGroups.ts
@@ -10,8 +10,14 @@ function getAdminSubject(): string | null {
   return process.env.GOOGLE_WORKSPACE_ADMIN_EMAIL?.trim() || null;
 }
 
+function getServiceAccountKey(): string | null {
+  return process.env.GOOGLE_SERVICE_ACCOUNT_KEY?.trim() || null;
+}
+
 export function isGoogleGroupsConfigured(): boolean {
-  return Boolean(getGroupEmail() && getAdminSubject());
+  return Boolean(
+    getGroupEmail() && getAdminSubject() && getServiceAccountKey()
+  );
 }
 
 // ── Cliente de Admin Directory API ──────────────────────────
@@ -25,7 +31,7 @@ function getDirectoryClient() {
   }
 
   const keyJson = Buffer.from(
-    process.env.GOOGLE_SERVICE_ACCOUNT_KEY ?? "",
+    getServiceAccountKey() ?? "",
     "base64"
   ).toString("utf-8");
   const credentials = JSON.parse(keyJson);

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -38,4 +38,21 @@ describe("migrations", () => {
     expect(migration).toContain("hay entregas individuales duplicadas");
     expect(migration).toContain("hay entregas grupales duplicadas");
   });
+
+  it("agrega el estado persistente de Google Groups con default pendiente", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260610120000_add_google_group_state_to_alumno.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('"google_group_estado"');
+    expect(migration).toContain("default 'pendiente'");
+    expect(migration).toContain('"google_group_email_sincronizado"');
+    expect(migration).toContain('"google_group_emails_pendientes_baja"');
+    expect(migration).toContain('"google_group_ultimo_error"');
+  });
 });

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -1,5 +1,9 @@
 import { getEM } from "@/lib/db";
-import { Alumno, type AlumnoData } from "@/domain/entities";
+import {
+  Alumno,
+  type AlumnoData,
+  type EstadoGoogleGroup,
+} from "@/domain/entities";
 import type { Comision } from "@/domain/entities";
 
 export type { AlumnoData } from "@/domain/entities";
@@ -172,6 +176,38 @@ export async function getAlumnosConGruposSyncPendiente(
     { comision: { id: comisionId }, gruposSyncFallidoEn: { $ne: null } },
     { orderBy: { apellido: "ASC", nombre: "ASC" } }
   );
+}
+
+export async function getAlumnosConGoogleGroupPendiente(
+  comisionId: string,
+  incluirOmitidos = false
+): Promise<Alumno[]> {
+  const entityManager = await getEM();
+  const estados: EstadoGoogleGroup[] = incluirOmitidos
+    ? ["pendiente", "fallido", "omitido"]
+    : ["pendiente", "fallido"];
+  return entityManager.find(
+    Alumno,
+    {
+      comision: { id: comisionId },
+      googleGroupEstado: { $in: estados },
+    },
+    { orderBy: { apellido: "ASC", nombre: "ASC" } }
+  );
+}
+
+export async function actualizarEstadoGoogleGroup(
+  githubUsername: string,
+  actualizar: (alumno: Alumno) => void
+): Promise<Alumno | null> {
+  const entityManager = await getEM();
+  const alumno = await entityManager.findOne(Alumno, {
+    githubUsername: Alumno.normalizarUsername(githubUsername),
+  });
+  if (!alumno) return null;
+  actualizar(alumno);
+  await entityManager.flush();
+  return alumno;
 }
 
 /** Crea o actualiza múltiples alumnos en un solo flush. */

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -13,6 +13,8 @@ export {
   marcarAlumnoSyncOk,
   getAlumnosByComision,
   getAlumnosConGruposSyncPendiente,
+  getAlumnosConGoogleGroupPendiente,
+  actualizarEstadoGoogleGroup,
   countAlumnos,
   LegajoConflictError,
 } from "./AlumnoRepository";

--- a/src/lib/services/alumnoRegistro.test.ts
+++ b/src/lib/services/alumnoRegistro.test.ts
@@ -280,31 +280,8 @@ describe("confirmarYProcesarAlumno", () => {
     );
   });
 
-  it("pasa emailPrevio: undefined cuando el alumno no existe en DB antes de confirmar", async () => {
-    mockGetAlumnoByGithub.mockResolvedValue(null);
+  it("no consulta el email previo: la reconciliación usa el estado persistido", async () => {
     await confirmarYProcesarAlumno(validInput);
-    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
-      expect.objectContaining({ emailPrevio: undefined }),
-      expect.any(Array)
-    );
-  });
-
-  it("pasa el email previo del alumno existente para que el hook lo des-suscriba si cambió", async () => {
-    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
-    await confirmarYProcesarAlumno(validInput);
-    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
-      expect.objectContaining({ emailPrevio: "viejo@gmail.com" }),
-      expect.any(Array)
-    );
-  });
-
-  it("lee el email previo ANTES de confirmar (upsertAlumno pisa el email en DB)", async () => {
-    mockGetAlumnoByGithub.mockResolvedValue({ email: "viejo@gmail.com" });
-    await confirmarYProcesarAlumno(validInput);
-    const ordenLlamadas = [
-      mockGetAlumnoByGithub.mock.invocationCallOrder[0],
-      mockUpsertAlumno.mock.invocationCallOrder[0],
-    ];
-    expect(ordenLlamadas[0]).toBeLessThan(ordenLlamadas[1]);
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/services/alumnoRegistro.ts
+++ b/src/lib/services/alumnoRegistro.ts
@@ -2,7 +2,6 @@ import { validateRegistro, type RegistroInput } from "@/domain/entities";
 import { upsertarAlumnoEnSheets } from "@/lib/sheets";
 import {
   getComisionActiva,
-  getAlumnoByGithub,
   upsertAlumno,
   marcarRegistroConfirmado,
   LegajoConflictError,
@@ -124,19 +123,12 @@ export type ResultadoConfirmacionConHooks =
 /**
  * Orquesta el evento completo "alumno confirmado/actualizado" para los flujos de
  * un único alumno (registro y perfil): confirma los datos y dispara los hooks
- * accesorios (Google Groups + sync de grupos). Captura el email previo ANTES de
- * confirmar para que, si cambió, el hook de Google Groups des-suscriba la
- * dirección vieja. La ruta sólo valida entrada, llama acá y traduce el resultado
- * a HTTP.
+ * accesorios (Google Groups + sync de grupos). La ruta sólo valida entrada,
+ * llama acá y traduce el resultado a HTTP.
  */
 export async function confirmarYProcesarAlumno(
   input: RegistroInput
 ): Promise<ResultadoConfirmacionConHooks> {
-  // El email previo se lee antes de confirmar: `upsertAlumno` (dentro de
-  // `confirmarDatosAlumno`) pisa el email en la DB, así que después ya no
-  // tendríamos la dirección vieja para des-suscribirla del grupo.
-  const emailPrevio = (await getAlumnoByGithub(input.githubUsername))?.email;
-
   const resultado = await confirmarDatosAlumno(input);
   if (!resultado.ok) return resultado;
 
@@ -145,7 +137,6 @@ export async function confirmarYProcesarAlumno(
       githubUsername: input.githubUsername,
       email: input.email,
       comision: resultado.comision,
-      emailPrevio,
     },
     HOOKS_CONFIRMACION_ALUMNO
   );

--- a/src/lib/services/hooksPostConfirmacion.test.ts
+++ b/src/lib/services/hooksPostConfirmacion.test.ts
@@ -1,14 +1,11 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// ── Mocks ────────────────────────────────────────────────────
-
-const mockAgregarMiembroAGrupo = vi.fn();
-const mockQuitarMiembroDeGrupo = vi.fn();
+const mockIntentarSincronizarGoogleGroup = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
 
-vi.mock("@/lib/googleGroups", () => ({
-  agregarMiembroAGrupo: (...args: unknown[]) => mockAgregarMiembroAGrupo(...args),
-  quitarMiembroDeGrupo: (...args: unknown[]) => mockQuitarMiembroDeGrupo(...args),
+vi.mock("./intentarSincronizarGoogleGroup", () => ({
+  intentarSincronizarGoogleGroup: (...args: unknown[]) =>
+    mockIntentarSincronizarGoogleGroup(...args),
 }));
 
 vi.mock("./intentarSincronizarGrupos", () => ({
@@ -17,15 +14,13 @@ vi.mock("./intentarSincronizarGrupos", () => ({
 }));
 
 import {
+  ejecutarHooksPostConfirmacion,
   hookGoogleGroups,
   hookGruposSync,
-  ejecutarHooksPostConfirmacion,
   HOOKS_CONFIRMACION_ALUMNO,
   HOOKS_IMPORTACION_ALUMNO,
   type ContextoAlumno,
 } from "./hooksPostConfirmacion";
-
-// ── Helpers ──────────────────────────────────────────────────
 
 function makeCtx(overrides: Partial<ContextoAlumno> = {}): ContextoAlumno {
   return {
@@ -36,116 +31,34 @@ function makeCtx(overrides: Partial<ContextoAlumno> = {}): ContextoAlumno {
   };
 }
 
-// ── hookGoogleGroups ─────────────────────────────────────────
-
 describe("hookGoogleGroups", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "removed" });
+    mockIntentarSincronizarGoogleGroup.mockResolvedValue({ status: "added" });
   });
 
-  it("devuelve el status de la suscripción del email actual", async () => {
-    const resultado = await hookGoogleGroups(makeCtx());
-    expect(resultado).toEqual({ groupSubscription: "added" });
-  });
-
-  it("pasa el email del contexto a agregarMiembroAGrupo", async () => {
-    await hookGoogleGroups(makeCtx({ email: "nueva@utn.edu.ar" }));
-    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith("nueva@utn.edu.ar");
-  });
-
-  it("loguea (con email enmascarado) cuando la suscripción falla", async () => {
-    const { logger } = await import("@/lib/logger");
-    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "Sin permisos" });
-
-    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com" }));
-
-    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
-    expect(loggedPayload).not.toContain("juan@gmail.com");
-    expect(loggedPayload).toContain("@gmail.com");
-    expect(loggedPayload).toContain("juangarcia");
-    errorSpy.mockRestore();
-  });
-
-  it("devuelve groupSubscription:'error' cuando la suscripción falla (sin throwear)", async () => {
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
-    const resultado = await hookGoogleGroups(makeCtx());
-    expect(resultado).toEqual({ groupSubscription: "error" });
-  });
-
-  it("no intenta quitar el email previo cuando no hay emailPrevio", async () => {
-    await hookGoogleGroups(makeCtx({ emailPrevio: undefined }));
-    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
-  });
-
-  it("no intenta quitar el email previo cuando el email no cambió", async () => {
-    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "juan@gmail.com" }));
-    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
-  });
-
-  it("no intenta quitar el email previo cuando la normalización coincide (case, espacios)", async () => {
-    await hookGoogleGroups(makeCtx({ email: "juan@gmail.com", emailPrevio: "  JUAN@GMAIL.COM  " }));
-    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
-  });
-
-  it("quita el email previo cuando el email cambió", async () => {
-    await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
-    );
-    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
-  });
-
-  it("quita el email previo cuando el email actual ya estaba suscripto", async () => {
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "already_member" });
-    await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
-    );
-    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
-  });
-
-  it("no quita el email previo si falló la suscripción del email actual", async () => {
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "error", error: "boom" });
-    await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
-    );
-    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
-  });
-
-  it("no quita el email previo si la suscripción del email actual fue skipeada", async () => {
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "skipped" });
-    await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
-    );
-    expect(mockQuitarMiembroDeGrupo).not.toHaveBeenCalled();
-  });
-
-  it("no degrada groupSubscription cuando la baja del email previo falla", async () => {
-    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+  it("delega por githubUsername y devuelve el status", async () => {
     const resultado = await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
+      makeCtx({ githubUsername: "anagarcia" })
+    );
+
+    expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledWith(
+      "anagarcia"
     );
     expect(resultado).toEqual({ groupSubscription: "added" });
   });
 
-  it("loguea (con email enmascarado) cuando la baja del email previo falla", async () => {
-    const { logger } = await import("@/lib/logger");
-    const errorSpy = vi.spyOn(logger, "error").mockImplementation(() => {});
-    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "error", error: "boom" });
+  it("propaga un resultado degradado sin lanzar", async () => {
+    mockIntentarSincronizarGoogleGroup.mockResolvedValue({
+      status: "error",
+      error: "boom",
+    });
 
-    await hookGoogleGroups(
-      makeCtx({ email: "nuevo@utn.edu.ar", emailPrevio: "viejo@gmail.com" })
-    );
-
-    const loggedPayload = JSON.stringify(errorSpy.mock.calls);
-    expect(loggedPayload).not.toContain("viejo@gmail.com");
-    expect(loggedPayload).toContain("@gmail.com");
-    errorSpy.mockRestore();
+    await expect(hookGoogleGroups(makeCtx())).resolves.toEqual({
+      groupSubscription: "error",
+    });
   });
 });
-
-// ── hookGruposSync ───────────────────────────────────────────
 
 describe("hookGruposSync", () => {
   beforeEach(() => {
@@ -153,85 +66,70 @@ describe("hookGruposSync", () => {
     mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
-  it("devuelve gruposSync:'ok' cuando el wrapper resuelve sin error", async () => {
-    const resultado = await hookGruposSync(makeCtx());
+  it("devuelve ok y pasa alumno y comisión", async () => {
+    const ctx = makeCtx({ githubUsername: "anagarcia" });
+    const resultado = await hookGruposSync(ctx);
+
+    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith(
+      "anagarcia",
+      ctx.comision
+    );
     expect(resultado).toEqual({ gruposSync: "ok" });
   });
 
-  it("devuelve gruposSync:'error' (sin throwear) cuando el wrapper lanza", async () => {
+  it("degrada el error sin lanzarlo", async () => {
     mockIntentarSincronizarGrupos.mockRejectedValue(new Error("Sheets caído"));
-    const resultado = await hookGruposSync(makeCtx());
-    expect(resultado).toEqual({ gruposSync: "error" });
-  });
-
-  it("pasa githubUsername y comision a intentarSincronizarGrupos", async () => {
-    const comision = { id: "c2" } as never;
-    await hookGruposSync(makeCtx({ githubUsername: "anagarcia", comision }));
-    expect(mockIntentarSincronizarGrupos).toHaveBeenCalledWith("anagarcia", comision);
+    await expect(hookGruposSync(makeCtx())).resolves.toEqual({
+      gruposSync: "error",
+    });
   });
 });
-
-// ── ejecutarHooksPostConfirmacion ────────────────────────────
 
 describe("ejecutarHooksPostConfirmacion", () => {
-  it("devuelve resultado vacío cuando la lista de hooks está vacía", async () => {
-    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), []);
-    expect(resultado).toEqual({});
+  it("devuelve vacío sin hooks", async () => {
+    await expect(ejecutarHooksPostConfirmacion(makeCtx(), [])).resolves.toEqual(
+      {}
+    );
   });
 
-  it("mergea los slices de resultado de múltiples hooks", async () => {
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-    mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
-
-    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [
-      hookGoogleGroups,
-      hookGruposSync,
-    ]);
-
-    expect(resultado).toEqual({ groupSubscription: "added", gruposSync: "ok" });
-  });
-
-  it("el slice de un hook posterior pisa el anterior si comparten clave", async () => {
+  it("mergea resultados en orden", async () => {
     const hookA = vi.fn().mockResolvedValue({ groupSubscription: "added" });
-    const hookB = vi.fn().mockResolvedValue({ groupSubscription: "already_member" });
+    const hookB = vi.fn().mockResolvedValue({
+      groupSubscription: "already_member",
+      gruposSync: "ok",
+    });
 
-    const resultado = await ejecutarHooksPostConfirmacion(makeCtx(), [hookA, hookB]);
-
-    expect(resultado).toEqual({ groupSubscription: "already_member" });
+    await expect(
+      ejecutarHooksPostConfirmacion(makeCtx(), [hookA, hookB])
+    ).resolves.toEqual({
+      groupSubscription: "already_member",
+      gruposSync: "ok",
+    });
   });
 });
 
-// ── Políticas por origen ─────────────────────────────────────
-
-describe("HOOKS_CONFIRMACION_ALUMNO (registro y perfil)", () => {
+describe("políticas por origen", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockIntentarSincronizarGoogleGroup.mockResolvedValue({ status: "added" });
     mockIntentarSincronizarGrupos.mockResolvedValue(undefined);
   });
 
-  it("corre Google Groups y sync de grupos", async () => {
-    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_CONFIRMACION_ALUMNO);
-    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
+  it("registro y perfil ejecutan Google Groups y grupos de TP", async () => {
+    await ejecutarHooksPostConfirmacion(
+      makeCtx(),
+      HOOKS_CONFIRMACION_ALUMNO
+    );
+    expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledOnce();
     expect(mockIntentarSincronizarGrupos).toHaveBeenCalledOnce();
   });
-});
 
-describe("HOOKS_IMPORTACION_ALUMNO (importación admin)", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
-  });
-
-  it("corre Google Groups", async () => {
-    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
-    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledOnce();
-  });
-
-  // La sync de grupos NO se hace inline en la importación: queda en la action
-  // dedicada `sincronizarGruposDeLaComision` (lectura única de la hoja, UI propia).
-  it("NO corre sync de grupos (queda delegado a sincronizarGruposDeLaComision)", async () => {
-    await ejecutarHooksPostConfirmacion(makeCtx(), HOOKS_IMPORTACION_ALUMNO);
+  it("la importación ejecuta solo Google Groups", async () => {
+    await ejecutarHooksPostConfirmacion(
+      makeCtx(),
+      HOOKS_IMPORTACION_ALUMNO
+    );
+    expect(mockIntentarSincronizarGoogleGroup).toHaveBeenCalledOnce();
     expect(mockIntentarSincronizarGrupos).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/services/hooksPostConfirmacion.ts
+++ b/src/lib/services/hooksPostConfirmacion.ts
@@ -1,24 +1,12 @@
-import {
-  agregarMiembroAGrupo,
-  quitarMiembroDeGrupo,
-  type AgregarMiembroResult,
-} from "@/lib/googleGroups";
+import type { AgregarMiembroResult } from "@/lib/googleGroups";
 import { intentarSincronizarGrupos } from "./intentarSincronizarGrupos";
-import { logger } from "@/lib/logger";
-import { Alumno, type Comision } from "@/domain/entities";
+import { intentarSincronizarGoogleGroup } from "./intentarSincronizarGoogleGroup";
+import type { Comision } from "@/domain/entities";
 
-/**
- * Contexto del evento "alumno confirmado/actualizado". `emailPrevio` es el email
- * que el alumno tenía en la DB antes de esta confirmación; se usa para des-suscribir
- * del Google Group la dirección vieja cuando el email cambió. En un alta nueva
- * (registro de un alumno inexistente) o en la importación no hay previo, así que
- * sólo se suscribe la dirección actual.
- */
 export type ContextoAlumno = {
   githubUsername: string;
   email: string;
   comision: Comision;
-  emailPrevio?: string;
 };
 
 export type ResultadoHooks = {
@@ -28,63 +16,14 @@ export type ResultadoHooks = {
 
 export type HookPostConfirmacion = (ctx: ContextoAlumno) => Promise<ResultadoHooks>;
 
-// Enmascara la parte local del email para no escupir PII a los logs,
-// preservando dominio y primeras 2 letras para que un admin pueda
-// reconocer al alumno (combinado con el githubUsername del log).
-function maskEmail(correo: string): string {
-  return correo.replace(/^([^@]{1,2})([^@]*)(@.+)$/, "$1xxxxxx$3");
-}
-
-// Enmascara cualquier email embebido en un texto libre (p. ej. el `message` de
-// un error de googleapis, que suele citar el email del miembro afectado).
-function maskEmailsEnTexto(texto: string): string {
-  return texto.replace(/([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g, "$1xxxxxx$3");
-}
-
 /**
- * Suscribe al alumno al Google Group con su email actual y, si el email cambió
- * respecto al previo, des-suscribe la dirección vieja sólo cuando el alta nueva
- * quedó asegurada. La baja es best-effort: se loguea pero no degrada la
- * respuesta. El status devuelto refleja la suscripción del email actual, no la
- * baja del viejo.
+ * Reconcilia la membresía persistente del alumno. El servicio obtiene email y
+ * estado desde DB para que la misma operación sirva también en los reintentos.
  */
 export const hookGoogleGroups: HookPostConfirmacion = async ({
   githubUsername,
-  email,
-  emailPrevio,
 }) => {
-  const suscripcion = await agregarMiembroAGrupo(email);
-  if (suscripcion.status === "error") {
-    logger.error(
-      {
-        githubUsername,
-        maskedEmail: maskEmail(email),
-        err: maskEmailsEnTexto(suscripcion.error),
-      },
-      "Error al suscribir al Google Group"
-    );
-  }
-
-  const puedeQuitarEmailPrevio =
-    suscripcion.status === "added" || suscripcion.status === "already_member";
-  if (
-    puedeQuitarEmailPrevio &&
-    emailPrevio &&
-    Alumno.normalizarEmail(emailPrevio) !== Alumno.normalizarEmail(email)
-  ) {
-    const baja = await quitarMiembroDeGrupo(emailPrevio);
-    if (baja.status === "error") {
-      logger.error(
-        {
-          githubUsername,
-          maskedEmail: maskEmail(emailPrevio),
-          err: maskEmailsEnTexto(baja.error),
-        },
-        "Error al des-suscribir el email anterior del Google Group"
-      );
-    }
-  }
-
+  const suscripcion = await intentarSincronizarGoogleGroup(githubUsername);
   return { groupSubscription: suscripcion.status };
 };
 

--- a/src/lib/services/importarAlumnosDeComision.test.ts
+++ b/src/lib/services/importarAlumnosDeComision.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetAlumnos = vi.fn();
-const mockGetAlumnosByGithubUsernames = vi.fn();
 const mockUpsertAlumnos = vi.fn();
 const mockEjecutarHooksPostConfirmacion = vi.fn();
 const mockIntentarSincronizarGrupos = vi.fn();
@@ -11,8 +10,6 @@ vi.mock("@/lib/sheets", () => ({
 }));
 
 vi.mock("@/lib/repositories", () => ({
-  getAlumnosByGithubUsernames: (...args: unknown[]) =>
-    mockGetAlumnosByGithubUsernames(...args),
   upsertAlumnos: (...args: unknown[]) => mockUpsertAlumnos(...args),
 }));
 
@@ -54,7 +51,6 @@ describe("importarAlumnosDeComision", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetAlumnos.mockResolvedValue(alumnos);
-    mockGetAlumnosByGithubUsernames.mockResolvedValue([]);
     mockUpsertAlumnos.mockResolvedValue(2);
     mockEjecutarHooksPostConfirmacion.mockResolvedValue({ groupSubscription: "added" });
   });
@@ -64,18 +60,6 @@ describe("importarAlumnosDeComision", () => {
     expect(mockGetAlumnos).toHaveBeenCalledWith("sheet-abc", {});
   });
 
-  it("captura emails previos antes de upsertAlumnos", async () => {
-    await importarAlumnosDeComision(comision as never);
-    expect(mockGetAlumnosByGithubUsernames.mock.invocationCallOrder[0]).toBeLessThan(
-      mockUpsertAlumnos.mock.invocationCallOrder[0]
-    );
-  });
-
-  it("busca alumnos previos por githubUsername en batch", async () => {
-    await importarAlumnosDeComision(comision as never);
-    expect(mockGetAlumnosByGithubUsernames).toHaveBeenCalledWith(["Ana", "beto"]);
-  });
-
   it("persiste los alumnos con la comisión incluida", async () => {
     await importarAlumnosDeComision(comision as never);
     expect(mockUpsertAlumnos).toHaveBeenCalledWith(
@@ -83,31 +67,14 @@ describe("importarAlumnosDeComision", () => {
     );
   });
 
-  it("pasa emailPrevio al hook cuando el alumno ya existía", async () => {
-    mockGetAlumnosByGithubUsernames.mockResolvedValue([
-      { githubUsername: "ana", usernameCanonico: "ana", email: "ana-viejo@b.com" },
-    ]);
-
+  it("pasa el contexto persistido al hook de Google Groups", async () => {
     await importarAlumnosDeComision(comision as never);
 
     expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
       expect.objectContaining({
         githubUsername: "Ana",
         email: "ana-nuevo@b.com",
-        emailPrevio: "ana-viejo@b.com",
-      }),
-      ["google-groups-hook"]
-    );
-  });
-
-  it("pasa emailPrevio undefined cuando el alumno no existía", async () => {
-    await importarAlumnosDeComision(comision as never);
-
-    expect(mockEjecutarHooksPostConfirmacion).toHaveBeenCalledWith(
-      expect.objectContaining({
-        githubUsername: "Ana",
-        email: "ana-nuevo@b.com",
-        emailPrevio: undefined,
+        comision,
       }),
       ["google-groups-hook"]
     );

--- a/src/lib/services/importarAlumnosDeComision.ts
+++ b/src/lib/services/importarAlumnosDeComision.ts
@@ -1,8 +1,5 @@
-import { Alumno, type Comision } from "@/domain/entities";
-import {
-  getAlumnosByGithubUsernames,
-  upsertAlumnos,
-} from "@/lib/repositories";
+import type { Comision } from "@/domain/entities";
+import { upsertAlumnos } from "@/lib/repositories";
 import { getAlumnos } from "@/lib/sheets";
 import {
   ejecutarHooksPostConfirmacion,
@@ -27,8 +24,7 @@ export class LecturaPlanillaAlumnosError extends Error {
 
 /**
  * Caso de uso de importación admin: lee alumnos desde Sheets, persiste el bulk
- * upsert y dispara los hooks accesorios de importación. Captura emails previos
- * antes del flush para que Google Groups pueda des-suscribir direcciones viejas.
+ * upsert y dispara los hooks accesorios de importación.
  */
 export async function importarAlumnosDeComision(
   comision: Comision
@@ -40,26 +36,17 @@ export async function importarAlumnosDeComision(
     throw new LecturaPlanillaAlumnosError(error);
   }
 
-  const existentes = await getAlumnosByGithubUsernames(
-    alumnos.map((alumno) => alumno.githubUsername)
-  );
-  const emailPrevioPorGithub = new Map(
-    existentes.map((alumno) => [alumno.usernameCanonico, alumno.email])
-  );
-
   const sincronizados = await upsertAlumnos(
     alumnos.map((alumno) => ({ ...alumno, comision }))
   );
 
   let conErrorDeGrupo = 0;
   for (const alumno of alumnos) {
-    const githubUsername = Alumno.normalizarUsername(alumno.githubUsername);
     const { groupSubscription } = await ejecutarHooksPostConfirmacion(
       {
         githubUsername: alumno.githubUsername,
         email: alumno.email,
         comision,
-        emailPrevio: emailPrevioPorGithub.get(githubUsername),
       },
       HOOKS_IMPORTACION_ALUMNO
     );

--- a/src/lib/services/intentarSincronizarGoogleGroup.test.ts
+++ b/src/lib/services/intentarSincronizarGoogleGroup.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Alumno } from "@/domain/entities";
+
+const mockAgregarMiembroAGrupo = vi.fn();
+const mockQuitarMiembroDeGrupo = vi.fn();
+const mockIsGoogleGroupsConfigured = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockActualizarEstadoGoogleGroup = vi.fn();
+
+vi.mock("@/lib/googleGroups", () => ({
+  agregarMiembroAGrupo: (...args: unknown[]) =>
+    mockAgregarMiembroAGrupo(...args),
+  quitarMiembroDeGrupo: (...args: unknown[]) =>
+    mockQuitarMiembroDeGrupo(...args),
+  isGoogleGroupsConfigured: () => mockIsGoogleGroupsConfigured(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (...args: unknown[]) => mockGetAlumnoByGithub(...args),
+  actualizarEstadoGoogleGroup: (...args: unknown[]) =>
+    mockActualizarEstadoGoogleGroup(...args),
+}));
+
+import {
+  intentarSincronizarGoogleGroup,
+  sanitizarErrorGoogleGroup,
+} from "./intentarSincronizarGoogleGroup";
+
+function makeAlumno(overrides: Partial<Alumno> = {}): Alumno {
+  return Object.assign(new Alumno(), {
+    githubUsername: "juangarcia",
+    email: "nuevo@utn.edu.ar",
+    ...overrides,
+  });
+}
+
+describe("intentarSincronizarGoogleGroup", () => {
+  let alumno: Alumno;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    alumno = makeAlumno();
+    mockGetAlumnoByGithub.mockResolvedValue(alumno);
+    mockActualizarEstadoGoogleGroup.mockImplementation(
+      async (_username: string, actualizar: (actual: Alumno) => void) => {
+        actualizar(alumno);
+        return alumno;
+      }
+    );
+    mockIsGoogleGroupsConfigured.mockReturnValue(true);
+    mockAgregarMiembroAGrupo.mockResolvedValue({ status: "added" });
+    mockQuitarMiembroDeGrupo.mockResolvedValue({ status: "removed" });
+  });
+
+  it("marca omitido sin llamar a Google cuando la integración está desactivada", async () => {
+    mockIsGoogleGroupsConfigured.mockReturnValue(false);
+
+    await expect(
+      intentarSincronizarGoogleGroup("juangarcia")
+    ).resolves.toEqual({ status: "skipped" });
+
+    expect(mockAgregarMiembroAGrupo).not.toHaveBeenCalled();
+    expect(alumno.googleGroupEstado).toBe("omitido");
+    expect(alumno.googleGroupUltimoIntentoEn).toBeInstanceOf(Date);
+  });
+
+  it("asegura el email actual y persiste el éxito", async () => {
+    await expect(
+      intentarSincronizarGoogleGroup("juangarcia")
+    ).resolves.toEqual({ status: "added" });
+
+    expect(mockAgregarMiembroAGrupo).toHaveBeenCalledWith(
+      "nuevo@utn.edu.ar"
+    );
+    expect(alumno.googleGroupEstado).toBe("sincronizado");
+    expect(alumno.googleGroupEmailSincronizado).toBe("nuevo@utn.edu.ar");
+    expect(alumno.googleGroupSincronizadoEn).toBeInstanceOf(Date);
+  });
+
+  it("trata already_member como éxito idempotente", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({
+      status: "already_member",
+    });
+
+    await expect(
+      intentarSincronizarGoogleGroup("juangarcia")
+    ).resolves.toEqual({ status: "already_member" });
+    expect(alumno.googleGroupEstado).toBe("sincronizado");
+  });
+
+  it("agrega el email nuevo antes de retirar el anterior", async () => {
+    alumno.googleGroupEmailSincronizado = "viejo@gmail.com";
+
+    await intentarSincronizarGoogleGroup("juangarcia");
+
+    expect(mockAgregarMiembroAGrupo.mock.invocationCallOrder[0]).toBeLessThan(
+      mockQuitarMiembroDeGrupo.mock.invocationCallOrder[0]
+    );
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledWith("viejo@gmail.com");
+    expect(alumno.googleGroupEmailsPendientesBaja).toEqual([]);
+    expect(alumno.googleGroupEmailSincronizado).toBe("nuevo@utn.edu.ar");
+  });
+
+  it("conserva la baja pendiente cuando Google falla", async () => {
+    alumno.googleGroupEmailSincronizado = "viejo@gmail.com";
+    mockQuitarMiembroDeGrupo.mockResolvedValue({
+      status: "error",
+      error: "No se pudo quitar viejo@gmail.com",
+    });
+
+    await expect(
+      intentarSincronizarGoogleGroup("juangarcia")
+    ).resolves.toMatchObject({ status: "error" });
+
+    expect(alumno.googleGroupEstado).toBe("fallido");
+    expect(alumno.googleGroupEmailsPendientesBaja).toEqual([
+      "viejo@gmail.com",
+    ]);
+    expect(alumno.googleGroupUltimoError).not.toContain("viejo@gmail.com");
+  });
+
+  it("un reintento limpia bajas acumuladas", async () => {
+    alumno.googleGroupEstado = "fallido";
+    alumno.googleGroupEmailSincronizado = "nuevo@utn.edu.ar";
+    alumno.googleGroupEmailsPendientesBaja = [
+      "primero@gmail.com",
+      "segundo@gmail.com",
+    ];
+
+    await intentarSincronizarGoogleGroup("juangarcia");
+
+    expect(mockQuitarMiembroDeGrupo).toHaveBeenCalledTimes(2);
+    expect(alumno.googleGroupEmailsPendientesBaja).toEqual([]);
+    expect(alumno.googleGroupEstado).toBe("sincronizado");
+    expect(alumno.googleGroupUltimoError).toBeNull();
+  });
+
+  it("persiste el error de alta sanitizado", async () => {
+    mockAgregarMiembroAGrupo.mockResolvedValue({
+      status: "error",
+      error: "Falló nuevo@utn.edu.ar por permisos",
+    });
+
+    await intentarSincronizarGoogleGroup("juangarcia");
+
+    expect(alumno.googleGroupEstado).toBe("fallido");
+    expect(alumno.googleGroupUltimoError).toContain("@utn.edu.ar");
+    expect(alumno.googleGroupUltimoError).not.toContain(
+      "nuevo@utn.edu.ar"
+    );
+  });
+
+  it("devuelve error si el alumno no existe", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+    await expect(
+      intentarSincronizarGoogleGroup("desconocido")
+    ).resolves.toEqual({
+      status: "error",
+      error: "Alumno no encontrado",
+    });
+  });
+
+  it("degrada errores inesperados de persistencia sin lanzar", async () => {
+    mockActualizarEstadoGoogleGroup.mockRejectedValue(new Error("DB caída"));
+
+    await expect(
+      intentarSincronizarGoogleGroup("juangarcia")
+    ).resolves.toEqual({
+      status: "error",
+      error: "DB caída",
+    });
+  });
+});
+
+describe("sanitizarErrorGoogleGroup", () => {
+  it("enmascara emails embebidos", () => {
+    expect(
+      sanitizarErrorGoogleGroup("Falló alumno.largo@gmail.com")
+    ).not.toContain("alumno.largo@gmail.com");
+  });
+});

--- a/src/lib/services/intentarSincronizarGoogleGroup.ts
+++ b/src/lib/services/intentarSincronizarGoogleGroup.ts
@@ -1,0 +1,124 @@
+import {
+  agregarMiembroAGrupo,
+  isGoogleGroupsConfigured,
+  quitarMiembroDeGrupo,
+  type AgregarMiembroResult,
+} from "@/lib/googleGroups";
+import {
+  actualizarEstadoGoogleGroup,
+  getAlumnoByGithub,
+} from "@/lib/repositories";
+import { logger } from "@/lib/logger";
+
+export function sanitizarErrorGoogleGroup(texto: string): string {
+  return texto.replace(
+    /([\w.+-]{1,2})([\w.+-]*)(@[\w.-]+\.\w+)/g,
+    "$1xxxxxx$3"
+  );
+}
+
+async function marcarFallido(
+  githubUsername: string,
+  error: string,
+  message: string
+): Promise<void> {
+  const errorSanitizado = sanitizarErrorGoogleGroup(error);
+  await actualizarEstadoGoogleGroup(githubUsername, (alumno) => {
+    alumno.marcarGoogleGroupFallido(errorSanitizado);
+  });
+  logger.error({ githubUsername, err: errorSanitizado }, message);
+}
+
+/**
+ * Hace converger la membresía del Google Group con el email actual del alumno.
+ * El email nuevo se asegura antes de retirar direcciones anteriores. Las bajas
+ * pendientes se conservan en DB para tolerar cambios sucesivos de email.
+ */
+async function reconciliarGoogleGroup(
+  githubUsername: string
+): Promise<AgregarMiembroResult> {
+  const alumno = await getAlumnoByGithub(githubUsername);
+  if (!alumno) {
+    return { status: "error", error: "Alumno no encontrado" };
+  }
+
+  await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+    actual.registrarIntentoGoogleGroup();
+  });
+
+  if (!isGoogleGroupsConfigured()) {
+    await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+      actual.marcarGoogleGroupOmitido();
+    });
+    return { status: "skipped" };
+  }
+
+  const alta = await agregarMiembroAGrupo(alumno.email);
+  if (alta.status === "error") {
+    await marcarFallido(
+      githubUsername,
+      alta.error,
+      "Error al suscribir al Google Group"
+    );
+    return alta;
+  }
+  if (alta.status === "skipped") {
+    await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+      actual.marcarGoogleGroupOmitido();
+    });
+    return alta;
+  }
+
+  const actualizado = await actualizarEstadoGoogleGroup(
+    githubUsername,
+    (actual) => {
+      actual.registrarEmailAgregadoAGoogleGroup(alumno.email);
+    }
+  );
+  const pendientesBaja = [
+    ...(actualizado?.googleGroupEmailsPendientesBaja ?? []),
+  ];
+
+  for (const emailAnterior of pendientesBaja) {
+    const baja = await quitarMiembroDeGrupo(emailAnterior);
+    if (baja.status === "error") {
+      await marcarFallido(
+        githubUsername,
+        baja.error,
+        "Error al des-suscribir un email anterior del Google Group"
+      );
+      return { status: "error", error: baja.error };
+    }
+    if (baja.status === "skipped") {
+      await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+        actual.marcarGoogleGroupOmitido();
+      });
+      return { status: "skipped" };
+    }
+    await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+      actual.registrarBajaGoogleGroup(emailAnterior);
+    });
+  }
+
+  await actualizarEstadoGoogleGroup(githubUsername, (actual) => {
+    actual.marcarGoogleGroupSincronizado();
+  });
+  return alta;
+}
+
+export async function intentarSincronizarGoogleGroup(
+  githubUsername: string
+): Promise<AgregarMiembroResult> {
+  try {
+    return await reconciliarGoogleGroup(githubUsername);
+  } catch (error) {
+    const message =
+      error instanceof Error ? error.message : "Error inesperado de sincronización";
+    const errorSanitizado = sanitizarErrorGoogleGroup(message);
+    logger.error(
+      { githubUsername, err: errorSanitizado },
+      "Falló la reconciliación persistente del Google Group"
+    );
+    return { status: "error", error: errorSanitizado };
+  }
+}


### PR DESCRIPTION
## Resumen
- persiste estado, errores, timestamps y emails pendientes de baja de Google Groups por alumno
- centraliza la reconciliación idempotente para registro, perfil e importación
- agrega reintentos desde el perfil y desde la edición de comisión
- señala sincronizaciones pendientes en navbar desktop/mobile y en el banner global
- incluye migración y cobertura de dominio, servicios y UI

## Verificación
- `npm run test:run` (928 tests)
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

Closes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integración con Google Groups para sincronizar membresías y registrar estado persistente.
  * Botón de reintento en comisiones que ejecuta sincronización y muestra métricas.
  * Indicadores visuales de acciones pendientes en navegación y menú de usuario.
  * Detalles y lista de pendientes de Google Groups en la vista de edición de comisión y en el perfil.

* **Chores**
  * Migración de base de datos para persistir estado y metadata de sincronización.

* **Tests**
  * Cobertura ampliada para flujos de Google Groups y nuevas acciones.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->