### PR TITLE
Corregir migración de estado de Google Groups

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,41 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage/lcov.info
           fail_ci_if_error: true
+
+  migration-test:
+    runs-on: ubuntu-latest
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_DB: pdep_classroom_test
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d pdep_classroom_test"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      MIGRATION_TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/pdep_classroom_test
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run PostgreSQL migration tests
+        run: pnpm test:migrations

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:
@@ -63,6 +65,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: pnpm/action-setup@v4
         with:

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -22,24 +22,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "anio": {
-          "name": "anio",
-          "type": "int",
+        "legajo": {
+          "name": "legajo",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
+          "unique": true,
+          "length": 255,
           "precision": null,
           "scale": null,
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "integer"
+          "mappedType": "string"
         },
-        "spreadsheet_id": {
-          "name": "spreadsheet_id",
+        "nombre": {
+          "name": "nombre",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -54,25 +54,57 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "activa": {
-          "name": "activa",
-          "type": "boolean",
+        "apellido": {
+          "name": "apellido",
+          "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
-          "length": null,
+          "length": 255,
           "precision": null,
           "scale": null,
-          "default": "false",
+          "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "boolean"
+          "mappedType": "string"
         },
-        "column_config": {
-          "name": "column_config",
-          "type": "jsonb",
+        "github_username": {
+          "name": "github_username",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "comision_id": {
+          "name": "comision_id",
+          "type": "uuid",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -84,26 +116,223 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "json"
+          "mappedType": "uuid"
+        },
+        "registro_confirmado_en_id": {
+          "name": "registro_confirmado_en_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "grupos_sync_fallido_en": {
+          "name": "grupos_sync_fallido_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "alumno_sync_fallido_en": {
+          "name": "alumno_sync_fallido_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "google_group_estado": {
+          "name": "google_group_estado",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'pendiente'",
+          "comment": null,
+          "enumItems": [
+            "pendiente",
+            "sincronizado",
+            "fallido",
+            "omitido"
+          ],
+          "mappedType": "enum"
+        },
+        "google_group_email_sincronizado": {
+          "name": "google_group_email_sincronizado",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "google_group_emails_pendientes_baja": {
+          "name": "google_group_emails_pendientes_baja",
+          "type": "text[]",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'{}'",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "array"
+        },
+        "google_group_ultimo_error": {
+          "name": "google_group_ultimo_error",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        },
+        "google_group_ultimo_intento_en": {
+          "name": "google_group_ultimo_intento_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "google_group_sincronizado_en": {
+          "name": "google_group_sincronizado_en",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
         }
       },
-      "name": "comision",
+      "name": "alumno",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "comision_pkey",
+          "columnNames": [
+            "github_username"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_github_username_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "legajo"
+          ],
+          "composite": false,
+          "constraint": true,
+          "keyName": "alumno_legajo_unique",
+          "unique": true,
+          "primary": false
+        },
+        {
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "alumno_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
-      "foreignKeys": {},
-      "nativeEnums": {}
+      "foreignKeys": {
+        "alumno_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
+          "constraintName": "alumno_comision_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "alumno_registro_confirmado_en_id_foreign": {
+          "columnNames": [
+            "registro_confirmado_en_id"
+          ],
+          "constraintName": "alumno_registro_confirmado_en_id_foreign",
+          "localTableName": "public.alumno",
+          "referencedTableName": "public.comision",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -244,7 +473,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -276,15 +505,15 @@
         },
         "max_integrantes": {
           "name": "max_integrantes",
-          "type": "int",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": true,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
@@ -292,11 +521,11 @@
         },
         "inscripciones_cerradas": {
           "name": "inscripciones_cerradas",
-          "type": "boolean",
+          "type": "bool",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
-          "nullable": true,
+          "nullable": false,
           "unique": false,
           "length": null,
           "precision": null,
@@ -312,270 +541,43 @@
       "indexes": [
         {
           "columnNames": [
-            "tipo"
-          ],
-          "composite": false,
-          "keyName": "assignment_tipo_index",
-          "constraint": false,
-          "primary": false,
-          "unique": false
-        },
-        {
-          "keyName": "assignment_pkey",
-          "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "tipo"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "assignment_tipo_index",
+          "unique": false,
+          "primary": false
         }
       ],
       "checks": [],
       "foreignKeys": {
         "assignment_comision_id_foreign": {
+          "columnNames": [
+            "comision_id"
+          ],
           "constraintName": "assignment_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
           "localTableName": "public.assignment",
+          "referencedTableName": "public.comision",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
-    },
-    {
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": true,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "legajo": {
-          "name": "legajo",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "apellido": {
-          "name": "apellido",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "github_username": {
-          "name": "github_username",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "email": {
-          "name": "email",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "comision_id": {
-          "name": "comision_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "registro_confirmado_en_id": {
-          "name": "registro_confirmado_en_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "grupos_sync_fallido_en": {
-          "name": "grupos_sync_fallido_en",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        },
-        "alumno_sync_fallido_en": {
-          "name": "alumno_sync_fallido_en",
-          "type": "timestamptz",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
-          "length": 6,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "datetime"
-        }
-      },
-      "name": "alumno",
-      "schema": "public",
-      "indexes": [
-        {
-          "columnNames": [
-            "legajo"
-          ],
-          "composite": false,
-          "keyName": "alumno_legajo_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "columnNames": [
-            "github_username"
-          ],
-          "composite": false,
-          "keyName": "alumno_github_username_unique",
-          "constraint": true,
-          "primary": false,
-          "unique": true
-        },
-        {
-          "keyName": "alumno_pkey",
-          "columnNames": [
-            "id"
-          ],
-          "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
-        }
-      ],
-      "checks": [],
-      "foreignKeys": {
-        "alumno_comision_id_foreign": {
-          "constraintName": "alumno_comision_id_foreign",
-          "columnNames": [
-            "comision_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
           "updateRule": "cascade",
           "deleteRule": "cascade"
-        },
-        "alumno_registro_confirmado_en_id_foreign": {
-          "constraintName": "alumno_registro_confirmado_en_id_foreign",
-          "columnNames": [
-            "registro_confirmado_en_id"
-          ],
-          "localTableName": "public.alumno",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.comision",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -616,47 +618,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "assignment_alumnos_pkey",
           "columnNames": [
             "assignment_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "assignment_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "assignment_alumnos_assignment_id_foreign": {
-          "constraintName": "assignment_alumnos_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.assignment_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "assignment_alumnos_alumno_id_foreign": {
-          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "assignment_alumnos_alumno_id_foreign",
           "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "assignment_alumnos_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "assignment_alumnos_assignment_id_foreign",
+          "localTableName": "public.assignment_alumnos",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -676,60 +679,24 @@
           "enumItems": [],
           "mappedType": "uuid"
         },
-        "nombre": {
-          "name": "nombre",
-          "type": "varchar(255)",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": 255,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "string"
-        },
-        "paradigma": {
-          "name": "paradigma",
-          "type": "text",
+        "anio": {
+          "name": "anio",
+          "type": "int4",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
           "nullable": false,
           "unique": false,
           "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [
-            "funcional",
-            "logico",
-            "objetos"
-          ],
-          "mappedType": "enum"
-        },
-        "max_integrantes": {
-          "name": "max_integrantes",
-          "type": "int",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
+          "precision": 32,
+          "scale": 0,
           "default": null,
           "comment": null,
           "enumItems": [],
           "mappedType": "integer"
         },
-        "creado_por": {
-          "name": "creado_por",
+        "spreadsheet_id": {
+          "name": "spreadsheet_id",
           "type": "varchar(255)",
           "unsigned": false,
           "autoincrement": false,
@@ -744,9 +711,25 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "assignment_id": {
-          "name": "assignment_id",
-          "type": "uuid",
+        "activa": {
+          "name": "activa",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": true,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
+        },
+        "column_config": {
+          "name": "column_config",
+          "type": "jsonb",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -758,40 +741,38 @@
           "default": null,
           "comment": null,
           "enumItems": [],
-          "mappedType": "uuid"
+          "mappedType": "json"
         }
       },
-      "name": "grupo",
+      "name": "comision",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_pkey",
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "comision_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "activa"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "comision_unica_activa_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX comision_unica_activa_idx ON public.comision USING btree (activa) WHERE (activa IS TRUE)"
         }
       ],
       "checks": [],
-      "foreignKeys": {
-        "grupo_assignment_id_foreign": {
-          "constraintName": "grupo_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.grupo",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        }
-      },
-      "nativeEnums": {}
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -818,23 +799,7 @@
           "autoincrement": false,
           "primary": false,
           "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": null,
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "uuid"
-        },
-        "alumno_id": {
-          "name": "alumno_id",
-          "type": "uuid",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": true,
-          "unique": false,
+          "unique": true,
           "length": null,
           "precision": null,
           "scale": null,
@@ -907,25 +872,9 @@
           "enumItems": [],
           "mappedType": "string"
         },
-        "repo_deleted": {
-          "name": "repo_deleted",
-          "type": "boolean",
-          "unsigned": false,
-          "autoincrement": false,
-          "primary": false,
-          "nullable": false,
-          "unique": false,
-          "length": null,
-          "precision": null,
-          "scale": null,
-          "default": "false",
-          "comment": null,
-          "enumItems": [],
-          "mappedType": "boolean"
-        },
         "created_at": {
           "name": "created_at",
-          "type": "timestamptz",
+          "type": "timestamptz(6)",
           "unsigned": false,
           "autoincrement": false,
           "primary": false,
@@ -938,65 +887,269 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "datetime"
+        },
+        "alumno_id": {
+          "name": "alumno_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "repo_deleted": {
+          "name": "repo_deleted",
+          "type": "bool",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "false",
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "boolean"
         }
       },
       "name": "entrega",
       "schema": "public",
       "indexes": [
         {
-          "keyName": "entrega_pkey",
+          "columnNames": [
+            "assignment_id",
+            "alumno_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "entrega_assignment_alumno_unique_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX entrega_assignment_alumno_unique_idx ON public.entrega USING btree (assignment_id, alumno_id) WHERE (alumno_id IS NOT NULL)"
+        },
+        {
+          "columnNames": [
+            "assignment_id",
+            "grupo_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "entrega_assignment_grupo_unique_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX entrega_assignment_grupo_unique_idx ON public.entrega USING btree (assignment_id, grupo_id) WHERE (grupo_id IS NOT NULL)"
+        },
+        {
           "columnNames": [
             "id"
           ],
           "composite": false,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "entrega_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "lower(repo_name::text)"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "entrega_repo_name_unique_idx",
+          "unique": true,
+          "primary": false,
+          "expression": "CREATE UNIQUE INDEX entrega_repo_name_unique_idx ON public.entrega USING btree (lower((repo_name)::text)) WHERE (repo_name IS NOT NULL)"
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "entrega_assignment_id_foreign": {
-          "constraintName": "entrega_assignment_id_foreign",
-          "columnNames": [
-            "assignment_id"
-          ],
-          "localTableName": "public.entrega",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.assignment",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "entrega_alumno_id_foreign": {
-          "constraintName": "entrega_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "entrega_alumno_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
+        },
+        "entrega_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "entrega_assignment_id_foreign",
+          "localTableName": "public.entrega",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         },
         "entrega_grupo_id_foreign": {
-          "constraintName": "entrega_grupo_id_foreign",
           "columnNames": [
             "grupo_id"
           ],
+          "constraintName": "entrega_grupo_id_foreign",
           "localTableName": "public.entrega",
+          "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "set null",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "set null"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "nombre": {
+          "name": "nombre",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "paradigma": {
+          "name": "paradigma",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [
+            "funcional",
+            "logico",
+            "objetos"
+          ],
+          "mappedType": "enum"
+        },
+        "max_integrantes": {
+          "name": "max_integrantes",
+          "type": "int4",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": 32,
+          "scale": 0,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "integer"
+        },
+        "creado_por": {
+          "name": "creado_por",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        }
+      },
+      "name": "grupo",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "grupo_pkey",
+          "unique": true,
+          "primary": true
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {
+        "grupo_assignment_id_foreign": {
+          "columnNames": [
+            "assignment_id"
+          ],
+          "constraintName": "grupo_assignment_id_foreign",
+          "localTableName": "public.grupo",
+          "referencedTableName": "public.assignment",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        }
+      },
+      "nativeEnums": {},
+      "comment": null
     },
     {
       "columns": {
@@ -1037,47 +1190,48 @@
       "schema": "public",
       "indexes": [
         {
-          "keyName": "grupo_alumnos_pkey",
           "columnNames": [
             "grupo_id",
             "alumno_id"
           ],
           "composite": true,
-          "constraint": true,
-          "primary": true,
-          "unique": true
+          "constraint": false,
+          "keyName": "grupo_alumnos_pkey",
+          "unique": true,
+          "primary": true
         }
       ],
       "checks": [],
       "foreignKeys": {
-        "grupo_alumnos_grupo_id_foreign": {
-          "constraintName": "grupo_alumnos_grupo_id_foreign",
-          "columnNames": [
-            "grupo_id"
-          ],
-          "localTableName": "public.grupo_alumnos",
-          "referencedColumnNames": [
-            "id"
-          ],
-          "referencedTableName": "public.grupo",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
-        },
         "grupo_alumnos_alumno_id_foreign": {
-          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "columnNames": [
             "alumno_id"
           ],
+          "constraintName": "grupo_alumnos_alumno_id_foreign",
           "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.alumno",
           "referencedColumnNames": [
             "id"
           ],
-          "referencedTableName": "public.alumno",
-          "deleteRule": "cascade",
-          "updateRule": "cascade"
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "grupo_alumnos_grupo_id_foreign": {
+          "columnNames": [
+            "grupo_id"
+          ],
+          "constraintName": "grupo_alumnos_grupo_id_foreign",
+          "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
         }
       },
-      "nativeEnums": {}
+      "nativeEnums": {},
+      "comment": null
     }
   ],
   "nativeEnums": {}

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "test": "vitest",
     "test:run": "vitest run",
+    "test:migrations": "vitest run --config vitest.migrations.config.ts",
     "test:coverage": "vitest run --coverage",
     "db:migration:create": "mikro-orm migration:create",
     "db:migration:up": "mikro-orm migration:up",

--- a/src/domain/entities/Alumno.ts
+++ b/src/domain/entities/Alumno.ts
@@ -78,7 +78,7 @@ export class Alumno {
 
   // Todo alumno pertenece a exactamente una comisión. La FK es NOT NULL;
   // borrar una comisión borra sus alumnos en cascada (on delete cascade).
-  @ManyToOne(() => Comision)
+  @ManyToOne(() => Comision, { deleteRule: "cascade" })
   comision!: Comision;
 
   // Marca la comisión en la que el alumno confirmó sus datos por última vez.
@@ -104,7 +104,7 @@ export class Alumno {
   @Property({ type: "string", nullable: true })
   googleGroupEmailSincronizado: string | null = null;
 
-  @Property({ type: "array" })
+  @Property({ type: "array", defaultRaw: "'{}'" })
   googleGroupEmailsPendientesBaja: string[] = [];
 
   @Property({ type: "text", nullable: true })

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -66,7 +66,7 @@ export abstract class Assignment {
   @Property({ type: 'datetime' })
   createdAt: Date = new Date();
 
-  @ManyToOne(() => Comision, { nullable: true })
+  @ManyToOne(() => Comision, { nullable: true, deleteRule: "cascade" })
   comision?: Comision;
 
   /** Etiqueta para el contador "totales" del admin (ej: "Alumnos" / "Grupos"). */

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -2,6 +2,12 @@ import { describe, expect, it } from "vitest";
 import { readFileSync } from "fs";
 import { join } from "path";
 
+type SnapshotTable = {
+  name: string;
+  columns: Record<string, { default?: string; nullable?: boolean }>;
+  foreignKeys: Record<string, { deleteRule?: string }>;
+};
+
 describe("migrations", () => {
   it("garantiza una única comisión activa con un índice único parcial", () => {
     const migration = readFileSync(
@@ -53,6 +59,38 @@ describe("migrations", () => {
     expect(migration).toContain("default 'pendiente'");
     expect(migration).toContain('"google_group_email_sincronizado"');
     expect(migration).toContain('"google_group_emails_pendientes_baja"');
+    expect(migration).toContain(
+      '"google_group_emails_pendientes_baja" text[] not null default \'{}\''
+    );
     expect(migration).toContain('"google_group_ultimo_error"');
+  });
+
+  it("mantiene el snapshot alineado con Google Groups y las cascadas", () => {
+    const snapshot = JSON.parse(
+      readFileSync(
+        join(process.cwd(), "migrations", ".snapshot-pdep_classroom.json"),
+        "utf8"
+      )
+    ) as { tables: SnapshotTable[] };
+    const alumno = snapshot.tables.find((table) => table.name === "alumno");
+    const assignment = snapshot.tables.find(
+      (table) => table.name === "assignment"
+    );
+
+    expect(alumno?.columns.google_group_emails_pendientes_baja).toMatchObject({
+      nullable: false,
+      default: "'{}'",
+    });
+    expect(alumno?.columns).toHaveProperty("google_group_estado");
+    expect(alumno?.columns).toHaveProperty("google_group_email_sincronizado");
+    expect(alumno?.columns).toHaveProperty("google_group_ultimo_error");
+    expect(alumno?.columns).toHaveProperty("google_group_ultimo_intento_en");
+    expect(alumno?.columns).toHaveProperty("google_group_sincronizado_en");
+    expect(
+      alumno?.foreignKeys.alumno_comision_id_foreign.deleteRule
+    ).toBe("cascade");
+    expect(
+      assignment?.foreignKeys.assignment_comision_id_foreign.deleteRule
+    ).toBe("cascade");
   });
 });

--- a/tests/migrations/google-group-state.integration.test.ts
+++ b/tests/migrations/google-group-state.integration.test.ts
@@ -1,0 +1,163 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import ormConfig from "../../mikro-orm.config";
+
+const PREVIOUS_MIGRATION =
+  "Migration20260529130107_alumno_comision_not_null_and_cascade";
+const GOOGLE_GROUP_MIGRATION =
+  "Migration20260610120000_add_google_group_state_to_alumno";
+
+function getSafeTestDatabaseUrl(): string {
+  const value = process.env.MIGRATION_TEST_DATABASE_URL;
+  if (!value) {
+    throw new Error(
+      "MIGRATION_TEST_DATABASE_URL es obligatoria para ejecutar pruebas de migraciones"
+    );
+  }
+
+  const url = new URL(value);
+  const databaseName = url.pathname.slice(1);
+  if (!["postgres:", "postgresql:"].includes(url.protocol)) {
+    throw new Error("La base de migraciones debe usar PostgreSQL");
+  }
+  if (!databaseName.endsWith("_test")) {
+    throw new Error(
+      `La base de migraciones debe terminar en _test; se recibió ${databaseName || "una base sin nombre"}`
+    );
+  }
+
+  return value;
+}
+
+async function resetPublicSchema(orm: MikroORM): Promise<void> {
+  const connection = orm.em.getConnection();
+  await connection.execute('drop schema if exists "public" cascade');
+  await connection.execute('create schema "public"');
+}
+
+async function getDeleteRule(
+  orm: MikroORM,
+  constraintName: string
+): Promise<string | undefined> {
+  const rows = await orm.em.getConnection().execute<{ delete_rule: string }[]>(
+    `select delete_rule
+       from information_schema.referential_constraints
+      where constraint_schema = 'public'
+        and constraint_name = ?`,
+    [constraintName]
+  );
+  return rows[0]?.delete_rule;
+}
+
+describe("Migration20260610120000_add_google_group_state_to_alumno", () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      ...ormConfig,
+      clientUrl: getSafeTestDatabaseUrl(),
+      debug: false,
+      migrations: {
+        ...ormConfig.migrations,
+        snapshot: false,
+      },
+    });
+    await resetPublicSchema(orm);
+  });
+
+  afterAll(async () => {
+    if (!orm) return;
+    await resetPublicSchema(orm);
+    await orm.close(true);
+  });
+
+  it("migra alumnos existentes, conserva defaults y revierte limpiamente", async () => {
+    const migrator = orm.getMigrator();
+    const connection = orm.em.getConnection();
+    await migrator.up({ to: PREVIOUS_MIGRATION });
+
+    const comisionId = randomUUID();
+    const alumnoExistenteId = randomUUID();
+    await connection.execute(
+      `insert into "comision"
+        ("id", "anio", "spreadsheet_id", "activa", "column_config")
+       values (?, 2026, 'sheet-migration-test', false, '{}'::jsonb)`,
+      [comisionId]
+    );
+    await connection.execute(
+      `insert into "alumno"
+        ("id", "legajo", "nombre", "apellido", "github_username", "email", "comision_id")
+       values (?, '10001', 'Ada', 'Lovelace', 'ada-migration', 'ada@example.com', ?)`,
+      [alumnoExistenteId, comisionId]
+    );
+
+    await migrator.up({ to: GOOGLE_GROUP_MIGRATION });
+
+    const alumnosExistentes = await connection.execute<
+      { google_group_emails_pendientes_baja: string[] }[]
+    >(
+      `select "google_group_emails_pendientes_baja"
+         from "alumno"
+        where "id" = ?`,
+      [alumnoExistenteId]
+    );
+    expect(alumnosExistentes[0]?.google_group_emails_pendientes_baja).toEqual([]);
+
+    const columns = await connection.execute<
+      { is_nullable: string; column_default: string | null }[]
+    >(
+      `select is_nullable, column_default
+         from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'alumno'
+          and column_name = 'google_group_emails_pendientes_baja'`
+    );
+    expect(columns[0]?.is_nullable).toBe("NO");
+    expect(columns[0]?.column_default).toBe("'{}'::text[]");
+
+    const alumnoNuevoId = randomUUID();
+    await connection.execute(
+      `insert into "alumno"
+        ("id", "legajo", "nombre", "apellido", "github_username", "email", "comision_id")
+       values (?, '10002', 'Grace', 'Hopper', 'grace-migration', 'grace@example.com', ?)`,
+      [alumnoNuevoId, comisionId]
+    );
+    const alumnosNuevos = await connection.execute<
+      { google_group_estado: string; google_group_emails_pendientes_baja: string[] }[]
+    >(
+      `select "google_group_estado", "google_group_emails_pendientes_baja"
+         from "alumno"
+        where "id" = ?`,
+      [alumnoNuevoId]
+    );
+    expect(alumnosNuevos[0]).toEqual({
+      google_group_estado: "pendiente",
+      google_group_emails_pendientes_baja: [],
+    });
+    expect(await getDeleteRule(orm, "alumno_comision_id_foreign")).toBe(
+      "CASCADE"
+    );
+    expect(await getDeleteRule(orm, "assignment_comision_id_foreign")).toBe(
+      "CASCADE"
+    );
+
+    await migrator.down({ migrations: [GOOGLE_GROUP_MIGRATION] });
+
+    const remainingColumns = await connection.execute<{ column_name: string }[]>(
+      `select column_name
+         from information_schema.columns
+        where table_schema = 'public'
+          and table_name = 'alumno'
+          and column_name like 'google_group_%'`
+    );
+    expect(remainingColumns).toEqual([]);
+    expect(await getDeleteRule(orm, "alumno_comision_id_foreign")).toBe(
+      "CASCADE"
+    );
+    expect(await getDeleteRule(orm, "assignment_comision_id_foreign")).toBe(
+      "CASCADE"
+    );
+
+  });
+});

--- a/vitest.migrations.config.ts
+++ b/vitest.migrations.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vitest/config";
+import path from "node:path";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/migrations/**/*.test.ts"],
+    fileParallelism: false,
+    hookTimeout: 60_000,
+    testTimeout: 60_000,
+  },
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "./src"),
+    },
+  },
+});


### PR DESCRIPTION
## Resumen
- alinea la entidad y el snapshot con el default seguro para emails pendientes de baja
- conserva las reglas ON DELETE CASCADE de alumnos y assignments
- agrega una prueba real de up/down sobre PostgreSQL 16 y un job dedicado en CI

## Verificación
- pnpm test:migrations
- pnpm test:run (936 tests)
- pnpm build
- pnpm exec tsc --noEmit
- git diff --check

Closes #45

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Mejoras**
  * Mejorada la consistencia de los datos relacionados con alumnos y asignaciones.
  * Añadidos valores predeterminados y reglas de eliminación en cascada para mantener relaciones más fiables.
  * Actualizado el esquema de datos con nuevas relaciones, restricciones e índices.

* **Pruebas**
  * Ampliada la validación de migraciones, incluidos los estados de Google Groups.
  * Integradas pruebas automatizadas de migraciones en la integración continua con PostgreSQL 16.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->