### PR TITLE
Aplicar autorización por comisión en assignments y grupos

### DIFF
--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -1,15 +1,16 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import { Entrega, GrupoNoAsignadoError } from "@/domain/entities";
+import { AccesoAssignmentProhibidoError } from "@/lib/services/assignmentAuthorization";
 
 const {
-  mockRequireUser,
+  mockGetCurrentUser,
   mockCheckRateLimit,
   mockAceptarAssignment,
   FakeAlumnoNoRegistradoError,
   FakeAssignmentNoEncontradoError,
 } = vi.hoisted(() => ({
-  mockRequireUser: vi.fn(),
+  mockGetCurrentUser: vi.fn(),
   mockCheckRateLimit: vi.fn(),
   mockAceptarAssignment: vi.fn(),
   FakeAlumnoNoRegistradoError: class AlumnoNoRegistradoError extends Error {},
@@ -17,7 +18,7 @@ const {
 }));
 
 vi.mock("@/lib/session", () => ({
-  requireUser: () => mockRequireUser(),
+  getCurrentUser: () => mockGetCurrentUser(),
 }));
 
 vi.mock("@/lib/rate-limit", () => ({
@@ -64,7 +65,7 @@ function makeRequest(): Request {
 describe("POST /api/assignments/[id]/accept", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetCurrentUser.mockResolvedValue(makeUser());
     mockCheckRateLimit.mockReturnValue(true);
     mockAceptarAssignment.mockResolvedValue(makeEntrega());
   });
@@ -113,7 +114,7 @@ describe("POST /api/assignments/[id]/accept", () => {
       repoName: "kata-funcional-los-lambdas",
       githubUsernames: ["juangarcia", "marialopez"],
     });
-    mockRequireUser
+    mockGetCurrentUser
       .mockResolvedValueOnce(makeUser({ githubUsername: "juangarcia" }))
       .mockResolvedValueOnce(makeUser({ githubUsername: "marialopez" }));
     mockAceptarAssignment.mockResolvedValue(entrega);
@@ -139,6 +140,14 @@ describe("POST /api/assignments/[id]/accept", () => {
     expect(response.status).toBe(404);
   });
 
+  it("devuelve 403 si el alumno pertenece a otra comisión", async () => {
+    mockAceptarAssignment.mockRejectedValue(
+      new AccesoAssignmentProhibidoError("a1")
+    );
+    const response = await POST(makeRequest(), { params: { id: "a1" } });
+    expect(response.status).toBe(403);
+  });
+
   it("devuelve 400 si assignment grupal y el usuario no tiene grupo", async () => {
     mockAceptarAssignment.mockRejectedValue(new GrupoNoAsignadoError("a1", "juangarcia"));
     const response = await POST(makeRequest(), { params: { id: "a1" } });
@@ -151,9 +160,9 @@ describe("POST /api/assignments/[id]/accept", () => {
     expect(response.status).toBe(400);
   });
 
-  it("devuelve 500 si requireUser lanza", async () => {
-    mockRequireUser.mockRejectedValue(new Error("redirect"));
+  it("devuelve 401 si no hay sesión", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
     const response = await POST(makeRequest(), { params: { id: "a1" } });
-    expect(response.status).toBe(500);
+    expect(response.status).toBe(401);
   });
 });

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/session";
+import { getCurrentUser } from "@/lib/session";
 import { GrupoNoAsignadoError } from "@/domain/entities";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { internalServerError } from "@/lib/api-errors";
@@ -8,13 +8,17 @@ import {
   AlumnoNoRegistradoError,
   AssignmentNoEncontradoError,
 } from "@/lib/services/aceptarAssignment";
+import { AccesoAssignmentProhibidoError } from "@/lib/services/assignmentAuthorization";
 
 export async function POST(
   _req: Request,
   { params }: { params: { id: string } }
 ) {
   try {
-    const user = await requireUser();
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
 
     if (!checkRateLimit(`${user.githubUsername}:${params.id}`)) {
       return NextResponse.json(
@@ -28,6 +32,9 @@ export async function POST(
   } catch (error) {
     if (error instanceof AssignmentNoEncontradoError) {
       return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
     }
     if (error instanceof GrupoNoAsignadoError || error instanceof AlumnoNoRegistradoError) {
       return NextResponse.json({ error: error.message }, { status: 400 });

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import {
+  AccesoAssignmentProhibidoError,
+  GrupoNoEncontradoError,
+} from "@/lib/services/assignmentAuthorization";
+import {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   GrupoLlenoError,
@@ -8,12 +12,12 @@ import {
 
 // ── Mocks ────────────────────────────────────────────────────
 
-const mockRequireUser = vi.fn();
+const mockGetCurrentUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
 const mockUnirseAGrupo = vi.fn();
 
 vi.mock("@/lib/session", () => ({
-  requireUser: () => mockRequireUser(),
+  getCurrentUser: () => mockGetCurrentUser(),
 }));
 
 vi.mock("@/lib/repositories", () => ({
@@ -36,7 +40,7 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
 }
 
 function makeAlumno(id = "alumno-ana", github = "ana") {
-  return { id, githubUsername: github };
+  return { id, githubUsername: github, comision: { id: "c1" } };
 }
 
 function makeGrupoEntity(overrides = {}) {
@@ -64,7 +68,7 @@ function makeRequest(): Request {
 describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetCurrentUser.mockResolvedValue(makeUser());
     mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
     mockUnirseAGrupo.mockResolvedValue(makeGrupoEntity());
   });
@@ -80,15 +84,27 @@ describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
   it("llama a unirseAGrupo con grupoId y alumnoId", async () => {
     await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
     expect(mockUnirseAGrupo).toHaveBeenCalledWith({
+      assignmentId: "a1",
       grupoId: "g1",
       alumnoId: "alumno-ana",
+      esAdmin: false,
     });
   });
 
-  it("devuelve 404 si el alumno no está registrado", async () => {
+  it("propaga el contexto administrativo confiable a la transacción", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ isAdmin: true }));
+
+    await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+
+    expect(mockUnirseAGrupo).toHaveBeenCalledWith(
+      expect.objectContaining({ esAdmin: true })
+    );
+  });
+
+  it("devuelve 403 si el alumno no está registrado", async () => {
     mockGetAlumnoByGithub.mockResolvedValue(null);
     const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(mockUnirseAGrupo).not.toHaveBeenCalled();
   });
 
@@ -110,6 +126,18 @@ describe("POST /api/assignments/[id]/grupos/[grupoId]/join", () => {
     mockUnirseAGrupo.mockRejectedValue(new GrupoLlenoError("g1", 3));
     const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
     expect(response.status).toBe(409);
+  });
+
+  it("devuelve 404 si el grupo no pertenece al assignment de la URL", async () => {
+    mockUnirseAGrupo.mockRejectedValue(new GrupoNoEncontradoError("a1", "g1"));
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(404);
+  });
+
+  it("devuelve 403 si la autorización transaccional rechaza la comisión", async () => {
+    mockUnirseAGrupo.mockRejectedValue(new AccesoAssignmentProhibidoError("a1"));
+    const response = await POST(makeRequest(), { params: { id: "a1", grupoId: "g1" } });
+    expect(response.status).toBe(403);
   });
 
   it("devuelve 500 para errores inesperados", async () => {

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { requireUser } from "@/lib/session";
+import { getCurrentUser } from "@/lib/session";
 import { getAlumnoByGithub, unirseAGrupo } from "@/lib/repositories";
 import {
   InscripcionesCerradasError,
@@ -8,6 +8,10 @@ import {
 } from "@/domain/entities";
 import { internalServerError } from "@/lib/api-errors";
 import type { Grupo } from "@/domain/entities";
+import {
+  AccesoAssignmentProhibidoError,
+  GrupoNoEncontradoError,
+} from "@/lib/services/assignmentAuthorization";
 
 function serializarGrupo(grupo: Grupo) {
   return {
@@ -25,23 +29,34 @@ export async function POST(
   { params }: { params: { id: string; grupoId: string } }
 ) {
   try {
-    const user = await requireUser();
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
 
-    const alumno = await getAlumnoByGithub(user.githubUsername);
+    const alumno = await getAlumnoByGithub(user.githubUsername, true);
     if (!alumno) {
       return NextResponse.json(
-        { error: "Alumno no registrado" },
-        { status: 404 }
+        { error: "No tenés acceso a este assignment" },
+        { status: 403 }
       );
     }
 
     const grupo = await unirseAGrupo({
+      assignmentId: params.id,
       grupoId: params.grupoId,
       alumnoId: alumno.id,
+      esAdmin: user.isAdmin,
     });
 
     return NextResponse.json(serializarGrupo(grupo));
   } catch (error) {
+    if (error instanceof GrupoNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
     if (error instanceof InscripcionesCerradasError) {
       return NextResponse.json(
         { error: "Las inscripciones a grupos están cerradas" },

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import {
+  AccesoAssignmentProhibidoError,
+  AssignmentNoEncontradoError,
+} from "@/lib/services/assignmentAuthorization";
+import {
   AssignmentNoGrupalError,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
@@ -8,17 +12,19 @@ import {
 
 // ── Mocks ────────────────────────────────────────────────────
 
-const mockRequireUser = vi.fn();
+const mockGetCurrentUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
+const mockGetAssignment = vi.fn();
 const mockGetGruposDeAssignment = vi.fn();
 const mockCrearGrupo = vi.fn();
 
 vi.mock("@/lib/session", () => ({
-  requireUser: () => mockRequireUser(),
+  getCurrentUser: () => mockGetCurrentUser(),
 }));
 
 vi.mock("@/lib/repositories", () => ({
   getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  getAssignment: (id: string) => mockGetAssignment(id),
   getGruposDeAssignment: (id: string) => mockGetGruposDeAssignment(id),
   crearGrupo: (params: unknown) => mockCrearGrupo(params),
 }));
@@ -38,7 +44,11 @@ function makeUser(overrides?: Partial<PdepUser>): PdepUser {
 }
 
 function makeAlumno(id = "alumno-ana", github = "ana") {
-  return { id, githubUsername: github };
+  return { id, githubUsername: github, comision: { id: "c1" } };
+}
+
+function makeAssignment(overrides = {}) {
+  return { id: "a1", comision: { id: "c1" }, ...overrides };
 }
 
 function makeGrupoEntity(overrides = {}) {
@@ -67,7 +77,9 @@ function makeRequest(body?: unknown, method = "POST"): Request {
 describe("GET /api/assignments/[id]/grupos", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetCurrentUser.mockResolvedValue(makeUser());
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
+    mockGetAssignment.mockResolvedValue(makeAssignment());
     mockGetGruposDeAssignment.mockResolvedValue([makeGrupoEntity()]);
   });
 
@@ -93,17 +105,46 @@ describe("GET /api/assignments/[id]/grupos", () => {
     expect(data).toEqual([]);
   });
 
-  it("devuelve 500 si el usuario no está autenticado", async () => {
-    mockRequireUser.mockRejectedValue(new Error("redirect"));
+  it("devuelve 403 y no consulta grupos para un alumno de otra comisión", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno("alumno-ana", "ana"));
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision: { id: "c2" } }));
+
     const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
-    expect(response.status).toBe(500);
+
+    expect(response.status).toBe(403);
+    expect(mockGetGruposDeAssignment).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 404 si el assignment no existe", async () => {
+    mockGetAssignment.mockResolvedValue(null);
+
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+
+    expect(response.status).toBe(404);
+    expect(mockGetGruposDeAssignment).not.toHaveBeenCalled();
+  });
+
+  it("permite acceso global al administrador", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ isAdmin: true }));
+
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+
+    expect(response.status).toBe(200);
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 401 si el usuario no está autenticado", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const response = await GET(makeRequest(undefined, "GET"), { params: { id: "a1" } });
+    expect(response.status).toBe(401);
+    expect(mockGetGruposDeAssignment).not.toHaveBeenCalled();
   });
 });
 
 describe("POST /api/assignments/[id]/grupos", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRequireUser.mockResolvedValue(makeUser());
+    mockGetCurrentUser.mockResolvedValue(makeUser());
     mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
     mockCrearGrupo.mockResolvedValue(makeGrupoEntity());
   });
@@ -122,7 +163,18 @@ describe("POST /api/assignments/[id]/grupos", () => {
       assignmentId: "a1",
       alumnoId: "alumno-ana",
       nombre: "Los Lambdas",
+      esAdmin: false,
     });
+  });
+
+  it("propaga el contexto administrativo confiable a la transacción", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ isAdmin: true }));
+
+    await POST(makeRequest({ nombre: "Los Lambdas" }), { params: { id: "a1" } });
+
+    expect(mockCrearGrupo).toHaveBeenCalledWith(
+      expect.objectContaining({ esAdmin: true })
+    );
   });
 
   it("devuelve 400 si el body no tiene nombre", async () => {
@@ -130,10 +182,10 @@ describe("POST /api/assignments/[id]/grupos", () => {
     expect(response.status).toBe(400);
   });
 
-  it("devuelve 404 si el alumno no está registrado", async () => {
+  it("devuelve 403 si el alumno no está registrado", async () => {
     mockGetAlumnoByGithub.mockResolvedValue(null);
     const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(mockCrearGrupo).not.toHaveBeenCalled();
   });
 
@@ -141,6 +193,18 @@ describe("POST /api/assignments/[id]/grupos", () => {
     mockCrearGrupo.mockRejectedValue(new AssignmentNoGrupalError("a1"));
     const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
     expect(response.status).toBe(400);
+  });
+
+  it("devuelve 404 si el assignment no existe", async () => {
+    mockCrearGrupo.mockRejectedValue(new AssignmentNoEncontradoError("a1"));
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(404);
+  });
+
+  it("devuelve 403 si la autorización transaccional rechaza la comisión", async () => {
+    mockCrearGrupo.mockRejectedValue(new AccesoAssignmentProhibidoError("a1"));
+    const response = await POST(makeRequest({ nombre: "x" }), { params: { id: "a1" } });
+    expect(response.status).toBe(403);
   });
 
   it("devuelve 409 si las inscripciones están cerradas", async () => {

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -1,8 +1,9 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
-import { requireUser } from "@/lib/session";
+import { getCurrentUser } from "@/lib/session";
 import {
   getAlumnoByGithub,
+  getAssignment,
   getGruposDeAssignment,
   crearGrupo,
 } from "@/lib/repositories";
@@ -13,6 +14,11 @@ import {
 } from "@/domain/entities";
 import { internalServerError } from "@/lib/api-errors";
 import type { Grupo } from "@/domain/entities";
+import {
+  AccesoAssignmentProhibidoError,
+  AssignmentNoEncontradoError,
+  autorizarAccesoAssignment,
+} from "@/lib/services/assignmentAuthorization";
 
 const CrearGrupoSchema = z.object({
   nombre: z.string().min(1).max(100),
@@ -34,10 +40,29 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    await requireUser();
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
+
+    const [assignment, alumno] = await Promise.all([
+      getAssignment(params.id),
+      user.isAdmin
+        ? Promise.resolve(null)
+        : getAlumnoByGithub(user.githubUsername, true),
+    ]);
+    if (!assignment) throw new AssignmentNoEncontradoError(params.id);
+    autorizarAccesoAssignment(user, alumno, assignment);
+
     const grupos = await getGruposDeAssignment(params.id);
     return NextResponse.json(grupos.map(serializarGrupo));
   } catch (error) {
+    if (error instanceof AssignmentNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
     return internalServerError("GET /api/assignments/[id]/grupos", error, {
       assignmentId: params.id,
     });
@@ -49,7 +74,10 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   try {
-    const user = await requireUser();
+    const user = await getCurrentUser();
+    if (!user) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
 
     const body = await req.json().catch(() => null);
     const parsed = CrearGrupoSchema.safeParse(body);
@@ -60,11 +88,11 @@ export async function POST(
       );
     }
 
-    const alumno = await getAlumnoByGithub(user.githubUsername);
+    const alumno = await getAlumnoByGithub(user.githubUsername, true);
     if (!alumno) {
       return NextResponse.json(
-        { error: "Alumno no registrado" },
-        { status: 404 }
+        { error: "No tenés acceso a este assignment" },
+        { status: 403 }
       );
     }
 
@@ -72,10 +100,17 @@ export async function POST(
       assignmentId: params.id,
       alumnoId: alumno.id,
       nombre: parsed.data.nombre,
+      esAdmin: user.isAdmin,
     });
 
     return NextResponse.json(serializarGrupo(grupo), { status: 201 });
   } catch (error) {
+    if (error instanceof AssignmentNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
     if (error instanceof AssignmentNoGrupalError) {
       return NextResponse.json(
         { error: "Este assignment no es grupal" },

--- a/src/app/api/assignments/route.test.ts
+++ b/src/app/api/assignments/route.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PdepUser } from "@/types";
+
+const mockGetCurrentUser = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
+const mockGetAssignments = vi.fn();
+const mockGetAssignmentsDeComision = vi.fn();
+
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
+  getAssignments: () => mockGetAssignments(),
+  getAssignmentsDeComision: (comisionId: string) =>
+    mockGetAssignmentsDeComision(comisionId),
+}));
+
+import { GET } from "./route";
+
+function makeUser(overrides: Partial<PdepUser> = {}): PdepUser {
+  return {
+    githubUsername: "ana",
+    name: "Ana",
+    image: "",
+    isAdmin: false,
+    ...overrides,
+  };
+}
+
+describe("GET /api/assignments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue(makeUser());
+    mockGetAlumnoByGithub.mockResolvedValue({
+      id: "alumno-ana",
+      comision: { id: "c1" },
+    });
+    mockGetAssignmentsDeComision.mockResolvedValue([{ id: "a1" }]);
+    mockGetAssignments.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
+  });
+
+  it("devuelve 401 sin sesión", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(401);
+    expect(mockGetAssignments).not.toHaveBeenCalled();
+    expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
+  });
+
+  it("lista únicamente los assignments de la comisión del alumno", async () => {
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(mockGetAssignmentsDeComision).toHaveBeenCalledWith("c1");
+    expect(mockGetAssignments).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 403 si el usuario no está registrado como alumno", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(null);
+
+    const response = await GET();
+
+    expect(response.status).toBe(403);
+    expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
+  });
+
+  it("mantiene el listado global para administradores", async () => {
+    mockGetCurrentUser.mockResolvedValue(makeUser({ isAdmin: true }));
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(mockGetAssignments).toHaveBeenCalled();
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+    expect(mockGetAssignmentsDeComision).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -1,11 +1,29 @@
 import { NextResponse } from "next/server";
-import { guardUser } from "@/lib/api-auth";
-import { getAssignments } from "@/lib/repositories";
+import { getCurrentUser } from "@/lib/session";
+import {
+  getAlumnoByGithub,
+  getAssignments,
+  getAssignmentsDeComision,
+} from "@/lib/repositories";
 
 export async function GET() {
-  const unauthorized = await guardUser();
-  if (unauthorized) return unauthorized;
+  const user = await getCurrentUser();
+  if (!user) {
+    return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+  }
 
-  const assignments = await getAssignments();
+  if (user.isAdmin) {
+    return NextResponse.json(await getAssignments());
+  }
+
+  const alumno = await getAlumnoByGithub(user.githubUsername, true);
+  if (!alumno) {
+    return NextResponse.json(
+      { error: "No tenés acceso a los assignments" },
+      { status: 403 }
+    );
+  }
+
+  const assignments = await getAssignmentsDeComision(alumno.comision.id);
   return NextResponse.json(assignments);
 }

--- a/src/app/assignments/[id]/grupo/page.test.tsx
+++ b/src/app/assignments/[id]/grupo/page.test.tsx
@@ -7,6 +7,7 @@ import { GrupalAssignment, IndividualAssignment } from "@/domain/entities";
 
 const mockRequireUser = vi.fn();
 const mockGetAssignment = vi.fn();
+const mockGetAlumnoByGithub = vi.fn();
 const mockGetGruposDeAssignment = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockNotFound = vi.fn(() => { throw new Error("NOT_FOUND"); });
@@ -17,6 +18,7 @@ vi.mock("@/lib/session", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAssignment: (id: string) => mockGetAssignment(id),
+  getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
   getGruposDeAssignment: (id: string) => mockGetGruposDeAssignment(id),
   getEntregaDeUsuario: (assignmentId: string, username: string) =>
     mockGetEntregaDeUsuario(assignmentId, username),
@@ -72,7 +74,16 @@ function makeGrupalAssignment(overrides = {}): GrupalAssignment {
   assignment.slug = "tp-grupal";
   assignment.maxIntegrantes = 3;
   assignment.inscripcionesCerradas = false;
+  assignment.comision = { id: "c1" } as never;
   return Object.assign(assignment, overrides);
+}
+
+function makeAlumno(comisionId = "c1") {
+  return {
+    id: "alumno-ana",
+    githubUsername: "ana",
+    comision: { id: comisionId },
+  };
 }
 
 function makeGrupo(
@@ -107,6 +118,7 @@ describe("GrupoPage", () => {
     vi.clearAllMocks();
     mockRequireUser.mockResolvedValue(makeUser());
     mockGetAssignment.mockResolvedValue(makeGrupalAssignment());
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno());
     mockGetGruposDeAssignment.mockResolvedValue([]);
     mockGetEntregaDeUsuario.mockResolvedValue(null);
   });
@@ -121,6 +133,23 @@ describe("GrupoPage", () => {
     individual.id = "a1";
     mockGetAssignment.mockResolvedValue(individual);
     await expect(GrupoPage({ params: { id: "a1" } })).rejects.toThrow("NOT_FOUND");
+  });
+
+  it("llama a notFound para acceso directo desde otra comisión", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(makeAlumno("c2"));
+
+    await expect(GrupoPage({ params: { id: "a1" } })).rejects.toThrow("NOT_FOUND");
+
+    expect(mockGetGruposDeAssignment).not.toHaveBeenCalled();
+  });
+
+  it("permite acceso global al administrador", async () => {
+    mockRequireUser.mockResolvedValue(makeUser({ isAdmin: true }));
+
+    const element = await GrupoPage({ params: { id: "a1" } });
+
+    expect(renderToStaticMarkup(element)).toContain("TP Grupal");
+    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
   });
 
   it("muestra el título del assignment", async () => {

--- a/src/app/assignments/[id]/grupo/page.tsx
+++ b/src/app/assignments/[id]/grupo/page.tsx
@@ -2,6 +2,7 @@ import { notFound } from "next/navigation";
 import { requireUser } from "@/lib/session";
 import {
   getAssignment,
+  getAlumnoByGithub,
   getGruposDeAssignment,
   getEntregaDeUsuario,
 } from "@/lib/repositories";
@@ -9,6 +10,7 @@ import { GrupalAssignment } from "@/domain/entities";
 import { GrupoSelector } from "./grupo-selector";
 import { MiGrupo } from "./mi-grupo";
 import type { GrupoResumen } from "./mi-grupo";
+import { autorizarAccesoAssignment } from "@/lib/services/assignmentAuthorization";
 
 export default async function GrupoPage({
   params,
@@ -17,14 +19,24 @@ export default async function GrupoPage({
 }) {
   const user = await requireUser();
 
-  const [assignment, grupos] = await Promise.all([
+  const [assignment, alumno] = await Promise.all([
     getAssignment(params.id),
-    getGruposDeAssignment(params.id),
+    user.isAdmin
+      ? Promise.resolve(null)
+      : getAlumnoByGithub(user.githubUsername, true),
   ]);
 
   if (!assignment || !(assignment instanceof GrupalAssignment)) {
     notFound();
   }
+
+  try {
+    autorizarAccesoAssignment(user, alumno, assignment);
+  } catch {
+    notFound();
+  }
+
+  const grupos = await getGruposDeAssignment(params.id);
 
   const miGrupo = grupos.find((grupo) => grupo.contieneA(user.githubUsername));
 

--- a/src/lib/repositories/AlumnoRepository.ts
+++ b/src/lib/repositories/AlumnoRepository.ts
@@ -41,12 +41,15 @@ export async function getAlumnos(): Promise<Alumno[]> {
 }
 
 export async function getAlumnoByGithub(
-  githubUsername: string
+  githubUsername: string,
+  populateComision = false
 ): Promise<Alumno | null> {
   const entityManager = await getEM();
-  return entityManager.findOne(Alumno, {
-    githubUsername: Alumno.normalizarUsername(githubUsername),
-  });
+  return entityManager.findOne(
+    Alumno,
+    { githubUsername: Alumno.normalizarUsername(githubUsername) },
+    populateComision ? { populate: ["comision"] } : undefined
+  );
 }
 
 export async function getAlumnosByGithubUsernames(

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -43,6 +43,7 @@ import { crearGrupo, unirseAGrupo } from "./GrupoRepository";
 import {
   Grupo,
   Alumno,
+  Comision,
   GrupalAssignment,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
@@ -51,6 +52,11 @@ import {
 } from "@/domain/entities";
 import { IndividualAssignment } from "@/domain/entities/IndividualAssignment";
 import type { Collection } from "@mikro-orm/core";
+import {
+  AccesoAssignmentProhibidoError,
+  AssignmentNoEncontradoError,
+  GrupoNoEncontradoError,
+} from "@/lib/services/assignmentAuthorization";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -63,7 +69,14 @@ function fakeAlumno(id: string, githubUsername: string): Alumno {
   alumno.nombre = githubUsername;
   alumno.apellido = "Test";
   alumno.email = `${githubUsername}@test`;
+  alumno.comision = fakeComision();
   return alumno;
+}
+
+function fakeComision(id = "c1"): Comision {
+  const comision = new Comision(2026, "sheet-test");
+  comision.id = id;
+  return comision;
 }
 
 function fakeGrupal(overrides: Partial<GrupalAssignment> = {}): GrupalAssignment {
@@ -72,6 +85,7 @@ function fakeGrupal(overrides: Partial<GrupalAssignment> = {}): GrupalAssignment
   grupal.paradigma = "funcional";
   grupal.maxIntegrantes = 3;
   grupal.inscripcionesCerradas = false;
+  grupal.comision = fakeComision();
   Object.assign(grupal, overrides);
   return grupal;
 }
@@ -136,6 +150,7 @@ describe("crearGrupo", () => {
       assignmentId: "a1",
       alumnoId: "alumno-ana",
       nombre: "Los Lambdas",
+      esAdmin: false,
     });
 
     expect(grupo.nombre).toBe("Los Lambdas");
@@ -148,12 +163,12 @@ describe("crearGrupo", () => {
     expect(mockTx.flush).toHaveBeenCalled();
   });
 
-  it("lanza AssignmentNoGrupalError si el assignment no existe", async () => {
+  it("lanza AssignmentNoEncontradoError si el assignment no existe", async () => {
     mockTx.findOne.mockResolvedValueOnce(null);
 
     await expect(
-      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
-    ).rejects.toBeInstanceOf(AssignmentNoGrupalError);
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x", esAdmin: false })
+    ).rejects.toBeInstanceOf(AssignmentNoEncontradoError);
   });
 
   it("lanza AssignmentNoGrupalError si el assignment es individual", async () => {
@@ -162,15 +177,17 @@ describe("crearGrupo", () => {
     mockTx.findOne.mockResolvedValueOnce(individual);
 
     await expect(
-      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x", esAdmin: false })
     ).rejects.toBeInstanceOf(AssignmentNoGrupalError);
   });
 
   it("lanza InscripcionesCerradasError si el docente cerró las inscripciones", async () => {
+    const ana = fakeAlumno("alumno-ana", "ana");
     mockTx.findOne.mockResolvedValueOnce(fakeGrupal({ inscripcionesCerradas: true }));
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
     await expect(
-      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x", esAdmin: false })
     ).rejects.toBeInstanceOf(InscripcionesCerradasError);
   });
 
@@ -184,27 +201,89 @@ describe("crearGrupo", () => {
     mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
     await expect(
-      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x" })
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x", esAdmin: false })
     ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
     expect(mockTx.persist).not.toHaveBeenCalled();
+  });
+
+  it("rechaza dentro de la transacción a un alumno de otra comisión", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    ana.comision = fakeComision("c2");
+    mockTx.findOne.mockResolvedValueOnce(assignment);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: "x",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(AccesoAssignmentProhibidoError);
+
+    expect(mockEm.transactional).toHaveBeenCalledTimes(1);
+    expect(mockTx.persist).not.toHaveBeenCalled();
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("permite crear entre comisiones cuando el contexto es administrador", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    ana.comision = fakeComision("c2");
+    mockTx.findOne
+      .mockResolvedValueOnce(assignment)
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: "x",
+        esAdmin: true,
+      })
+    ).resolves.toBeInstanceOf(Grupo);
   });
 });
 
 // ── unirseAGrupo ────────────────────────────────────────────
 
 describe("unirseAGrupo", () => {
+  it("rechaza con 404 lógico si el grupo no pertenece al assignment de la URL", async () => {
+    mockTx.findOne.mockResolvedValueOnce(null);
+
+    await expect(
+      unirseAGrupo({
+        assignmentId: "a-otro",
+        grupoId: "g1",
+        alumnoId: "alumno-ana",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(GrupoNoEncontradoError);
+
+    expect(mockTx.findOneOrFail).not.toHaveBeenCalled();
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
   it("happy path: suma al alumno y flushea", async () => {
     const assignment = fakeGrupal();
     const ana = fakeAlumno("alumno-ana", "ana");
     const grupo = fakeGrupo("g1", assignment, []);
-    mockTx.findOneOrFail
+    mockTx.findOne
       .mockResolvedValueOnce(grupo) // Grupo
-      .mockResolvedValueOnce(ana); // Alumno
-    mockTx.findOne.mockResolvedValueOnce(null); // enOtroGrupo
+      .mockResolvedValueOnce(null); // enOtroGrupo
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana); // Alumno
 
-    const resultado = await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+    const resultado = await unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-ana", esAdmin: false });
 
     expect(resultado).toBe(grupo);
+    expect(mockTx.findOne).toHaveBeenNthCalledWith(
+      1,
+      Grupo,
+      { id: "g1", assignment: { id: "a1" } },
+      { populate: ["alumnos", "assignment.comision"] }
+    );
     expect(grupo.alumnos.contains(ana)).toBe(true);
     expect(mockTx.flush).toHaveBeenCalled();
   });
@@ -213,11 +292,10 @@ describe("unirseAGrupo", () => {
     const assignment = fakeGrupal();
     const ana = fakeAlumno("alumno-ana", "ana");
     const grupo = fakeGrupo("g1", assignment, [ana]);
-    mockTx.findOneOrFail
-      .mockResolvedValueOnce(grupo)
-      .mockResolvedValueOnce(ana);
+    mockTx.findOne.mockResolvedValueOnce(grupo);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
-    const resultado = await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+    const resultado = await unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-ana", esAdmin: false });
 
     expect(resultado).toBe(grupo);
     expect(mockTx.flush).not.toHaveBeenCalled();
@@ -225,11 +303,13 @@ describe("unirseAGrupo", () => {
 
   it("lanza InscripcionesCerradasError cuando el docente cerró el assignment", async () => {
     const assignment = fakeGrupal({ inscripcionesCerradas: true });
+    const ana = fakeAlumno("alumno-ana", "ana");
     const grupo = fakeGrupo("g1", assignment, []);
-    mockTx.findOneOrFail.mockResolvedValueOnce(grupo);
+    mockTx.findOne.mockResolvedValueOnce(grupo);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
     await expect(
-      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" })
+      unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-ana", esAdmin: false })
     ).rejects.toBeInstanceOf(InscripcionesCerradasError);
   });
 
@@ -238,13 +318,13 @@ describe("unirseAGrupo", () => {
     const ana = fakeAlumno("alumno-ana", "ana");
     const grupoDestino = fakeGrupo("g1", assignment, []);
     const grupoOtro = fakeGrupo("g-otro", assignment, [ana]);
-    mockTx.findOneOrFail
+    mockTx.findOne
       .mockResolvedValueOnce(grupoDestino)
-      .mockResolvedValueOnce(ana);
-    mockTx.findOne.mockResolvedValueOnce(grupoOtro);
+      .mockResolvedValueOnce(grupoOtro);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
     await expect(
-      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" })
+      unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-ana", esAdmin: false })
     ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
     expect(mockTx.flush).not.toHaveBeenCalled();
   });
@@ -255,13 +335,13 @@ describe("unirseAGrupo", () => {
     const bob = fakeAlumno("alumno-bob", "bob");
     const cora = fakeAlumno("alumno-cora", "cora");
     const grupoLleno = fakeGrupo("g1", assignment, [ana, bob]);
-    mockTx.findOneOrFail
+    mockTx.findOne
       .mockResolvedValueOnce(grupoLleno)
-      .mockResolvedValueOnce(cora);
-    mockTx.findOne.mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(cora);
 
     await expect(
-      unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-cora" })
+      unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-cora", esAdmin: false })
     ).rejects.toBeInstanceOf(GrupoLlenoError);
   });
 
@@ -269,13 +349,56 @@ describe("unirseAGrupo", () => {
     const assignment = fakeGrupal();
     const ana = fakeAlumno("alumno-ana", "ana");
     const grupo = fakeGrupo("g1", assignment, []);
-    mockTx.findOneOrFail
+    mockTx.findOne
       .mockResolvedValueOnce(grupo)
-      .mockResolvedValueOnce(ana);
-    mockTx.findOne.mockResolvedValueOnce(null);
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
 
-    await unirseAGrupo({ grupoId: "g1", alumnoId: "alumno-ana" });
+    await unirseAGrupo({ assignmentId: "a1", grupoId: "g1", alumnoId: "alumno-ana", esAdmin: false });
 
     expect(mockEm.transactional).toHaveBeenCalledTimes(1);
+  });
+
+  it("rechaza dentro de la transacción a un alumno de otra comisión", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    ana.comision = fakeComision("c2");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOne.mockResolvedValueOnce(grupo);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      unirseAGrupo({
+        assignmentId: "a1",
+        grupoId: "g1",
+        alumnoId: "alumno-ana",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(AccesoAssignmentProhibidoError);
+
+    expect(mockEm.transactional).toHaveBeenCalledTimes(1);
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("permite unirse entre comisiones cuando el contexto es administrador", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    ana.comision = fakeComision("c2");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOne
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      unirseAGrupo({
+        assignmentId: "a1",
+        grupoId: "g1",
+        alumnoId: "alumno-ana",
+        esAdmin: true,
+      })
+    ).resolves.toBe(grupo);
+
+    expect(mockTx.flush).toHaveBeenCalled();
   });
 });

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -9,6 +9,11 @@ import {
   AssignmentNoGrupalError,
 } from "@/domain/entities";
 import type { Paradigma } from "@/types";
+import {
+  AssignmentNoEncontradoError,
+  GrupoNoEncontradoError,
+  autorizarAccesoAssignment,
+} from "@/lib/services/assignmentAuthorization";
 
 export async function getGruposDeAlumno(
   githubUsername: string
@@ -61,20 +66,34 @@ export async function crearGrupo(params: {
   assignmentId: string;
   alumnoId: string;
   nombre: string;
+  esAdmin: boolean;
 }): Promise<Grupo> {
-  const { assignmentId, alumnoId, nombre } = params;
+  const { assignmentId, alumnoId, nombre, esAdmin } = params;
   const entityManager = await getEM();
 
   return entityManager.transactional(async (transaction) => {
-    const assignment = await transaction.findOne(Assignment, { id: assignmentId });
-    if (!assignment || !(assignment instanceof GrupalAssignment)) {
+    const assignment = await transaction.findOne(
+      Assignment,
+      { id: assignmentId },
+      { populate: ["comision"] }
+    );
+    if (!assignment) {
+      throw new AssignmentNoEncontradoError(assignmentId);
+    }
+    if (!(assignment instanceof GrupalAssignment)) {
       throw new AssignmentNoGrupalError(assignmentId);
     }
+
+    const alumno = await transaction.findOneOrFail(
+      Alumno,
+      { id: alumnoId },
+      { populate: ["comision"] }
+    );
+    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+
     if (!assignment.aceptaNuevasInscripciones()) {
       throw new InscripcionesCerradasError(assignmentId);
     }
-
-    const alumno = await transaction.findOneOrFail(Alumno, { id: alumnoId });
 
     const yaEnGrupo = await transaction.findOne(Grupo, {
       assignment: { id: assignmentId },
@@ -103,20 +122,29 @@ export async function crearGrupo(params: {
 // para resolver el race del último cupo (dos joins simultáneos al mismo
 // grupo cuando queda un solo lugar).
 export async function unirseAGrupo(params: {
+  assignmentId: string;
   grupoId: string;
   alumnoId: string;
+  esAdmin: boolean;
 }): Promise<Grupo> {
-  const { grupoId, alumnoId } = params;
+  const { assignmentId, grupoId, alumnoId, esAdmin } = params;
   const entityManager = await getEM();
 
   return entityManager.transactional(async (transaction) => {
-    const grupo = await transaction.findOneOrFail(
+    const grupo = await transaction.findOne(
       Grupo,
-      { id: grupoId },
-      { populate: ["alumnos", "assignment"] }
+      { id: grupoId, assignment: { id: assignmentId } },
+      { populate: ["alumnos", "assignment.comision"] }
     );
+    if (!grupo) throw new GrupoNoEncontradoError(assignmentId, grupoId);
+
     const assignment = grupo.assignment;
-    const alumno = await transaction.findOneOrFail(Alumno, { id: alumnoId });
+    const alumno = await transaction.findOneOrFail(
+      Alumno,
+      { id: alumnoId },
+      { populate: ["comision"] }
+    );
+    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
     if (grupo.alumnos.contains(alumno)) {
       return grupo;

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import {
   Alumno,
+  Comision,
   Entrega,
   GrupalAssignment,
   IndividualAssignment,
@@ -39,6 +40,13 @@ import {
   AlumnoNoRegistradoError,
   AssignmentNoEncontradoError,
 } from "./aceptarAssignment";
+import { AccesoAssignmentProhibidoError } from "./assignmentAuthorization";
+
+function makeComision(id = "c1"): Comision {
+  const comision = new Comision(2026, "sheet-test");
+  comision.id = id;
+  return comision;
+}
 
 function makeUser(overrides?: Partial<PdepUser>): PdepUser {
   return {
@@ -62,6 +70,7 @@ function makeAssignment(overrides?: Partial<IndividualAssignment & GrupalAssignm
   assignment.paradigma = "funcional";
   assignment.slug = "kata-funcional";
   assignment.createdAt = new Date("2026-01-01");
+  assignment.comision = makeComision();
   return Object.assign(assignment, overrides);
 }
 
@@ -73,6 +82,7 @@ function makeAlumno(overrides?: Partial<Alumno>): Alumno {
   alumno.nombre = "Juan";
   alumno.apellido = "García";
   alumno.email = "juan@example.com";
+  alumno.comision = makeComision();
   return Object.assign(alumno, overrides);
 }
 
@@ -146,10 +156,10 @@ describe("aceptarAssignment", () => {
     );
   });
 
-  it("falla si el alumno individual no existe en DB", async () => {
+  it("mantiene el requisito funcional de alumno para un admin que acepta un TP individual", async () => {
     mockGetAlumnoByGithub.mockResolvedValue(null);
 
-    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+    await expect(aceptarAssignment("a1", makeUser({ isAdmin: true }))).rejects.toBeInstanceOf(
       AlumnoNoRegistradoError
     );
 
@@ -166,7 +176,7 @@ describe("aceptarAssignment", () => {
 
     await aceptarAssignment("a1", makeUser());
 
-    expect(mockGetAlumnoByGithub).not.toHaveBeenCalled();
+    expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("juangarcia");
     expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
       expect.objectContaining({
         assignmentId: "a1",
@@ -217,5 +227,38 @@ describe("aceptarAssignment", () => {
     mockCrearEntrega.mockRejectedValue(new Error("GitHub caído"));
 
     await expect(aceptarAssignment("a1", makeUser())).rejects.toThrow("GitHub caído");
+  });
+
+  it("rechaza un alumno de otra comisión antes de consultar entregas o GitHub", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ comision: makeComision("c2") })
+    );
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AccesoAssignmentProhibidoError
+    );
+
+    expect(mockGetEntregaDeUsuario).not.toHaveBeenCalled();
+    expect(mockRepoExists).not.toHaveBeenCalled();
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+    expect(mockCreateOrGetEntrega).not.toHaveBeenCalled();
+  });
+
+  it("rechaza para alumnos un assignment histórico sin comisión", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment({ comision: undefined }));
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AccesoAssignmentProhibidoError
+    );
+  });
+
+  it("permite acceso global al administrador", async () => {
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ comision: makeComision("c2") })
+    );
+
+    await expect(
+      aceptarAssignment("a1", makeUser({ isAdmin: true }))
+    ).resolves.toBeInstanceOf(Entrega);
   });
 });

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -9,13 +9,12 @@ import {
 } from "@/lib/repositories";
 import { addCollaborators, crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
+import {
+  AssignmentNoEncontradoError,
+  autorizarAccesoAssignment,
+} from "./assignmentAuthorization";
 
-export class AssignmentNoEncontradoError extends Error {
-  constructor(public readonly assignmentId: string) {
-    super("Assignment no encontrado");
-    this.name = "AssignmentNoEncontradoError";
-  }
-}
+export { AssignmentNoEncontradoError } from "./assignmentAuthorization";
 
 export class AlumnoNoRegistradoError extends Error {
   constructor(public readonly githubUsername: string) {
@@ -33,8 +32,12 @@ export async function aceptarAssignment(
   assignmentId: string,
   user: PdepUser
 ): Promise<Entrega> {
-  const assignment = await getAssignment(assignmentId);
+  const [assignment, alumno] = await Promise.all([
+    getAssignment(assignmentId),
+    getAlumnoByGithub(user.githubUsername, true),
+  ]);
   if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
+  autorizarAccesoAssignment(user, alumno, assignment);
 
   const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
   if (existente) return existente;
@@ -45,7 +48,6 @@ export async function aceptarAssignment(
   );
 
   const { usernames, grupoId } = participantes;
-  const alumno = grupoId ? null : await getAlumnoByGithub(user.githubUsername);
   if (!grupoId && !alumno) throw new AlumnoNoRegistradoError(user.githubUsername);
 
   const repoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
@@ -55,7 +57,7 @@ export async function aceptarAssignment(
       repoName: createdRepoName,
       repoUrl,
       githubUsernames: usernames,
-      alumnoId: alumno?.id,
+      alumnoId: grupoId ? undefined : alumno?.id,
       grupoId,
     });
 

--- a/src/lib/services/assignmentAuthorization.test.ts
+++ b/src/lib/services/assignmentAuthorization.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import {
+  AccesoAssignmentProhibidoError,
+  autorizarAccesoAssignment,
+} from "./assignmentAuthorization";
+
+function makeAssignment(comisionId: string | null = "c1") {
+  return {
+    id: "a1",
+    comision: comisionId ? { id: comisionId } : undefined,
+  } as never;
+}
+
+function makeAlumno(comisionId = "c1") {
+  return {
+    id: "alumno-1",
+    comision: { id: comisionId },
+  } as never;
+}
+
+describe("autorizarAccesoAssignment", () => {
+  it("permite al alumno de la misma comisión", () => {
+    expect(() =>
+      autorizarAccesoAssignment(
+        { isAdmin: false },
+        makeAlumno("c1"),
+        makeAssignment("c1")
+      )
+    ).not.toThrow();
+  });
+
+  it("rechaza al alumno de otra comisión", () => {
+    expect(() =>
+      autorizarAccesoAssignment(
+        { isAdmin: false },
+        makeAlumno("c2"),
+        makeAssignment("c1")
+      )
+    ).toThrow(AccesoAssignmentProhibidoError);
+  });
+
+  it("rechaza usuarios comunes sin alumno registrado", () => {
+    expect(() =>
+      autorizarAccesoAssignment(
+        { isAdmin: false },
+        null,
+        makeAssignment("c1")
+      )
+    ).toThrow(AccesoAssignmentProhibidoError);
+  });
+
+  it("rechaza para alumnos los assignments históricos sin comisión", () => {
+    expect(() =>
+      autorizarAccesoAssignment(
+        { isAdmin: false },
+        makeAlumno("c1"),
+        makeAssignment(null)
+      )
+    ).toThrow(AccesoAssignmentProhibidoError);
+  });
+
+  it("permite acceso global a administradores", () => {
+    expect(() =>
+      autorizarAccesoAssignment(
+        { isAdmin: true },
+        null,
+        makeAssignment(null)
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/lib/services/assignmentAuthorization.ts
+++ b/src/lib/services/assignmentAuthorization.ts
@@ -1,0 +1,47 @@
+import type { Alumno, Assignment } from "@/domain/entities";
+
+export class AssignmentNoEncontradoError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Assignment no encontrado");
+    this.name = "AssignmentNoEncontradoError";
+  }
+}
+
+export class AccesoAssignmentProhibidoError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("No tenés acceso a este assignment");
+    this.name = "AccesoAssignmentProhibidoError";
+  }
+}
+
+export class GrupoNoEncontradoError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly grupoId: string
+  ) {
+    super("Grupo no encontrado");
+    this.name = "GrupoNoEncontradoError";
+  }
+}
+
+/**
+ * Política única de acceso académico a un assignment.
+ *
+ * Los administradores tienen alcance global. Para el resto, tanto el alumno
+ * como el assignment deben tener una comisión y ambas deben coincidir.
+ */
+export function autorizarAccesoAssignment(
+  user: { isAdmin: boolean },
+  alumno: Alumno | null,
+  assignment: Assignment
+): void {
+  if (user.isAdmin) return;
+
+  if (
+    !alumno ||
+    !assignment.comision ||
+    alumno.comision?.id !== assignment.comision.id
+  ) {
+    throw new AccesoAssignmentProhibidoError(assignment.id);
+  }
+}


### PR DESCRIPTION
## Resumen
- centraliza la autorización académica por comisión, con acceso global para administradores
- restringe el listado y la aceptación de assignments antes de consultar entregas o llamar a GitHub
- protege lectura, creación y unión a grupos, validando `assignmentId + grupoId` dentro de las transacciones
- normaliza respuestas 401, 403 y 404, y oculta accesos directos a páginas de otra comisión

## Validación
- `pnpm test:run` — 79 archivos, 965 tests OK
- `pnpm build` — OK
- `pnpm exec tsc --noEmit` — OK
- `git diff --check` — OK
- `pnpm lint` — no ejecutable de forma no interactiva porque Next abre el asistente al no existir configuración de ESLint; no generó cambios

Closes #47