### PR TITLE
Garantizar inscripción única y cupos de grupos bajo concurrencia

### DIFF
--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -1141,6 +1141,18 @@
           "keyName": "grupo_id_assignment_unique",
           "unique": true,
           "primary": false
+        },
+        {
+          "columnNames": [
+            "assignment_id",
+            "nombre",
+            "paradigma"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "grupo_assignment_nombre_paradigma_unique_idx",
+          "unique": true,
+          "primary": false
         }
       ],
       "checks": [],

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -1130,6 +1130,17 @@
           "keyName": "grupo_pkey",
           "unique": true,
           "primary": true
+        },
+        {
+          "columnNames": [
+            "id",
+            "assignment_id"
+          ],
+          "composite": true,
+          "constraint": true,
+          "keyName": "grupo_id_assignment_unique",
+          "unique": true,
+          "primary": false
         }
       ],
       "checks": [],
@@ -1184,6 +1195,22 @@
           "comment": null,
           "enumItems": [],
           "mappedType": "uuid"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
         }
       },
       "name": "grupo_alumnos",
@@ -1199,6 +1226,17 @@
           "keyName": "grupo_alumnos_pkey",
           "unique": true,
           "primary": true
+        },
+        {
+          "columnNames": [
+            "assignment_id",
+            "alumno_id"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "grupo_alumnos_assignment_alumno_unique_idx",
+          "unique": true,
+          "primary": false
         }
       ],
       "checks": [],
@@ -1225,6 +1263,21 @@
           "referencedTableName": "public.grupo",
           "referencedColumnNames": [
             "id"
+          ],
+          "updateRule": "cascade",
+          "deleteRule": "cascade"
+        },
+        "grupo_alumnos_grupo_assignment_foreign": {
+          "columnNames": [
+            "grupo_id",
+            "assignment_id"
+          ],
+          "constraintName": "grupo_alumnos_grupo_assignment_foreign",
+          "localTableName": "public.grupo_alumnos",
+          "referencedTableName": "public.grupo",
+          "referencedColumnNames": [
+            "id",
+            "assignment_id"
           ],
           "updateRule": "cascade",
           "deleteRule": "cascade"

--- a/migrations/Migration20260813190000_group_membership_invariants.ts
+++ b/migrations/Migration20260813190000_group_membership_invariants.ts
@@ -1,0 +1,69 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260813190000_group_membership_invariants extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      do $$
+      begin
+        if exists (
+          select 1
+          from "grupo_alumnos" ga
+          join "grupo" g on g."id" = ga."grupo_id"
+          group by g."assignment_id", ga."alumno_id"
+          having count(*) > 1
+        ) then
+          raise exception 'No se puede garantizar una unica inscripcion por assignment: hay alumnos en mas de un grupo del mismo assignment.';
+        end if;
+
+        if exists (
+          select 1
+          from "grupo" g
+          join "grupo_alumnos" ga on ga."grupo_id" = g."id"
+          group by g."id", g."max_integrantes"
+          having count(*) > g."max_integrantes"
+        ) then
+          raise exception 'No se pueden garantizar los cupos: hay grupos con mas alumnos que max_integrantes.';
+        end if;
+      end $$;
+    `);
+
+    this.addSql(`alter table "grupo_alumnos" add column "assignment_id" uuid null;`);
+    this.addSql(`
+      update "grupo_alumnos" ga
+      set "assignment_id" = g."assignment_id"
+      from "grupo" g
+      where g."id" = ga."grupo_id";
+    `);
+    this.addSql(`alter table "grupo_alumnos" alter column "assignment_id" set not null;`);
+
+    this.addSql(`alter table "grupo" add constraint "grupo_id_assignment_unique" unique ("id", "assignment_id");`);
+    this.addSql(`alter table "grupo_alumnos" add constraint "grupo_alumnos_grupo_assignment_foreign" foreign key ("grupo_id", "assignment_id") references "grupo" ("id", "assignment_id") on update cascade on delete cascade;`);
+    this.addSql(`create unique index "grupo_alumnos_assignment_alumno_unique_idx" on "grupo_alumnos" ("assignment_id", "alumno_id");`);
+
+    this.addSql(`
+      create function "completar_assignment_grupo_alumnos"() returns trigger as $$
+      begin
+        select "assignment_id"
+          into new."assignment_id"
+          from "grupo"
+         where "id" = new."grupo_id";
+        return new;
+      end;
+      $$ language plpgsql;
+    `);
+    this.addSql(`
+      create trigger "grupo_alumnos_completar_assignment"
+      before insert or update of "grupo_id" on "grupo_alumnos"
+      for each row execute function "completar_assignment_grupo_alumnos"();
+    `);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop trigger if exists "grupo_alumnos_completar_assignment" on "grupo_alumnos";`);
+    this.addSql(`drop function if exists "completar_assignment_grupo_alumnos"();`);
+    this.addSql(`drop index if exists "grupo_alumnos_assignment_alumno_unique_idx";`);
+    this.addSql(`alter table "grupo_alumnos" drop constraint if exists "grupo_alumnos_grupo_assignment_foreign";`);
+    this.addSql(`alter table "grupo" drop constraint if exists "grupo_id_assignment_unique";`);
+    this.addSql(`alter table "grupo_alumnos" drop column "assignment_id";`);
+  }
+}

--- a/migrations/Migration20260813190000_group_membership_invariants.ts
+++ b/migrations/Migration20260813190000_group_membership_invariants.ts
@@ -24,6 +24,15 @@ export class Migration20260813190000_group_membership_invariants extends Migrati
         ) then
           raise exception 'No se pueden garantizar los cupos: hay grupos con mas alumnos que max_integrantes.';
         end if;
+
+        if exists (
+          select 1
+          from "grupo"
+          group by "assignment_id", "nombre", "paradigma"
+          having count(*) > 1
+        ) then
+          raise exception 'No se puede garantizar la unicidad de grupos: hay nombres y paradigmas duplicados dentro de un assignment.';
+        end if;
       end $$;
     `);
 
@@ -37,6 +46,7 @@ export class Migration20260813190000_group_membership_invariants extends Migrati
     this.addSql(`alter table "grupo_alumnos" alter column "assignment_id" set not null;`);
 
     this.addSql(`alter table "grupo" add constraint "grupo_id_assignment_unique" unique ("id", "assignment_id");`);
+    this.addSql(`alter table "grupo" add constraint "grupo_assignment_nombre_paradigma_unique_idx" unique ("assignment_id", "nombre", "paradigma");`);
     this.addSql(`alter table "grupo_alumnos" add constraint "grupo_alumnos_grupo_assignment_foreign" foreign key ("grupo_id", "assignment_id") references "grupo" ("id", "assignment_id") on update cascade on delete cascade;`);
     this.addSql(`create unique index "grupo_alumnos_assignment_alumno_unique_idx" on "grupo_alumnos" ("assignment_id", "alumno_id");`);
 
@@ -63,6 +73,7 @@ export class Migration20260813190000_group_membership_invariants extends Migrati
     this.addSql(`drop function if exists "completar_assignment_grupo_alumnos"();`);
     this.addSql(`drop index if exists "grupo_alumnos_assignment_alumno_unique_idx";`);
     this.addSql(`alter table "grupo_alumnos" drop constraint if exists "grupo_alumnos_grupo_assignment_foreign";`);
+    this.addSql(`alter table "grupo" drop constraint if exists "grupo_assignment_nombre_paradigma_unique_idx";`);
     this.addSql(`alter table "grupo" drop constraint if exists "grupo_id_assignment_unique";`);
     this.addSql(`alter table "grupo_alumnos" drop column "assignment_id";`);
   }

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -40,6 +40,13 @@ export default defineConfig({
     glob: "!(*.d).{js,ts}",
   },
 
+  // `grupo_alumnos` incluye assignment_id, un índice único y una FK compuesta
+  // mantenidos por una migración manual. La relación sigue disponible para el
+  // runtime, pero el schema diff no debe intentar simplificar ese pivot.
+  schemaGenerator: {
+    skipTables: ["grupo_alumnos"],
+  },
+
   // Debugging (solo en dev)
   debug: process.env.NODE_ENV === "development",
 });

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -8,6 +8,7 @@ import {
   AssignmentNoGrupalError,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
+  NombreGrupoDuplicadoError,
 } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -217,6 +218,20 @@ describe("POST /api/assignments/[id]/grupos", () => {
     mockCrearGrupo.mockRejectedValue(new AlumnoYaEnGrupoDelAssignmentError("a1", "ana"));
     const response = await POST(makeRequest({ nombre: "x" }), { params: Promise.resolve({ id: "a1" }) });
     expect(response.status).toBe(409);
+  });
+
+  it("devuelve 409 si ya existe un grupo con el mismo nombre", async () => {
+    mockCrearGrupo.mockRejectedValue(
+      new NombreGrupoDuplicadoError("a1", "Los Lambdas")
+    );
+    const response = await POST(makeRequest({ nombre: "Los Lambdas" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+
+    expect(response.status).toBe(409);
+    await expect(response.json()).resolves.toEqual({
+      error: 'Ya existe un grupo llamado "Los Lambdas" para este TP.',
+    });
   });
 
   it("devuelve 500 para errores inesperados", async () => {

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -11,6 +11,7 @@ import {
   AssignmentNoGrupalError,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
+  NombreGrupoDuplicadoError,
 } from "@/domain/entities";
 import { internalServerError } from "@/lib/api-errors";
 import type { Grupo } from "@/domain/entities";
@@ -124,6 +125,9 @@ export async function POST(req: Request, props: { params: Promise<{ id: string }
         { error: "Ya estás en un grupo para este TP" },
         { status: 409 }
       );
+    }
+    if (error instanceof NombreGrupoDuplicadoError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
     }
     return internalServerError("POST /api/assignments/[id]/grupos", error, {
       assignmentId: params.id,

--- a/src/domain/entities/Grupo.ts
+++ b/src/domain/entities/Grupo.ts
@@ -6,6 +6,7 @@ import {
   ManyToOne,
   PrimaryKey,
   Property,
+  Unique,
 } from "@mikro-orm/core";
 import { randomUUID } from "crypto";
 import { Alumno } from "./Alumno";
@@ -33,6 +34,16 @@ export class AlumnoYaEnGrupoDelAssignmentError extends Error {
   }
 }
 
+export class NombreGrupoDuplicadoError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly nombre: string
+  ) {
+    super(`Ya existe un grupo llamado "${nombre}" para este TP.`);
+    this.name = "NombreGrupoDuplicadoError";
+  }
+}
+
 export class GrupoLlenoError extends Error {
   constructor(
     public readonly grupoId: string,
@@ -51,6 +62,14 @@ export class AssignmentNoGrupalError extends Error {
 }
 
 @Entity()
+@Unique({
+  name: "grupo_id_assignment_unique",
+  properties: ["id", "assignment"],
+})
+@Unique({
+  name: "grupo_assignment_nombre_paradigma_unique_idx",
+  properties: ["assignment", "nombre", "paradigma"],
+})
 export class Grupo {
   @PrimaryKey({ type: "uuid" })
   id: string = randomUUID();
@@ -61,7 +80,7 @@ export class Grupo {
   @Enum({ items: ["funcional", "logico", "objetos"] })
   paradigma!: Paradigma;
 
-  @ManyToMany(() => Alumno)
+  @ManyToMany({ entity: () => Alumno, pivotTable: "grupo_alumnos" })
   alumnos = new Collection<Alumno>(this);
 
   @Property({ type: 'integer' })

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -19,6 +19,7 @@ export {
   Grupo,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
+  NombreGrupoDuplicadoError,
   GrupoLlenoError,
   AssignmentNoGrupalError,
 } from "./Grupo";

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 type SnapshotTable = {
   name: string;
   columns: Record<string, { default?: string; nullable?: boolean }>;
+  indexes: Array<{ keyName: string }>;
   foreignKeys: Record<string, { deleteRule?: string }>;
 };
 
@@ -65,6 +66,29 @@ describe("migrations", () => {
     expect(migration).toContain('"google_group_ultimo_error"');
   });
 
+  it("garantiza membresía única por assignment y prepara el locking de cupos", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260813190000_group_membership_invariants.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain(
+      'create unique index "grupo_alumnos_assignment_alumno_unique_idx"'
+    );
+    expect(migration).toContain(
+      'constraint "grupo_alumnos_grupo_assignment_foreign"'
+    );
+    expect(migration).toContain(
+      'create trigger "grupo_alumnos_completar_assignment"'
+    );
+    expect(migration).toContain("hay alumnos en mas de un grupo");
+    expect(migration).toContain("hay grupos con mas alumnos");
+  });
+
   it("mantiene el snapshot alineado con Google Groups y las cascadas", () => {
     const snapshot = JSON.parse(
       readFileSync(
@@ -75,6 +99,10 @@ describe("migrations", () => {
     const alumno = snapshot.tables.find((table) => table.name === "alumno");
     const assignment = snapshot.tables.find(
       (table) => table.name === "assignment"
+    );
+    const grupo = snapshot.tables.find((table) => table.name === "grupo");
+    const grupoAlumnos = snapshot.tables.find(
+      (table) => table.name === "grupo_alumnos"
     );
 
     expect(alumno?.columns.google_group_emails_pendientes_baja).toMatchObject({
@@ -92,5 +120,17 @@ describe("migrations", () => {
     expect(
       assignment?.foreignKeys.assignment_comision_id_foreign.deleteRule
     ).toBe("cascade");
+    expect(grupo?.indexes).toContainEqual(
+      expect.objectContaining({ keyName: "grupo_id_assignment_unique" })
+    );
+    expect(grupoAlumnos?.columns).toHaveProperty("assignment_id");
+    expect(grupoAlumnos?.indexes).toContainEqual(
+      expect.objectContaining({
+        keyName: "grupo_alumnos_assignment_alumno_unique_idx",
+      })
+    );
+    expect(grupoAlumnos?.foreignKeys).toHaveProperty(
+      "grupo_alumnos_grupo_assignment_foreign"
+    );
   });
 });

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -80,6 +80,9 @@ describe("migrations", () => {
       'create unique index "grupo_alumnos_assignment_alumno_unique_idx"'
     );
     expect(migration).toContain(
+      'constraint "grupo_assignment_nombre_paradigma_unique_idx" unique ("assignment_id", "nombre", "paradigma")'
+    );
+    expect(migration).toContain(
       'constraint "grupo_alumnos_grupo_assignment_foreign"'
     );
     expect(migration).toContain(
@@ -87,6 +90,7 @@ describe("migrations", () => {
     );
     expect(migration).toContain("hay alumnos en mas de un grupo");
     expect(migration).toContain("hay grupos con mas alumnos");
+    expect(migration).toContain("hay nombres y paradigmas duplicados");
   });
 
   it("mantiene el snapshot alineado con Google Groups y las cascadas", () => {
@@ -122,6 +126,11 @@ describe("migrations", () => {
     ).toBe("cascade");
     expect(grupo?.indexes).toContainEqual(
       expect.objectContaining({ keyName: "grupo_id_assignment_unique" })
+    );
+    expect(grupo?.indexes).toContainEqual(
+      expect.objectContaining({
+        keyName: "grupo_assignment_nombre_paradigma_unique_idx",
+      })
     );
     expect(grupoAlumnos?.columns).toHaveProperty("assignment_id");
     expect(grupoAlumnos?.indexes).toContainEqual(

--- a/src/lib/orm.test.ts
+++ b/src/lib/orm.test.ts
@@ -46,4 +46,27 @@ describe("ORM metadata", () => {
 
     await orm.close(true);
   });
+
+  it("preserva el pivot de grupos administrado por migraciones", async () => {
+    const orm = await MikroORM.init({ ...testConfig, connect: false });
+    const meta = orm.getMetadata();
+    const grupo = meta.get("Grupo");
+
+    expect(grupo.properties.alumnos.pivotTable).toBe("grupo_alumnos");
+    expect(grupo.uniques).toContainEqual(
+      expect.objectContaining({
+        name: "grupo_id_assignment_unique",
+        properties: ["id", "assignment"],
+      })
+    );
+    expect(grupo.uniques).toContainEqual(
+      expect.objectContaining({
+        name: "grupo_assignment_nombre_paradigma_unique_idx",
+        properties: ["assignment", "nombre", "paradigma"],
+      })
+    );
+    expect(config.schemaGenerator?.skipTables).toContain("grupo_alumnos");
+
+    await orm.close(true);
+  });
 });

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -46,6 +46,7 @@ import {
   unirseAGrupo,
   upsertGrupoConMiembro,
 } from "./GrupoRepository";
+import { getEM } from "@/lib/db";
 import {
   Grupo,
   Alumno,
@@ -53,6 +54,7 @@ import {
   GrupalAssignment,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
+  NombreGrupoDuplicadoError,
   GrupoLlenoError,
   AssignmentNoGrupalError,
 } from "@/domain/entities";
@@ -124,6 +126,15 @@ function uniqueMembershipError(): Error {
   return Object.assign(
     new Error(
       'duplicate key value violates unique constraint "grupo_alumnos_assignment_alumno_unique_idx"'
+    ),
+    { code: "23505" }
+  );
+}
+
+function uniqueGroupNameError(): Error {
+  return Object.assign(
+    new Error(
+      'duplicate key value violates unique constraint "grupo_assignment_nombre_paradigma_unique_idx"'
     ),
     { code: "23505" }
   );
@@ -277,7 +288,34 @@ describe("crearGrupo", () => {
         nombre: "Los Lambdas",
         esAdmin: false,
       })
-    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+    ).rejects.toMatchObject({
+      constructor: AlumnoYaEnGrupoDelAssignmentError,
+      assignmentId: "a1",
+      githubUsername: "ana",
+    });
+  });
+
+  it("traduce el conflicto concurrente por nombre de grupo duplicado", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    mockTx.findOne
+      .mockResolvedValueOnce(assignment)
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+    mockTx.flush.mockRejectedValueOnce(uniqueGroupNameError());
+
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: "Los Lambdas",
+        esAdmin: false,
+      })
+    ).rejects.toMatchObject({
+      constructor: NombreGrupoDuplicadoError,
+      assignmentId: "a1",
+      nombre: "Los Lambdas",
+    });
   });
 });
 
@@ -458,7 +496,11 @@ describe("unirseAGrupo", () => {
         alumnoId: "alumno-ana",
         esAdmin: false,
       })
-    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+    ).rejects.toMatchObject({
+      constructor: AlumnoYaEnGrupoDelAssignmentError,
+      assignmentId: "a1",
+      githubUsername: "ana",
+    });
   });
 });
 
@@ -554,5 +596,58 @@ describe("upsertGrupoConMiembro", () => {
         alumno: ana,
       })
     ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+  });
+
+  it("reintenta con un EM nuevo si otra transacción crea el mismo grupo", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const ganador = fakeGrupo("g-ganador", assignment, []);
+    ganador.nombre = "Los Lambdas";
+    mockTx.findOne
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(ganador)
+      .mockResolvedValueOnce(null);
+    mockTx.flush.mockRejectedValueOnce(uniqueGroupNameError());
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: "Los Lambdas",
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).resolves.toBe(ganador);
+
+    expect(getEM).toHaveBeenCalledTimes(2);
+    expect(mockEm.transactional).toHaveBeenCalledTimes(2);
+    expect(mockTx.populate).toHaveBeenCalledWith(
+      ganador,
+      ["alumnos"],
+      { refresh: true }
+    );
+    expect(ganador.alumnos.contains(ana)).toBe(true);
+  });
+
+  it("devuelve un conflicto explícito si el reintento también colisiona", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    mockTx.findOne.mockResolvedValue(null);
+    mockTx.flush.mockRejectedValue(uniqueGroupNameError());
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: "Los Lambdas",
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toMatchObject({
+      constructor: NombreGrupoDuplicadoError,
+      assignmentId: "a1",
+      nombre: "Los Lambdas",
+    });
+
+    expect(getEM).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -17,6 +17,7 @@ import config from "../../../mikro-orm.config";
 type MockTx = {
   findOne: ReturnType<typeof vi.fn>;
   findOneOrFail: ReturnType<typeof vi.fn>;
+  populate: ReturnType<typeof vi.fn>;
   persist: ReturnType<typeof vi.fn>;
   flush: ReturnType<typeof vi.fn>;
 };
@@ -24,6 +25,7 @@ type MockTx = {
 const mockTx: MockTx = {
   findOne: vi.fn(),
   findOneOrFail: vi.fn(),
+  populate: vi.fn(),
   persist: vi.fn(),
   flush: vi.fn(),
 };
@@ -39,7 +41,11 @@ vi.mock("@/lib/db", () => ({
 
 // ── Imports después del mock ─────────────────────────────────
 
-import { crearGrupo, unirseAGrupo } from "./GrupoRepository";
+import {
+  crearGrupo,
+  unirseAGrupo,
+  upsertGrupoConMiembro,
+} from "./GrupoRepository";
 import {
   Grupo,
   Alumno,
@@ -51,7 +57,7 @@ import {
   AssignmentNoGrupalError,
 } from "@/domain/entities";
 import { IndividualAssignment } from "@/domain/entities/IndividualAssignment";
-import type { Collection } from "@mikro-orm/core";
+import { LockMode, type Collection } from "@mikro-orm/core";
 import {
   AccesoAssignmentProhibidoError,
   AssignmentNoEncontradoError,
@@ -112,6 +118,15 @@ function fakeGrupo(
     },
   } as unknown as Collection<Alumno>;
   return grupo;
+}
+
+function uniqueMembershipError(): Error {
+  return Object.assign(
+    new Error(
+      'duplicate key value violates unique constraint "grupo_alumnos_assignment_alumno_unique_idx"'
+    ),
+    { code: "23505" }
+  );
 }
 
 let orm: MikroORM;
@@ -245,6 +260,25 @@ describe("crearGrupo", () => {
       })
     ).resolves.toBeInstanceOf(Grupo);
   });
+
+  it("traduce el conflicto concurrente de inscripción única", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    mockTx.findOne
+      .mockResolvedValueOnce(assignment)
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+    mockTx.flush.mockRejectedValueOnce(uniqueMembershipError());
+
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: "Los Lambdas",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+  });
 });
 
 // ── unirseAGrupo ────────────────────────────────────────────
@@ -282,7 +316,12 @@ describe("unirseAGrupo", () => {
       1,
       Grupo,
       { id: "g1", assignment: { id: "a1" } },
-      { populate: ["alumnos", "assignment.comision"] }
+      { lockMode: LockMode.PESSIMISTIC_WRITE }
+    );
+    expect(mockTx.populate).toHaveBeenCalledWith(
+      grupo,
+      ["alumnos", "assignment.comision"],
+      { refresh: true }
     );
     expect(grupo.alumnos.contains(ana)).toBe(true);
     expect(mockTx.flush).toHaveBeenCalled();
@@ -400,5 +439,120 @@ describe("unirseAGrupo", () => {
     ).resolves.toBe(grupo);
 
     expect(mockTx.flush).toHaveBeenCalled();
+  });
+
+  it("traduce el conflicto concurrente al unirse a dos grupos", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOne
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(null);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+    mockTx.flush.mockRejectedValueOnce(uniqueMembershipError());
+
+    await expect(
+      unirseAGrupo({
+        assignmentId: "a1",
+        grupoId: "g1",
+        alumnoId: "alumno-ana",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+  });
+});
+
+describe("upsertGrupoConMiembro", () => {
+  it("bloquea el grupo, valida las invariantes y agrega al alumno", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOne
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(null);
+
+    const result = await upsertGrupoConMiembro({
+      nombreGrupo: grupo.nombre,
+      paradigma: "funcional",
+      assignment,
+      alumno: ana,
+    });
+
+    expect(result).toBe(grupo);
+    expect(mockTx.findOne).toHaveBeenNthCalledWith(
+      1,
+      Grupo,
+      {
+        nombre: grupo.nombre,
+        paradigma: "funcional",
+        assignment: { id: "a1" },
+      },
+      { lockMode: LockMode.PESSIMISTIC_WRITE }
+    );
+    expect(mockTx.populate).toHaveBeenCalledWith(
+      grupo,
+      ["alumnos"],
+      { refresh: true }
+    );
+    expect(grupo.alumnos.contains(ana)).toBe(true);
+    expect(mockTx.flush).toHaveBeenCalled();
+  });
+
+  it("rechaza un alumno que ya pertenece a otro grupo del assignment", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const destino = fakeGrupo("g1", assignment, []);
+    const otro = fakeGrupo("g2", assignment, [ana]);
+    mockTx.findOne
+      .mockResolvedValueOnce(destino)
+      .mockResolvedValueOnce(otro);
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: destino.nombre,
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("respeta el cupo del grupo al sincronizar desde Sheets", async () => {
+    const assignment = fakeGrupal({ maxIntegrantes: 1 });
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const bob = fakeAlumno("alumno-bob", "bob");
+    const lleno = fakeGrupo("g1", assignment, [bob], 1);
+    mockTx.findOne
+      .mockResolvedValueOnce(lleno)
+      .mockResolvedValueOnce(null);
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: lleno.nombre,
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toBeInstanceOf(GrupoLlenoError);
+  });
+
+  it("traduce la restricción única si otra transacción gana la carrera", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", assignment, []);
+    mockTx.findOne
+      .mockResolvedValueOnce(grupo)
+      .mockResolvedValueOnce(null);
+    mockTx.flush.mockRejectedValueOnce(uniqueMembershipError());
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: grupo.nombre,
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toBeInstanceOf(AlumnoYaEnGrupoDelAssignmentError);
   });
 });

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -1,4 +1,5 @@
 import { getEM } from "@/lib/db";
+import { LockMode } from "@mikro-orm/core";
 import {
   Grupo,
   Alumno,
@@ -14,6 +15,39 @@ import {
   GrupoNoEncontradoError,
   autorizarAccesoAssignment,
 } from "@/lib/services/assignmentAuthorization";
+import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
+
+const INSCRIPCION_UNICA_CONSTRAINT =
+  "grupo_alumnos_assignment_alumno_unique_idx";
+
+function esViolacionDeInscripcionUnica(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const message = `${error.message} ${
+    error.cause instanceof Error ? error.cause.message : ""
+  }`;
+  return (
+    extractDbErrorCode(error) === UNIQUE_VIOLATION &&
+    message.includes(INSCRIPCION_UNICA_CONSTRAINT)
+  );
+}
+
+async function traducirConflictoDeInscripcion<T>(
+  assignmentId: string,
+  githubUsername: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (esViolacionDeInscripcionUnica(error)) {
+      throw new AlumnoYaEnGrupoDelAssignmentError(
+        assignmentId,
+        githubUsername
+      );
+    }
+    throw error;
+  }
+}
 
 export async function getGruposDeAlumno(
   githubUsername: string
@@ -71,50 +105,58 @@ export async function crearGrupo(params: {
   const { assignmentId, alumnoId, nombre, esAdmin } = params;
   const entityManager = await getEM();
 
-  return entityManager.transactional(async (transaction) => {
-    const assignment = await transaction.findOne(
-      Assignment,
-      { id: assignmentId },
-      { populate: ["comision"] }
-    );
-    if (!assignment) {
-      throw new AssignmentNoEncontradoError(assignmentId);
-    }
-    if (!(assignment instanceof GrupalAssignment)) {
-      throw new AssignmentNoGrupalError(assignmentId);
-    }
+  return traducirConflictoDeInscripcion(
+    assignmentId,
+    alumnoId,
+    () =>
+      entityManager.transactional(async (transaction) => {
+        const assignment = await transaction.findOne(
+          Assignment,
+          { id: assignmentId },
+          { populate: ["comision"] }
+        );
+        if (!assignment) {
+          throw new AssignmentNoEncontradoError(assignmentId);
+        }
+        if (!(assignment instanceof GrupalAssignment)) {
+          throw new AssignmentNoGrupalError(assignmentId);
+        }
 
-    const alumno = await transaction.findOneOrFail(
-      Alumno,
-      { id: alumnoId },
-      { populate: ["comision"] }
-    );
-    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+        const alumno = await transaction.findOneOrFail(
+          Alumno,
+          { id: alumnoId },
+          { populate: ["comision"] }
+        );
+        autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
-    if (!assignment.aceptaNuevasInscripciones()) {
-      throw new InscripcionesCerradasError(assignmentId);
-    }
+        if (!assignment.aceptaNuevasInscripciones()) {
+          throw new InscripcionesCerradasError(assignmentId);
+        }
 
-    const yaEnGrupo = await transaction.findOne(Grupo, {
-      assignment: { id: assignmentId },
-      alumnos: { id: alumno.id },
-    });
-    if (yaEnGrupo) {
-      throw new AlumnoYaEnGrupoDelAssignmentError(assignmentId, alumno.githubUsername);
-    }
+        const yaEnGrupo = await transaction.findOne(Grupo, {
+          assignment: { id: assignmentId },
+          alumnos: { id: alumno.id },
+        });
+        if (yaEnGrupo) {
+          throw new AlumnoYaEnGrupoDelAssignmentError(
+            assignmentId,
+            alumno.githubUsername
+          );
+        }
 
-    const grupo = new Grupo();
-    grupo.nombre = nombre;
-    grupo.paradigma = assignment.paradigma;
-    grupo.assignment = assignment;
-    grupo.maxIntegrantes = assignment.maxIntegrantes;
-    grupo.creadoPor = alumno.githubUsername;
-    grupo.alumnos.add(alumno);
-    transaction.persist(grupo);
+        const grupo = new Grupo();
+        grupo.nombre = nombre;
+        grupo.paradigma = assignment.paradigma;
+        grupo.assignment = assignment;
+        grupo.maxIntegrantes = assignment.maxIntegrantes;
+        grupo.creadoPor = alumno.githubUsername;
+        grupo.alumnos.add(alumno);
+        transaction.persist(grupo);
 
-    await transaction.flush();
-    return grupo;
-  });
+        await transaction.flush();
+        return grupo;
+      })
+  );
 }
 
 // Suma al alumno como miembro de un grupo existente. Atómico: re-checa cupo
@@ -130,46 +172,60 @@ export async function unirseAGrupo(params: {
   const { assignmentId, grupoId, alumnoId, esAdmin } = params;
   const entityManager = await getEM();
 
-  return entityManager.transactional(async (transaction) => {
-    const grupo = await transaction.findOne(
-      Grupo,
-      { id: grupoId, assignment: { id: assignmentId } },
-      { populate: ["alumnos", "assignment.comision"] }
-    );
-    if (!grupo) throw new GrupoNoEncontradoError(assignmentId, grupoId);
+  return traducirConflictoDeInscripcion(
+    assignmentId,
+    alumnoId,
+    () =>
+      entityManager.transactional(async (transaction) => {
+        const grupo = await transaction.findOne(
+          Grupo,
+          { id: grupoId, assignment: { id: assignmentId } },
+          { lockMode: LockMode.PESSIMISTIC_WRITE }
+        );
+        if (!grupo) throw new GrupoNoEncontradoError(assignmentId, grupoId);
 
-    const assignment = grupo.assignment;
-    const alumno = await transaction.findOneOrFail(
-      Alumno,
-      { id: alumnoId },
-      { populate: ["comision"] }
-    );
-    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+        // El lock se toma antes de leer la colección. Cuando dos requests compiten
+        // por el último cupo, el segundo carga los miembros recién confirmados por
+        // el primero y vuelve a evaluar el límite con el estado vigente.
+        await transaction.populate(
+          grupo,
+          ["alumnos", "assignment.comision"],
+          { refresh: true }
+        );
 
-    if (grupo.alumnos.contains(alumno)) {
-      return grupo;
-    }
+        const assignment = grupo.assignment;
+        const alumno = await transaction.findOneOrFail(
+          Alumno,
+          { id: alumnoId },
+          { populate: ["comision"] }
+        );
+        autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
-    if (!assignment.aceptaNuevasInscripciones()) {
-      throw new InscripcionesCerradasError(assignment.id);
-    }
+        if (grupo.alumnos.contains(alumno)) {
+          return grupo;
+        }
 
-    const enOtroGrupo = await transaction.findOne(Grupo, {
-      assignment: { id: assignment.id },
-      alumnos: { id: alumno.id },
-    });
-    if (enOtroGrupo) {
-      throw new AlumnoYaEnGrupoDelAssignmentError(
-        assignment.id,
-        alumno.githubUsername
-      );
-    }
+        if (!assignment.aceptaNuevasInscripciones()) {
+          throw new InscripcionesCerradasError(assignment.id);
+        }
 
-    grupo.addMember(alumno);
+        const enOtroGrupo = await transaction.findOne(Grupo, {
+          assignment: { id: assignment.id },
+          alumnos: { id: alumno.id },
+        });
+        if (enOtroGrupo) {
+          throw new AlumnoYaEnGrupoDelAssignmentError(
+            assignment.id,
+            alumno.githubUsername
+          );
+        }
 
-    await transaction.flush();
-    return grupo;
-  });
+        grupo.addMember(alumno);
+
+        await transaction.flush();
+        return grupo;
+      })
+  );
 }
 
 // Usado por la sincronización desde la planilla: crea el Grupo (nombre +
@@ -184,33 +240,51 @@ export async function upsertGrupoConMiembro(params: {
   const { nombreGrupo, paradigma, assignment, alumno } = params;
   const entityManager = await getEM();
 
-  const existente = await entityManager.findOne(
-    Grupo,
-    {
-      nombre: nombreGrupo,
-      paradigma,
-      assignment: { id: assignment.id },
-    },
-    { populate: ["alumnos"] }
+  return traducirConflictoDeInscripcion(
+    assignment.id,
+    alumno.githubUsername,
+    () =>
+      entityManager.transactional(async (transaction) => {
+        const existente = await transaction.findOne(
+          Grupo,
+          {
+            nombre: nombreGrupo,
+            paradigma,
+            assignment: { id: assignment.id },
+          },
+          { lockMode: LockMode.PESSIMISTIC_WRITE }
+        );
+
+        let grupo: Grupo;
+        if (existente) {
+          grupo = existente;
+          await transaction.populate(grupo, ["alumnos"], { refresh: true });
+        } else {
+          grupo = new Grupo();
+          grupo.nombre = nombreGrupo;
+          grupo.paradigma = paradigma;
+          grupo.assignment = assignment;
+          grupo.maxIntegrantes = assignment.maxIntegrantes;
+          grupo.creadoPor = "sheets-sync";
+          transaction.persist(grupo);
+        }
+
+        if (grupo.alumnos.contains(alumno)) return grupo;
+
+        const enOtroGrupo = await transaction.findOne(Grupo, {
+          assignment: { id: assignment.id },
+          alumnos: { id: alumno.id },
+        });
+        if (enOtroGrupo) {
+          throw new AlumnoYaEnGrupoDelAssignmentError(
+            assignment.id,
+            alumno.githubUsername
+          );
+        }
+
+        grupo.addMember(alumno);
+        await transaction.flush();
+        return grupo;
+      })
   );
-
-  let grupo: Grupo;
-  if (existente) {
-    grupo = existente;
-  } else {
-    grupo = new Grupo();
-    grupo.nombre = nombreGrupo;
-    grupo.paradigma = paradigma;
-    grupo.assignment = assignment;
-    grupo.maxIntegrantes = assignment.maxIntegrantes;
-    grupo.creadoPor = "sheets-sync";
-    entityManager.persist(grupo);
-  }
-
-  if (!grupo.alumnos.contains(alumno)) {
-    grupo.alumnos.add(alumno);
-  }
-
-  await entityManager.flush();
-  return grupo;
 }

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -7,6 +7,7 @@ import {
   Assignment,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
+  NombreGrupoDuplicadoError,
   AssignmentNoGrupalError,
 } from "@/domain/entities";
 import type { Paradigma } from "@/types";
@@ -19,15 +20,34 @@ import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 
 const INSCRIPCION_UNICA_CONSTRAINT =
   "grupo_alumnos_assignment_alumno_unique_idx";
+const NOMBRE_GRUPO_UNICO_CONSTRAINT =
+  "grupo_assignment_nombre_paradigma_unique_idx";
 
-function esViolacionDeInscripcionUnica(error: unknown): boolean {
+function esViolacionDeRestriccionUnica(
+  error: unknown,
+  constraint: string
+): boolean {
   if (!(error instanceof Error)) return false;
   const message = `${error.message} ${
     error.cause instanceof Error ? error.cause.message : ""
   }`;
   return (
     extractDbErrorCode(error) === UNIQUE_VIOLATION &&
-    message.includes(INSCRIPCION_UNICA_CONSTRAINT)
+    message.includes(constraint)
+  );
+}
+
+function esViolacionDeInscripcionUnica(error: unknown): boolean {
+  return esViolacionDeRestriccionUnica(
+    error,
+    INSCRIPCION_UNICA_CONSTRAINT
+  );
+}
+
+function esViolacionDeNombreGrupoUnico(error: unknown): boolean {
+  return esViolacionDeRestriccionUnica(
+    error,
+    NOMBRE_GRUPO_UNICO_CONSTRAINT
   );
 }
 
@@ -44,6 +64,21 @@ async function traducirConflictoDeInscripcion<T>(
         assignmentId,
         githubUsername
       );
+    }
+    throw error;
+  }
+}
+
+async function traducirConflictoDeNombreGrupo<T>(
+  assignmentId: string,
+  nombre: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (esViolacionDeNombreGrupoUnico(error)) {
+      throw new NombreGrupoDuplicadoError(assignmentId, nombre);
     }
     throw error;
   }
@@ -105,57 +140,60 @@ export async function crearGrupo(params: {
   const { assignmentId, alumnoId, nombre, esAdmin } = params;
   const entityManager = await getEM();
 
-  return traducirConflictoDeInscripcion(
-    assignmentId,
-    alumnoId,
-    () =>
-      entityManager.transactional(async (transaction) => {
-        const assignment = await transaction.findOne(
-          Assignment,
-          { id: assignmentId },
-          { populate: ["comision"] }
-        );
-        if (!assignment) {
-          throw new AssignmentNoEncontradoError(assignmentId);
+  return traducirConflictoDeNombreGrupo(assignmentId, nombre, () =>
+    entityManager.transactional(async (transaction) => {
+      const assignment = await transaction.findOne(
+        Assignment,
+        { id: assignmentId },
+        { populate: ["comision"] }
+      );
+      if (!assignment) {
+        throw new AssignmentNoEncontradoError(assignmentId);
+      }
+      if (!(assignment instanceof GrupalAssignment)) {
+        throw new AssignmentNoGrupalError(assignmentId);
+      }
+
+      const alumno = await transaction.findOneOrFail(
+        Alumno,
+        { id: alumnoId },
+        { populate: ["comision"] }
+      );
+      autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+
+      return traducirConflictoDeInscripcion(
+        assignmentId,
+        alumno.githubUsername,
+        async () => {
+          if (!assignment.aceptaNuevasInscripciones()) {
+            throw new InscripcionesCerradasError(assignmentId);
+          }
+
+          const yaEnGrupo = await transaction.findOne(Grupo, {
+            assignment: { id: assignmentId },
+            alumnos: { id: alumno.id },
+          });
+          if (yaEnGrupo) {
+            throw new AlumnoYaEnGrupoDelAssignmentError(
+              assignmentId,
+              alumno.githubUsername
+            );
+          }
+
+          const grupo = new Grupo();
+          grupo.nombre = nombre;
+          grupo.paradigma = assignment.paradigma;
+          grupo.assignment = assignment;
+          grupo.maxIntegrantes = assignment.maxIntegrantes;
+          grupo.creadoPor = alumno.githubUsername;
+          grupo.alumnos.add(alumno);
+          transaction.persist(grupo);
+
+          await transaction.flush();
+          return grupo;
         }
-        if (!(assignment instanceof GrupalAssignment)) {
-          throw new AssignmentNoGrupalError(assignmentId);
-        }
-
-        const alumno = await transaction.findOneOrFail(
-          Alumno,
-          { id: alumnoId },
-          { populate: ["comision"] }
-        );
-        autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
-
-        if (!assignment.aceptaNuevasInscripciones()) {
-          throw new InscripcionesCerradasError(assignmentId);
-        }
-
-        const yaEnGrupo = await transaction.findOne(Grupo, {
-          assignment: { id: assignmentId },
-          alumnos: { id: alumno.id },
-        });
-        if (yaEnGrupo) {
-          throw new AlumnoYaEnGrupoDelAssignmentError(
-            assignmentId,
-            alumno.githubUsername
-          );
-        }
-
-        const grupo = new Grupo();
-        grupo.nombre = nombre;
-        grupo.paradigma = assignment.paradigma;
-        grupo.assignment = assignment;
-        grupo.maxIntegrantes = assignment.maxIntegrantes;
-        grupo.creadoPor = alumno.githubUsername;
-        grupo.alumnos.add(alumno);
-        transaction.persist(grupo);
-
-        await transaction.flush();
-        return grupo;
-      })
+      );
+    })
   );
 }
 
@@ -172,35 +210,35 @@ export async function unirseAGrupo(params: {
   const { assignmentId, grupoId, alumnoId, esAdmin } = params;
   const entityManager = await getEM();
 
-  return traducirConflictoDeInscripcion(
-    assignmentId,
-    alumnoId,
-    () =>
-      entityManager.transactional(async (transaction) => {
-        const grupo = await transaction.findOne(
-          Grupo,
-          { id: grupoId, assignment: { id: assignmentId } },
-          { lockMode: LockMode.PESSIMISTIC_WRITE }
-        );
-        if (!grupo) throw new GrupoNoEncontradoError(assignmentId, grupoId);
+  return entityManager.transactional(async (transaction) => {
+    const grupo = await transaction.findOne(
+      Grupo,
+      { id: grupoId, assignment: { id: assignmentId } },
+      { lockMode: LockMode.PESSIMISTIC_WRITE }
+    );
+    if (!grupo) throw new GrupoNoEncontradoError(assignmentId, grupoId);
 
-        // El lock se toma antes de leer la colección. Cuando dos requests compiten
-        // por el último cupo, el segundo carga los miembros recién confirmados por
-        // el primero y vuelve a evaluar el límite con el estado vigente.
-        await transaction.populate(
-          grupo,
-          ["alumnos", "assignment.comision"],
-          { refresh: true }
-        );
+    // El lock se toma antes de leer la colección. Cuando dos requests compiten
+    // por el último cupo, el segundo carga los miembros recién confirmados por
+    // el primero y vuelve a evaluar el límite con el estado vigente.
+    await transaction.populate(
+      grupo,
+      ["alumnos", "assignment.comision"],
+      { refresh: true }
+    );
 
-        const assignment = grupo.assignment;
-        const alumno = await transaction.findOneOrFail(
-          Alumno,
-          { id: alumnoId },
-          { populate: ["comision"] }
-        );
-        autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+    const assignment = grupo.assignment;
+    const alumno = await transaction.findOneOrFail(
+      Alumno,
+      { id: alumnoId },
+      { populate: ["comision"] }
+    );
+    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
+    return traducirConflictoDeInscripcion(
+      assignmentId,
+      alumno.githubUsername,
+      async () => {
         if (grupo.alumnos.contains(alumno)) {
           return grupo;
         }
@@ -224,14 +262,36 @@ export async function unirseAGrupo(params: {
 
         await transaction.flush();
         return grupo;
-      })
-  );
+      }
+    );
+  });
 }
 
 // Usado por la sincronización desde la planilla: crea el Grupo (nombre +
 // paradigma + assignment) si no existe, y agrega al alumno como miembro
 // si no lo era. Idempotente.
 export async function upsertGrupoConMiembro(params: {
+  nombreGrupo: string;
+  paradigma: Paradigma;
+  assignment: GrupalAssignment;
+  alumno: Alumno;
+}): Promise<Grupo> {
+  try {
+    return await ejecutarUpsertGrupoConMiembro(params);
+  } catch (error) {
+    if (!esViolacionDeNombreGrupoUnico(error)) throw error;
+
+    // La otra transacción ya creó el grupo. Un EM nuevo evita reutilizar el
+    // estado abortado y permite encontrar al ganador en el segundo intento.
+    return traducirConflictoDeNombreGrupo(
+      params.assignment.id,
+      params.nombreGrupo,
+      () => ejecutarUpsertGrupoConMiembro(params)
+    );
+  }
+}
+
+async function ejecutarUpsertGrupoConMiembro(params: {
   nombreGrupo: string;
   paradigma: Paradigma;
   assignment: GrupalAssignment;

--- a/tests/migrations/group-membership-invariants.integration.test.ts
+++ b/tests/migrations/group-membership-invariants.integration.test.ts
@@ -207,6 +207,25 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
     await connection.execute('truncate table "comision" cascade');
   });
 
+  it("rechaza grupos históricos con nombre y paradigma duplicados", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 0,
+      grupos: 2,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `update "grupo" set "nombre" = 'Los Lambdas' where "assignment_id" = ?`,
+      [seed.assignmentId]
+    );
+
+    await expect(
+      orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION })
+    ).rejects.toThrow("hay nombres y paradigmas duplicados");
+
+    await connection.execute('truncate table "comision" cascade');
+  });
+
   it("migra, completa assignment_id mediante trigger y revierte limpiamente", async () => {
     const seed = await seedGroups(orm, {
       alumnos: 1,
@@ -235,6 +254,25 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
 
     await orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION });
     migrationReady = true;
+  });
+
+  it("el schema diff preserva los objetos manuales del pivot", async () => {
+    const { up } = await orm
+      .getSchemaGenerator()
+      .getUpdateSchemaMigrationSQL();
+
+    expect(up).not.toContain('drop table if exists "grupo_alumnos"');
+    expect(up).not.toContain('drop column "assignment_id"');
+    expect(up).not.toContain(
+      'drop index "grupo_alumnos_assignment_alumno_unique_idx"'
+    );
+    expect(up).not.toContain(
+      'drop constraint "grupo_alumnos_grupo_assignment_foreign"'
+    );
+    expect(up).not.toContain('drop constraint "grupo_id_assignment_unique"');
+    expect(up).not.toContain(
+      'drop constraint "grupo_assignment_nombre_paradigma_unique_idx"'
+    );
   });
 
   beforeEach(async () => {
@@ -358,5 +396,43 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
       [seed.assignmentId, seed.alumnoIds[0]]
     );
     expect(Number(memberships[0]?.count)).toBe(1);
+  });
+
+  it("unifica dos upserts concurrentes con el mismo nombre de grupo", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 2,
+      grupos: 0,
+      maxIntegrantes: 3,
+    });
+
+    const sync = async (alumnoId: string) => {
+      const em = orm.em.fork();
+      const [assignment, alumno] = await Promise.all([
+        em.findOneOrFail(GrupalAssignment, { id: seed.assignmentId }),
+        em.findOneOrFail(Alumno, { id: alumnoId }),
+      ]);
+      return upsertGrupoConMiembro({
+        nombreGrupo: "Los Lambdas",
+        paradigma: "funcional",
+        assignment,
+        alumno,
+      });
+    };
+
+    const grupos = await Promise.all(seed.alumnoIds.map(sync));
+
+    expect(new Set(grupos.map((grupo) => grupo.id)).size).toBe(1);
+    const rows = await orm.em.getConnection().execute<
+      { grupos: string; membresias: string }[]
+    >(
+      `select
+         (select count(*) from "grupo"
+          where "assignment_id" = ? and "nombre" = 'Los Lambdas'
+            and "paradigma" = 'funcional') as grupos,
+         (select count(*) from "grupo_alumnos"
+          where "assignment_id" = ?) as membresias`,
+      [seed.assignmentId, seed.assignmentId]
+    );
+    expect(rows[0]).toEqual({ grupos: "1", membresias: "2" });
   });
 });

--- a/tests/migrations/group-membership-invariants.integration.test.ts
+++ b/tests/migrations/group-membership-invariants.integration.test.ts
@@ -1,0 +1,362 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import ormConfig from "../../mikro-orm.config";
+
+const ormHolder = vi.hoisted(() => ({ orm: undefined as MikroORM | undefined }));
+
+vi.mock("@/lib/db", () => ({
+  getEM: async () => {
+    if (!ormHolder.orm) throw new Error("ORM de integración no inicializado");
+    return ormHolder.orm.em.fork();
+  },
+}));
+
+import {
+  AlumnoYaEnGrupoDelAssignmentError,
+  GrupoLlenoError,
+} from "../../src/domain/entities";
+import {
+  crearGrupo,
+  unirseAGrupo,
+  upsertGrupoConMiembro,
+} from "../../src/lib/repositories/GrupoRepository";
+import { Alumno, GrupalAssignment } from "../../src/domain/entities";
+
+const PREVIOUS_MIGRATION =
+  "Migration20260610120000_add_google_group_state_to_alumno";
+const MEMBERSHIP_MIGRATION =
+  "Migration20260813190000_group_membership_invariants";
+
+function getSafeTestDatabaseUrl(): string {
+  const value = process.env.MIGRATION_TEST_DATABASE_URL;
+  if (!value) {
+    throw new Error(
+      "MIGRATION_TEST_DATABASE_URL es obligatoria para ejecutar pruebas de migraciones"
+    );
+  }
+
+  const url = new URL(value);
+  const databaseName = url.pathname.slice(1);
+  if (!["postgres:", "postgresql:"].includes(url.protocol)) {
+    throw new Error("La base de migraciones debe usar PostgreSQL");
+  }
+  if (!databaseName.endsWith("_test")) {
+    throw new Error(
+      `La base de migraciones debe terminar en _test; se recibió ${databaseName || "una base sin nombre"}`
+    );
+  }
+
+  return value;
+}
+
+async function resetPublicSchema(orm: MikroORM): Promise<void> {
+  const connection = orm.em.getConnection();
+  await connection.execute('drop schema if exists "public" cascade');
+  await connection.execute('create schema "public"');
+}
+
+type Seed = {
+  comisionId: string;
+  assignmentId: string;
+  alumnoIds: string[];
+  grupoIds: string[];
+};
+
+async function seedGroups(
+  orm: MikroORM,
+  options: { alumnos: number; grupos: number; maxIntegrantes: number }
+): Promise<Seed> {
+  const connection = orm.em.getConnection();
+  const comisionId = randomUUID();
+  const assignmentId = randomUUID();
+  const alumnoIds = Array.from({ length: options.alumnos }, () => randomUUID());
+  const grupoIds = Array.from({ length: options.grupos }, () => randomUUID());
+
+  await connection.execute(
+    `insert into "comision"
+      ("id", "anio", "spreadsheet_id", "activa", "column_config")
+     values (?, 2026, ?, false, '{}'::jsonb)`,
+    [comisionId, `sheet-${comisionId}`]
+  );
+  await connection.execute(
+    `insert into "assignment"
+      ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+       "created_at", "comision_id", "max_integrantes", "inscripciones_cerradas")
+     values (?, 'TP concurrente', ?, 'org/template', 'funcional', 'grupal',
+       now(), ?, ?, false)`,
+    [assignmentId, `tp-${assignmentId}`, comisionId, options.maxIntegrantes]
+  );
+
+  for (const [index, alumnoId] of alumnoIds.entries()) {
+    await connection.execute(
+      `insert into "alumno"
+        ("id", "legajo", "nombre", "apellido", "github_username", "email", "comision_id")
+       values (?, ?, ?, 'Test', ?, ?, ?)`,
+      [
+        alumnoId,
+        `${1000 + index}`,
+        `Alumno ${index}`,
+        `alumno-${index}-${alumnoId}`,
+        `alumno-${index}-${alumnoId}@example.com`,
+        comisionId,
+      ]
+    );
+  }
+
+  for (const [index, grupoId] of grupoIds.entries()) {
+    await connection.execute(
+      `insert into "grupo"
+        ("id", "nombre", "paradigma", "max_integrantes", "creado_por", "assignment_id")
+       values (?, ?, 'funcional', ?, 'test', ?)`,
+      [grupoId, `Grupo ${index}`, options.maxIntegrantes, assignmentId]
+    );
+  }
+
+  return { comisionId, assignmentId, alumnoIds, grupoIds };
+}
+
+function expectOneConcurrentConflict(
+  results: PromiseSettledResult<unknown>[],
+  ErrorType:
+    | typeof AlumnoYaEnGrupoDelAssignmentError
+    | typeof GrupoLlenoError
+): void {
+  expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
+  const rejected = results.filter(
+    (result): result is PromiseRejectedResult => result.status === "rejected"
+  );
+  expect(rejected).toHaveLength(1);
+  expect(rejected[0]?.reason).toBeInstanceOf(ErrorType);
+}
+
+describe.sequential("invariantes concurrentes de membresías de grupos", () => {
+  let orm: MikroORM;
+  let migrationReady = false;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      ...ormConfig,
+      clientUrl: getSafeTestDatabaseUrl(),
+      debug: false,
+      migrations: {
+        ...ormConfig.migrations,
+        snapshot: false,
+      },
+    });
+    await resetPublicSchema(orm);
+    await orm.getMigrator().up({ to: PREVIOUS_MIGRATION });
+    ormHolder.orm = orm;
+  });
+
+  afterAll(async () => {
+    if (!orm) return;
+    ormHolder.orm = undefined;
+    await resetPublicSchema(orm);
+    await orm.close(true);
+  });
+
+  it("rechaza membresías históricas duplicadas sin decidir cuál borrar", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 1,
+      grupos: 2,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `insert into "grupo_alumnos" ("grupo_id", "alumno_id") values (?, ?), (?, ?)`,
+      [seed.grupoIds[0], seed.alumnoIds[0], seed.grupoIds[1], seed.alumnoIds[0]]
+    );
+
+    await expect(
+      orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION })
+    ).rejects.toThrow("hay alumnos en mas de un grupo");
+
+    const columns = await connection.execute<{ column_name: string }[]>(
+      `select column_name from information_schema.columns
+       where table_name = 'grupo_alumnos' and column_name = 'assignment_id'`
+    );
+    expect(columns).toEqual([]);
+    await connection.execute('truncate table "comision" cascade');
+  });
+
+  it("rechaza grupos históricos que ya superan el cupo", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 2,
+      grupos: 1,
+      maxIntegrantes: 1,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `insert into "grupo_alumnos" ("grupo_id", "alumno_id") values (?, ?), (?, ?)`,
+      [seed.grupoIds[0], seed.alumnoIds[0], seed.grupoIds[0], seed.alumnoIds[1]]
+    );
+
+    await expect(
+      orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION })
+    ).rejects.toThrow("hay grupos con mas alumnos");
+
+    await connection.execute('truncate table "comision" cascade');
+  });
+
+  it("migra, completa assignment_id mediante trigger y revierte limpiamente", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 1,
+      grupos: 1,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `insert into "grupo_alumnos" ("grupo_id", "alumno_id") values (?, ?)`,
+      [seed.grupoIds[0], seed.alumnoIds[0]]
+    );
+
+    await orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION });
+    const rows = await connection.execute<{ assignment_id: string }[]>(
+      `select "assignment_id" from "grupo_alumnos" where "alumno_id" = ?`,
+      [seed.alumnoIds[0]]
+    );
+    expect(rows[0]?.assignment_id).toBe(seed.assignmentId);
+
+    await orm.getMigrator().down({ migrations: [MEMBERSHIP_MIGRATION] });
+    const columnsAfterDown = await connection.execute<{ column_name: string }[]>(
+      `select column_name from information_schema.columns
+       where table_name = 'grupo_alumnos' and column_name = 'assignment_id'`
+    );
+    expect(columnsAfterDown).toEqual([]);
+
+    await orm.getMigrator().up({ to: MEMBERSHIP_MIGRATION });
+    migrationReady = true;
+  });
+
+  beforeEach(async () => {
+    if (!migrationReady) return;
+    await orm.em.getConnection().execute('truncate table "comision" cascade');
+  });
+
+  it("serializa dos joins que compiten por el último cupo", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 3,
+      grupos: 1,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `insert into "grupo_alumnos" ("grupo_id", "alumno_id") values (?, ?)`,
+      [seed.grupoIds[0], seed.alumnoIds[0]]
+    );
+
+    const results = await Promise.allSettled(
+      [seed.alumnoIds[1], seed.alumnoIds[2]].map((alumnoId) =>
+        unirseAGrupo({
+          assignmentId: seed.assignmentId,
+          grupoId: seed.grupoIds[0]!,
+          alumnoId,
+          esAdmin: false,
+        })
+      )
+    );
+
+    expectOneConcurrentConflict(results, GrupoLlenoError);
+    const count = await connection.execute<{ count: string }[]>(
+      `select count(*) from "grupo_alumnos" where "grupo_id" = ?`,
+      [seed.grupoIds[0]]
+    );
+    expect(Number(count[0]?.count)).toBe(2);
+  });
+
+  it("impide que un alumno se una a dos grupos en paralelo", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 1,
+      grupos: 2,
+      maxIntegrantes: 2,
+    });
+
+    const results = await Promise.allSettled(
+      seed.grupoIds.map((grupoId) =>
+        unirseAGrupo({
+          assignmentId: seed.assignmentId,
+          grupoId,
+          alumnoId: seed.alumnoIds[0]!,
+          esAdmin: false,
+        })
+      )
+    );
+
+    expectOneConcurrentConflict(results, AlumnoYaEnGrupoDelAssignmentError);
+    const memberships = await orm.em.getConnection().execute<{ count: string }[]>(
+      `select count(*) from "grupo_alumnos"
+       where "assignment_id" = ? and "alumno_id" = ?`,
+      [seed.assignmentId, seed.alumnoIds[0]]
+    );
+    expect(Number(memberships[0]?.count)).toBe(1);
+  });
+
+  it("revierte el grupo perdedor si el alumno crea dos grupos en paralelo", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 1,
+      grupos: 0,
+      maxIntegrantes: 3,
+    });
+
+    const results = await Promise.allSettled(
+      ["Grupo A", "Grupo B"].map((nombre) =>
+        crearGrupo({
+          assignmentId: seed.assignmentId,
+          alumnoId: seed.alumnoIds[0]!,
+          nombre,
+          esAdmin: false,
+        })
+      )
+    );
+
+    expectOneConcurrentConflict(results, AlumnoYaEnGrupoDelAssignmentError);
+    const rows = await orm.em.getConnection().execute<{ grupos: string; membresias: string }[]>(
+      `select
+         (select count(*) from "grupo" where "assignment_id" = ?) as grupos,
+         (select count(*) from "grupo_alumnos" where "assignment_id" = ?) as membresias`,
+      [seed.assignmentId, seed.assignmentId]
+    );
+    expect(rows[0]).toEqual({ grupos: "1", membresias: "1" });
+  });
+
+  it("la sincronización desde Sheets reporta el mismo conflicto explícito", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 1,
+      grupos: 2,
+      maxIntegrantes: 3,
+    });
+
+    const sync = async (groupIndex: number) => {
+      const em = orm.em.fork();
+      const [assignment, alumno] = await Promise.all([
+        em.findOneOrFail(GrupalAssignment, { id: seed.assignmentId }),
+        em.findOneOrFail(Alumno, { id: seed.alumnoIds[0] }),
+      ]);
+      return upsertGrupoConMiembro({
+        nombreGrupo: `Grupo ${groupIndex}`,
+        paradigma: "funcional",
+        assignment,
+        alumno,
+      });
+    };
+
+    const results = await Promise.allSettled([sync(0), sync(1)]);
+
+    expectOneConcurrentConflict(results, AlumnoYaEnGrupoDelAssignmentError);
+    const memberships = await orm.em.getConnection().execute<{ count: string }[]>(
+      `select count(*) from "grupo_alumnos"
+       where "assignment_id" = ? and "alumno_id" = ?`,
+      [seed.assignmentId, seed.alumnoIds[0]]
+    );
+    expect(Number(memberships[0]?.count)).toBe(1);
+  });
+});


### PR DESCRIPTION
## Resumen

- agrega una garantía de PostgreSQL para una única membresía por alumno y assignment
- serializa la ocupación de cupos con locking pesimista y traduce conflictos esperables a errores 409
- aplica las mismas invariantes a la sincronización desde Google Sheets
- incorpora una migración defensiva con rollback y pruebas de carreras reales

## Validación

- pnpm test:run: 976 tests pasaron
- pnpm test:coverage: 92,83 % de statements
- pnpm test:migrations: 8 pruebas PostgreSQL pasaron
- pnpm lint: sin errores, 10 warnings preexistentes
- pnpm exec tsc --noEmit: pasó
- pnpm build: pasó

Closes #44

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Se refuerzan las reglas de pertenencia de alumnos a grupos por asignación.
  * Se evita que un alumno pertenezca a varios grupos dentro de la misma asignación.
  * Se controlan los cupos disponibles incluso ante incorporaciones simultáneas.
  * La sincronización y las operaciones de grupos ahora informan claramente los conflictos de pertenencia.

* **Correcciones**
  * Se mejoró la consistencia al crear grupos, unirse a ellos y sincronizar sus miembros.
  * Se validan duplicados y grupos sobreocupados durante las actualizaciones del esquema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->