### PR TITLE
Hacer resiliente y auditable el borrado masivo de repositorios

### DIFF
--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -1297,6 +1297,225 @@
       },
       "nativeEnums": {},
       "comment": null
+    },
+    {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": true,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "operation_id": {
+          "name": "operation_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "assignment_id": {
+          "name": "assignment_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "entrega_id": {
+          "name": "entrega_id",
+          "type": "uuid",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "uuid"
+        },
+        "repo_name": {
+          "name": "repo_name",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "requested_by": {
+          "name": "requested_by",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": "'pending'",
+          "comment": null,
+          "enumItems": [
+            "pending",
+            "deleted",
+            "already_absent",
+            "failed"
+          ],
+          "mappedType": "enum"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamptz(6)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": 6,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "datetime"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": true,
+          "unique": false,
+          "length": null,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "text"
+        }
+      },
+      "name": "repo_deletion_attempt",
+      "schema": "public",
+      "indexes": [
+        {
+          "columnNames": [
+            "id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "repo_deletion_attempt_pkey",
+          "unique": true,
+          "primary": true
+        },
+        {
+          "columnNames": [
+            "assignment_id",
+            "started_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "repo_deletion_attempt_assignment_started_idx",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "operation_id"
+          ],
+          "composite": false,
+          "constraint": false,
+          "keyName": "repo_deletion_attempt_operation_idx",
+          "unique": false,
+          "primary": false
+        },
+        {
+          "columnNames": [
+            "entrega_id",
+            "started_at"
+          ],
+          "composite": true,
+          "constraint": false,
+          "keyName": "repo_deletion_attempt_entrega_started_idx",
+          "unique": false,
+          "primary": false
+        }
+      ],
+      "checks": [],
+      "foreignKeys": {},
+      "nativeEnums": {},
+      "comment": null
     }
   ],
   "nativeEnums": {}

--- a/migrations/Migration20260814140000_repo_deletion_audit.ts
+++ b/migrations/Migration20260814140000_repo_deletion_audit.ts
@@ -1,0 +1,28 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260814140000_repo_deletion_audit extends Migration {
+  override async up(): Promise<void> {
+    this.addSql(`
+      create table "repo_deletion_attempt" (
+        "id" uuid not null,
+        "operation_id" uuid not null,
+        "assignment_id" uuid not null,
+        "entrega_id" uuid not null,
+        "repo_name" varchar(255) not null,
+        "requested_by" varchar(255) not null,
+        "status" text check ("status" in ('pending', 'deleted', 'already_absent', 'failed')) not null default 'pending',
+        "started_at" timestamptz not null,
+        "completed_at" timestamptz null,
+        "error" text null,
+        constraint "repo_deletion_attempt_pkey" primary key ("id")
+      );
+    `);
+    this.addSql(`create index "repo_deletion_attempt_assignment_started_idx" on "repo_deletion_attempt" ("assignment_id", "started_at");`);
+    this.addSql(`create index "repo_deletion_attempt_operation_idx" on "repo_deletion_attempt" ("operation_id");`);
+    this.addSql(`create index "repo_deletion_attempt_entrega_started_idx" on "repo_deletion_attempt" ("entrega_id", "started_at");`);
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop table if exists "repo_deletion_attempt";`);
+  }
+}

--- a/mikro-orm.config.ts
+++ b/mikro-orm.config.ts
@@ -17,6 +17,7 @@ import {
   GrupalAssignment,
   Grupo,
   Entrega,
+  RepoDeletionAttempt,
 } from "./src/domain/entities";
 
 export default defineConfig({
@@ -27,7 +28,16 @@ export default defineConfig({
   },
 
   // Entidades
-  entities: [Alumno, Comision, Assignment, IndividualAssignment, GrupalAssignment, Grupo, Entrega],
+  entities: [
+    Alumno,
+    Comision,
+    Assignment,
+    IndividualAssignment,
+    GrupalAssignment,
+    Grupo,
+    Entrega,
+    RepoDeletionAttempt,
+  ],
 
   // Usa reflect-metadata en runtime (funciona en webpack/RSC sin necesitar
   // leer archivos .ts desde el filesystem).

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -12,6 +12,7 @@ const mockGetAssignment = vi.fn();
 const mockGetEntregas = vi.fn();
 const mockGetAlumnos = vi.fn();
 const mockGetGruposDeAssignment = vi.fn();
+const mockGetRepoDeletionHistory = vi.fn();
 const mockRedirect = vi.fn();
 
 vi.mock("@/lib/session", () => ({
@@ -23,6 +24,8 @@ vi.mock("@/lib/repositories", () => ({
   getEntregas: (id: string) => mockGetEntregas(id),
   getAlumnos: () => mockGetAlumnos(),
   getGruposDeAssignment: (id: string) => mockGetGruposDeAssignment(id),
+  getRepoDeletionHistory: (id: string, page: number) =>
+    mockGetRepoDeletionHistory(id, page),
 }));
 
 vi.mock("next/navigation", () => ({
@@ -168,6 +171,35 @@ describe("Admin Assignment Detail Page", () => {
     mockGetEntregas.mockResolvedValue([]);
     mockGetAlumnos.mockResolvedValue([]);
     mockGetGruposDeAssignment.mockResolvedValue([]);
+    mockGetRepoDeletionHistory.mockResolvedValue({
+      items: [],
+      page: 1,
+      pageSize: 25,
+      total: 0,
+      totalPages: 1,
+    });
+  });
+
+  it("normaliza y consulta la página solicitada del historial", async () => {
+    mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+
+    await AssignmentDetailPage({
+      params: Promise.resolve({ id: "a1" }),
+      searchParams: Promise.resolve({ repoDeletionPage: "3" }),
+    });
+
+    expect(mockGetRepoDeletionHistory).toHaveBeenCalledWith("a1", 3);
+  });
+
+  it("normaliza una página inválida a la primera", async () => {
+    mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+
+    await AssignmentDetailPage({
+      params: Promise.resolve({ id: "a1" }),
+      searchParams: Promise.resolve({ repoDeletionPage: "3-invalida" }),
+    });
+
+    expect(mockGetRepoDeletionHistory).toHaveBeenCalledWith("a1", 1);
   });
 
   it("siempre llama a requireAdmin", async () => {

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -4,6 +4,7 @@ import {
   getEntregas,
   getAlumnos,
   getGruposDeAssignment,
+  getRepoDeletionHistory,
 } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import Link from "next/link";
@@ -13,22 +14,35 @@ import { GruposPanel } from "./grupos-panel";
 import type { GrupoAdminResumen, AlumnoSinGrupoResumen } from "./grupos-panel";
 import { GrupalAssignment, Alumno } from "@/domain/entities";
 import type { Grupo } from "@/domain/entities";
+import { RepoDeletionHistory } from "./repo-deletion-history";
 
 export default async function AssignmentDetailPage(
   props: {
     params: Promise<{ id: string }>;
+    searchParams?: Promise<{ repoDeletionPage?: string | string[] }>;
   }
 ) {
-  const params = await props.params;
+  const emptySearchParams: { repoDeletionPage?: string | string[] } = {};
+  const [params, searchParams] = await Promise.all([
+    props.params,
+    props.searchParams ?? Promise.resolve(emptySearchParams),
+  ]);
   await requireAdmin();
 
   const assignment = await getAssignment(params.id);
   if (!assignment) redirect("/admin/assignments");
 
   const gruposPromise = assignment.cargarGruposCon(getGruposDeAssignment);
+  const rawHistoryPage = Array.isArray(searchParams.repoDeletionPage)
+    ? searchParams.repoDeletionPage[0]
+    : searchParams.repoDeletionPage;
+  const parsedHistoryPage = Number(rawHistoryPage ?? 1);
+  const historyPage = Number.isInteger(parsedHistoryPage) && parsedHistoryPage > 0
+    ? parsedHistoryPage
+    : 1;
 
   const alumnosPromise = getAlumnos();
-  const [entregas, alumnos, grupos, total] = await Promise.all([
+  const [entregas, alumnos, grupos, total, deletionHistory] = await Promise.all([
     getEntregas(params.id),
     alumnosPromise,
     gruposPromise,
@@ -36,6 +50,7 @@ export default async function AssignmentDetailPage(
       getAlumnosDelCurso: () => alumnosPromise,
       getGruposDeAssignment: (_assignmentId: string) => gruposPromise,
     }),
+    getRepoDeletionHistory(params.id, historyPage),
   ]);
 
   const aceptadas = entregas.length;
@@ -109,7 +124,11 @@ export default async function AssignmentDetailPage(
         <div className="flex items-center gap-3">
           <DeleteReposButton
             assignmentId={assignment.id}
-            activeRepoCount={entregas.filter((entrega) => entrega.hasRepo()).length}
+            activeRepoCount={
+              entregas.filter(
+                (entrega) => Boolean(entrega.repoName) && !entrega.repoDeleted
+              ).length
+            }
           />
           <Link
             href={`/admin/assignments/${assignment.id}/edit`}
@@ -166,6 +185,11 @@ export default async function AssignmentDetailPage(
       <div className="bg-white border border-gray-200 rounded-lg overflow-hidden">
         <EntregasTable entregas={entregaRows} />
       </div>
+
+      <RepoDeletionHistory
+        assignmentId={assignment.id}
+        history={deletionHistory}
+      />
 
       {gruposPanel}
     </div>

--- a/src/app/admin/assignments/[id]/repo-deletion-history.test.tsx
+++ b/src/app/admin/assignments/[id]/repo-deletion-history.test.tsx
@@ -1,0 +1,67 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it } from "vitest";
+import { RepoDeletionAttempt } from "@/domain/entities";
+import { RepoDeletionHistory } from "./repo-deletion-history";
+
+function attempt(overrides: Partial<RepoDeletionAttempt> = {}) {
+  const item = new RepoDeletionAttempt();
+  item.id = "attempt-1";
+  item.operationId = "00000000-0000-4000-8000-000000000001";
+  item.assignmentId = "a1";
+  item.entregaId = "e1";
+  item.repoName = "tp-ana";
+  item.requestedBy = "docente";
+  item.startedAt = new Date("2026-08-14T12:00:00Z");
+  return Object.assign(item, overrides);
+}
+
+function history(items: RepoDeletionAttempt[], overrides = {}) {
+  return {
+    items,
+    page: 1,
+    pageSize: 25,
+    total: items.length,
+    totalPages: 1,
+    ...overrides,
+  };
+}
+
+describe("RepoDeletionHistory", () => {
+  it("muestra el estado vacío", () => {
+    const html = renderToStaticMarkup(
+      <RepoDeletionHistory assignmentId="a1" history={history([])} />
+    );
+
+    expect(html).toContain("Todavía no hay intentos");
+  });
+
+  it("muestra actor, repo, operación, estado y error", () => {
+    const html = renderToStaticMarkup(
+      <RepoDeletionHistory
+        assignmentId="a1"
+        history={history([
+          attempt({ status: "failed", error: "GitHub no disponible" }),
+        ])}
+      />
+    );
+
+    expect(html).toContain("tp-ana");
+    expect(html).toContain("docente");
+    expect(html).toContain("00000000");
+    expect(html).toContain("Fallido");
+    expect(html).toContain("GitHub no disponible");
+  });
+
+  it("incluye navegación paginada completa", () => {
+    const html = renderToStaticMarkup(
+      <RepoDeletionHistory
+        assignmentId="a1"
+        history={history([attempt()], { page: 2, total: 60, totalPages: 3 })}
+      />
+    );
+
+    expect(html).toContain("Página 2 de 3");
+    expect(html).toContain("repoDeletionPage=1");
+    expect(html).toContain("repoDeletionPage=3");
+  });
+});

--- a/src/app/admin/assignments/[id]/repo-deletion-history.tsx
+++ b/src/app/admin/assignments/[id]/repo-deletion-history.tsx
@@ -1,0 +1,117 @@
+import Link from "next/link";
+import type { RepoDeletionHistoryPage } from "@/lib/repositories";
+import type { RepoDeletionStatus } from "@/domain/entities";
+
+const STATUS_LABELS: Record<RepoDeletionStatus, string> = {
+  pending: "Pendiente / incierto",
+  deleted: "Eliminado",
+  already_absent: "Ya estaba ausente",
+  failed: "Fallido",
+};
+
+const STATUS_CLASSES: Record<RepoDeletionStatus, string> = {
+  pending: "bg-amber-50 text-amber-800",
+  deleted: "bg-green-50 text-green-800",
+  already_absent: "bg-gray-100 text-gray-700",
+  failed: "bg-red-50 text-red-800",
+};
+
+export function RepoDeletionHistory({
+  assignmentId,
+  history,
+}: {
+  assignmentId: string;
+  history: RepoDeletionHistoryPage;
+}) {
+  const pageHref = (page: number) =>
+    `/admin/assignments/${assignmentId}?repoDeletionPage=${page}#repo-deletion-history`;
+
+  return (
+    <section
+      id="repo-deletion-history"
+      className="mt-6 overflow-hidden rounded-lg border border-gray-200 bg-white"
+    >
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h2 className="text-lg font-semibold">Historial de borrado de repositorios</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          {history.total} {history.total === 1 ? "intento registrado" : "intentos registrados"}
+        </p>
+      </div>
+
+      {history.items.length === 0 ? (
+        <p className="px-6 py-8 text-sm text-gray-500">
+          Todavía no hay intentos de borrado para este assignment.
+        </p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full divide-y divide-gray-200 text-sm">
+            <thead className="bg-gray-50 text-left text-xs uppercase tracking-wide text-gray-500">
+              <tr>
+                <th className="px-4 py-3">Fecha</th>
+                <th className="px-4 py-3">Repositorio</th>
+                <th className="px-4 py-3">Administrador</th>
+                <th className="px-4 py-3">Operación</th>
+                <th className="px-4 py-3">Resultado</th>
+                <th className="px-4 py-3">Detalle</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {history.items.map((attempt) => (
+                <tr key={attempt.id}>
+                  <td className="whitespace-nowrap px-4 py-3 text-gray-600">
+                    {new Date(attempt.startedAt).toLocaleString("es-AR")}
+                  </td>
+                  <td className="px-4 py-3 font-mono text-xs text-gray-800">
+                    {attempt.repoName}
+                  </td>
+                  <td className="px-4 py-3 text-gray-700">{attempt.requestedBy}</td>
+                  <td
+                    className="px-4 py-3 font-mono text-xs text-gray-500"
+                    title={attempt.operationId}
+                  >
+                    {attempt.operationId.slice(0, 8)}
+                  </td>
+                  <td className="px-4 py-3">
+                    <span
+                      className={`inline-flex rounded-full px-2 py-1 text-xs font-medium ${STATUS_CLASSES[attempt.status]}`}
+                    >
+                      {STATUS_LABELS[attempt.status]}
+                    </span>
+                  </td>
+                  <td className="max-w-md px-4 py-3 text-gray-600">
+                    {attempt.error ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {history.totalPages > 1 && (
+        <nav
+          aria-label="Paginación del historial de borrados"
+          className="flex items-center justify-between border-t border-gray-200 px-6 py-4 text-sm"
+        >
+          {history.page > 1 ? (
+            <Link className="text-pdep-600 hover:text-pdep-800" href={pageHref(history.page - 1)}>
+              ← Anterior
+            </Link>
+          ) : (
+            <span className="text-gray-300">← Anterior</span>
+          )}
+          <span className="text-gray-500">
+            Página {history.page} de {history.totalPages}
+          </span>
+          {history.page < history.totalPages ? (
+            <Link className="text-pdep-600 hover:text-pdep-800" href={pageHref(history.page + 1)}>
+              Siguiente →
+            </Link>
+          ) : (
+            <span className="text-gray-300">Siguiente →</span>
+          )}
+        </nav>
+      )}
+    </section>
+  );
+}

--- a/src/app/admin/assignments/delete-repos-button.test.tsx
+++ b/src/app/admin/assignments/delete-repos-button.test.tsx
@@ -8,7 +8,17 @@ vi.mock("next/navigation", () => ({
 
 import { DeleteReposButton } from "./delete-repos-button";
 
-function mockResponse(ok: boolean, data: object = {}) {
+const successResult = {
+  ok: true,
+  operationId: "op-1",
+  attempted: 2,
+  deleted: 2,
+  alreadyAbsent: 0,
+  failed: 0,
+  results: [],
+};
+
+function mockResponse(ok: boolean, data: object = successResult) {
   return { ok, json: async () => data };
 }
 
@@ -106,5 +116,49 @@ describe("DeleteReposButton", () => {
     await user.click(screen.getByRole("button"));
 
     expect(await screen.findByText("No se pudo eliminar")).toBeInTheDocument();
+  });
+
+  it("muestra el resumen al completar todos los borrados", async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirm).mockReturnValue(true);
+    vi.mocked(fetch).mockResolvedValue(mockResponse(true) as Response);
+
+    render(<DeleteReposButton assignmentId="a1" activeRepoCount={2} />);
+    await user.click(screen.getByRole("button"));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Se confirmaron 2 de 2 repositorios"
+    );
+  });
+
+  it("muestra los fallidos y permite reintentarlos", async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirm).mockReturnValue(true);
+    vi.mocked(fetch).mockResolvedValue(
+      mockResponse(true, {
+        ...successResult,
+        ok: false,
+        attempted: 2,
+        deleted: 1,
+        failed: 1,
+        results: [
+          {
+            entregaId: "e2",
+            repoName: "tp-bob",
+            status: "failed",
+            error: "GitHub no disponible",
+          },
+        ],
+      }) as Response
+    );
+
+    render(<DeleteReposButton assignmentId="a1" activeRepoCount={2} />);
+    await user.click(screen.getByRole("button"));
+
+    expect(await screen.findByRole("status")).toHaveTextContent(
+      "Fallaron 1; podés reintentarlos"
+    );
+    expect(screen.getByText(/tp-bob/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Reintentar fallidos (2)" })).toBeInTheDocument();
   });
 });

--- a/src/app/admin/assignments/delete-repos-button.test.tsx
+++ b/src/app/admin/assignments/delete-repos-button.test.tsx
@@ -45,6 +45,7 @@ describe("DeleteReposButton", () => {
     expect(
       screen.getByRole("button", { name: "Borrar todos los repos (5)" })
     ).toBeInTheDocument();
+    expect(screen.getByRole("status")).toBeEmptyDOMElement();
   });
 
   it("usa 'repo' en singular con 1 repo en el confirm", async () => {
@@ -126,7 +127,8 @@ describe("DeleteReposButton", () => {
     render(<DeleteReposButton assignmentId="a1" activeRepoCount={2} />);
     await user.click(screen.getByRole("button"));
 
-    expect(await screen.findByRole("status")).toHaveTextContent(
+    await screen.findByText(/Se confirmaron 2 de 2 repositorios/);
+    expect(screen.getByRole("status")).toHaveTextContent(
       "Se confirmaron 2 de 2 repositorios"
     );
   });
@@ -155,10 +157,15 @@ describe("DeleteReposButton", () => {
     render(<DeleteReposButton assignmentId="a1" activeRepoCount={2} />);
     await user.click(screen.getByRole("button"));
 
-    expect(await screen.findByRole("status")).toHaveTextContent(
+    await screen.findByText(/Fallaron 1; podés reintentarlos/);
+    expect(screen.getByRole("status")).toHaveTextContent(
       "Fallaron 1; podés reintentarlos"
     );
-    expect(screen.getByText(/tp-bob/)).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Reintentar fallidos (2)" })).toBeInTheDocument();
+    expect(screen.getByText(/tp-bob/).closest("li")).toHaveTextContent(
+      "tp-bob: GitHub no disponible"
+    );
+    expect(
+      screen.getByRole("button", { name: "Reintentar fallidos (2)" })
+    ).toBeInTheDocument();
   });
 });

--- a/src/app/admin/assignments/delete-repos-button.tsx
+++ b/src/app/admin/assignments/delete-repos-button.tsx
@@ -1,7 +1,9 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { useApiCall } from "@/app/hooks/useApiCall";
+import type { DeleteAssignmentReposResult } from "@/lib/services/borrarRepositoriosDeAssignment";
 
 export function DeleteReposButton({
   assignmentId,
@@ -12,6 +14,7 @@ export function DeleteReposButton({
 }) {
   const router = useRouter();
   const { loading, error, call } = useApiCall();
+  const [result, setResult] = useState<DeleteAssignmentReposResult | null>(null);
 
   async function handleDelete() {
     if (
@@ -21,28 +24,73 @@ export function DeleteReposButton({
     )
       return;
 
-    await call(async () => {
+    setResult(null);
+    const responseResult = await call(async () => {
       const response = await fetch(`/api/assignments/${assignmentId}/repos`, { method: "DELETE" });
       if (!response.ok) {
         const body = await response.json().catch(() => ({}));
         throw new Error(body.error ?? `Error ${response.status}`);
       }
-      router.refresh();
+      return (await response.json()) as DeleteAssignmentReposResult;
     });
+    if (responseResult) {
+      setResult(responseResult);
+      router.refresh();
+    }
   }
 
-  if (activeRepoCount === 0) return null;
+  if (activeRepoCount === 0 && !result) return null;
+
+  const failedResults = result?.results.filter(
+    (item) => item.status === "failed"
+  );
+  const confirmed = result
+    ? result.deleted + result.alreadyAbsent
+    : 0;
 
   return (
-    <span className="inline-flex flex-col items-start gap-1">
-      <button
-        onClick={handleDelete}
-        disabled={loading}
-        className="bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
-      >
-        {loading ? "Eliminando repos…" : `Borrar todos los repos (${activeRepoCount})`}
-      </button>
+    <span className="inline-flex max-w-md flex-col items-start gap-2">
+      {activeRepoCount > 0 && (
+        <button
+          onClick={handleDelete}
+          disabled={loading}
+          className="bg-red-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-red-700 transition-colors disabled:opacity-50"
+        >
+          {loading
+            ? "Eliminando repos…"
+            : result?.failed
+              ? `Reintentar fallidos (${activeRepoCount})`
+              : `Borrar todos los repos (${activeRepoCount})`}
+        </button>
+      )}
       {error && <span className="text-red-600 text-sm">{error}</span>}
+      {result && (
+        <span
+          role="status"
+          className={`rounded-md px-3 py-2 text-sm ${
+            result.ok
+              ? "bg-green-50 text-green-800"
+              : "bg-amber-50 text-amber-900"
+          }`}
+        >
+          {result.ok ? (
+            <>Se confirmaron {confirmed} de {result.attempted} repositorios.</>
+          ) : (
+            <>
+              Se confirmaron {confirmed} de {result.attempted} repositorios.
+              Fallaron {result.failed}; podés reintentarlos.
+              <ul className="mt-1 list-disc pl-5">
+                {failedResults?.map((item) => (
+                  <li key={item.entregaId}>
+                    <span className="font-mono">{item.repoName}</span>
+                    {item.error ? `: ${item.error}` : ""}
+                  </li>
+                ))}
+              </ul>
+            </>
+          )}
+        </span>
+      )}
     </span>
   );
 }

--- a/src/app/admin/assignments/delete-repos-button.tsx
+++ b/src/app/admin/assignments/delete-repos-button.tsx
@@ -49,7 +49,7 @@ export function DeleteReposButton({
     : 0;
 
   return (
-    <span className="inline-flex max-w-md flex-col items-start gap-2">
+    <div className="inline-flex max-w-md flex-col items-start gap-2">
       {activeRepoCount > 0 && (
         <button
           onClick={handleDelete}
@@ -63,34 +63,43 @@ export function DeleteReposButton({
               : `Borrar todos los repos (${activeRepoCount})`}
         </button>
       )}
-      {error && <span className="text-red-600 text-sm">{error}</span>}
-      {result && (
-        <span
-          role="status"
-          className={`rounded-md px-3 py-2 text-sm ${
-            result.ok
-              ? "bg-green-50 text-green-800"
-              : "bg-amber-50 text-amber-900"
-          }`}
-        >
-          {result.ok ? (
-            <>Se confirmaron {confirmed} de {result.attempted} repositorios.</>
-          ) : (
-            <>
-              Se confirmaron {confirmed} de {result.attempted} repositorios.
-              Fallaron {result.failed}; podés reintentarlos.
-              <ul className="mt-1 list-disc pl-5">
-                {failedResults?.map((item) => (
-                  <li key={item.entregaId}>
-                    <span className="font-mono">{item.repoName}</span>
-                    {item.error ? `: ${item.error}` : ""}
-                  </li>
-                ))}
-              </ul>
-            </>
-          )}
-        </span>
-      )}
-    </span>
+      {error && <div className="text-red-600 text-sm">{error}</div>}
+      <div
+        role="status"
+        aria-live="polite"
+        className={
+          result
+            ? `rounded-md px-3 py-2 text-sm ${
+                result.ok
+                  ? "bg-green-50 text-green-800"
+                  : "bg-amber-50 text-amber-900"
+              }`
+            : undefined
+        }
+      >
+        {result && (
+          <>
+            {result.ok ? (
+              <>
+                Se confirmaron {confirmed} de {result.attempted} repositorios.
+              </>
+            ) : (
+              <>
+                Se confirmaron {confirmed} de {result.attempted} repositorios.
+                Fallaron {result.failed}; podés reintentarlos.
+                <ul className="mt-1 list-disc pl-5">
+                  {failedResults?.map((item) => (
+                    <li key={item.entregaId}>
+                      <span className="font-mono">{item.repoName}</span>
+                      {item.error ? `: ${item.error}` : ""}
+                    </li>
+                  ))}
+                </ul>
+              </>
+            )}
+          </>
+        )}
+      </div>
+    </div>
   );
 }

--- a/src/app/api/assignments/[id]/repos/route.test.ts
+++ b/src/app/api/assignments/[id]/repos/route.test.ts
@@ -1,53 +1,44 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { IndividualAssignment } from "@/domain/entities";
-import { Entrega } from "@/domain/entities/Entrega";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PdepUser } from "@/types";
 
-// ── Mocks ────────────────────────────────────────────────────
-
-const mockGuardAdmin = vi.fn();
+const mockGetCurrentUser = vi.fn();
 const mockGetAssignment = vi.fn();
-const mockGetEntregas = vi.fn();
-const mockDeleteRepo = vi.fn();
-const mockClearReposDeAssignment = vi.fn();
+const mockBorrarRepositorios = vi.fn();
 
-vi.mock("@/lib/api-auth", () => ({
-  guardAdmin: () => mockGuardAdmin(),
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
 }));
 
 vi.mock("@/lib/repositories", () => ({
   getAssignment: (id: string) => mockGetAssignment(id),
-  getEntregas: (id: string) => mockGetEntregas(id),
-  clearReposDeAssignment: (id: string) => mockClearReposDeAssignment(id),
 }));
 
-vi.mock("@/lib/github", () => ({
-  deleteRepo: (name: string) => mockDeleteRepo(name),
+vi.mock("@/lib/services/borrarRepositoriosDeAssignment", () => ({
+  borrarRepositoriosDeAssignment: (data: unknown) => mockBorrarRepositorios(data),
 }));
 
 import { DELETE } from "./route";
 
-// ── Helpers ──────────────────────────────────────────────────
-
-function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAssignment {
-  const assignment = new IndividualAssignment();
-  assignment.id = "a1";
-  assignment.titulo = "Kata Funcional";
-  assignment.templateRepo = "kata-template";
-  assignment.tipo = "individual";
-  assignment.paradigma = "funcional";
-  assignment.slug = "kata-funcional";
-  assignment.createdAt = new Date("2026-01-01");
-  return Object.assign(assignment, overrides);
+function admin(): PdepUser {
+  return {
+    githubUsername: "docente",
+    name: "Docente",
+    image: "",
+    isAdmin: true,
+  };
 }
 
-function makeEntrega(repoName?: string): Entrega {
-  const entrega = new Entrega();
-  entrega.id = crypto.randomUUID();
-  entrega.repoName = repoName;
-  entrega.repoUrl = repoName ? `https://github.com/org/${repoName}` : undefined;
-  entrega.githubUsernames = ["alumno1"];
-  entrega.createdAt = new Date();
-  return entrega;
+function result(overrides = {}) {
+  return {
+    ok: true,
+    operationId: "op-1",
+    attempted: 2,
+    deleted: 2,
+    alreadyAbsent: 0,
+    failed: 0,
+    results: [],
+    ...overrides,
+  };
 }
 
 function makeRequest(): Request {
@@ -56,113 +47,100 @@ function makeRequest(): Request {
   });
 }
 
-// ── Tests ────────────────────────────────────────────────────
-
 describe("DELETE /api/assignments/[id]/repos", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGuardAdmin.mockResolvedValue(null);
-    mockDeleteRepo.mockResolvedValue(undefined);
-    mockClearReposDeAssignment.mockResolvedValue(undefined);
+    mockGetCurrentUser.mockResolvedValue(admin());
+    mockGetAssignment.mockResolvedValue({ id: "a1" });
+    mockBorrarRepositorios.mockResolvedValue(result());
   });
 
-  it("devuelve 401 si no es admin", async () => {
-    mockGuardAdmin.mockResolvedValue(
-      new Response(JSON.stringify({ error: "No autorizado" }), { status: 401 })
-    );
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
+  it.each([
+    ["sin sesión", null],
+    ["sin rol admin", { ...admin(), isAdmin: false }],
+  ])("devuelve 401 %s", async (_case, user) => {
+    mockGetCurrentUser.mockResolvedValue(user);
+
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+
     expect(response.status).toBe(401);
+    expect(mockBorrarRepositorios).not.toHaveBeenCalled();
   });
 
   it("devuelve 404 si el assignment no existe", async () => {
     mockGetAssignment.mockResolvedValue(null);
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: "no-existe" }) });
+
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "no-existe" }),
+    });
+
     expect(response.status).toBe(404);
-    const data = await response.json();
-    expect(data.error).toContain("no encontrado");
+    expect(mockBorrarRepositorios).not.toHaveBeenCalled();
   });
 
-  it("elimina todos los repos y devuelve ok: true con el conteo", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregas.mockResolvedValue([
-      makeEntrega("kata-funcional-alumno1"),
-      makeEntrega("kata-funcional-alumno2"),
-    ]);
+  it("propaga el actor autenticado al servicio", async () => {
+    await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
 
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
+    expect(mockBorrarRepositorios).toHaveBeenCalledWith({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+  });
+
+  it("devuelve 200 con el resumen de éxito", async () => {
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
 
     expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.ok).toBe(true);
-    expect(data.deleted).toBe(2);
+    await expect(response.json()).resolves.toEqual(result());
   });
 
-  it("llama a deleteRepo por cada entrega con repo", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregas.mockResolvedValue([
-      makeEntrega("kata-funcional-alumno1"),
-      makeEntrega("kata-funcional-alumno2"),
-    ]);
+  it("devuelve 200 y ok=false para un resultado parcial", async () => {
+    mockBorrarRepositorios.mockResolvedValue(
+      result({ ok: false, deleted: 1, failed: 1 })
+    );
 
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
-
-    expect(mockDeleteRepo).toHaveBeenCalledTimes(2);
-    expect(mockDeleteRepo).toHaveBeenCalledWith("kata-funcional-alumno1");
-    expect(mockDeleteRepo).toHaveBeenCalledWith("kata-funcional-alumno2");
-  });
-
-  it("ignora entregas sin repo asignado", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregas.mockResolvedValue([
-      makeEntrega("kata-funcional-alumno1"),
-      makeEntrega(undefined), // pendiente, sin repo
-    ]);
-
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
-
-    const data = await response.json();
-    expect(data.deleted).toBe(1);
-    expect(mockDeleteRepo).toHaveBeenCalledTimes(1);
-    expect(mockDeleteRepo).toHaveBeenCalledWith("kata-funcional-alumno1");
-  });
-
-  it("devuelve deleted: 0 si no hay entregas con repo", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregas.mockResolvedValue([]);
-
-    const response = await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
 
     expect(response.status).toBe(200);
-    const data = await response.json();
-    expect(data.ok).toBe(true);
-    expect(data.deleted).toBe(0);
-    expect(mockDeleteRepo).not.toHaveBeenCalled();
+    await expect(response.json()).resolves.toMatchObject({
+      ok: false,
+      deleted: 1,
+      failed: 1,
+    });
   });
 
-  it("llama a getEntregas con el id del assignment correcto", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment({ id: "tp-logico" }));
-    mockGetEntregas.mockResolvedValue([]);
+  it("devuelve un lote vacío sin inventar una operación", async () => {
+    mockBorrarRepositorios.mockResolvedValue(
+      result({
+        operationId: null,
+        attempted: 0,
+        deleted: 0,
+      })
+    );
 
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: "tp-logico" }) });
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
 
-    expect(mockGetEntregas).toHaveBeenCalledWith("tp-logico");
+    await expect(response.json()).resolves.toMatchObject({
+      operationId: null,
+      attempted: 0,
+    });
   });
 
-  it("limpia los repos de las entregas en la DB tras borrarlos en GitHub", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment({ id: "a1" }));
-    mockGetEntregas.mockResolvedValue([makeEntrega("kata-funcional-alumno1")]);
+  it("devuelve 500 para fallos previos al procesamiento", async () => {
+    mockGetAssignment.mockRejectedValue(new Error("DB caída"));
 
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
 
-    expect(mockClearReposDeAssignment).toHaveBeenCalledWith("a1");
-  });
-
-  it("no llama a clearReposDeAssignment si no hay repos que borrar", async () => {
-    mockGetAssignment.mockResolvedValue(makeAssignment());
-    mockGetEntregas.mockResolvedValue([makeEntrega(undefined)]);
-
-    await DELETE(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
-
-    expect(mockClearReposDeAssignment).not.toHaveBeenCalled();
+    expect(response.status).toBe(500);
   });
 });

--- a/src/app/api/assignments/[id]/repos/route.test.ts
+++ b/src/app/api/assignments/[id]/repos/route.test.ts
@@ -4,6 +4,7 @@ import type { PdepUser } from "@/types";
 const mockGetCurrentUser = vi.fn();
 const mockGetAssignment = vi.fn();
 const mockBorrarRepositorios = vi.fn();
+const mockConLock = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getCurrentUser: () => mockGetCurrentUser(),
@@ -11,6 +12,10 @@ vi.mock("@/lib/session", () => ({
 
 vi.mock("@/lib/repositories", () => ({
   getAssignment: (id: string) => mockGetAssignment(id),
+  conLockBorradoReposAssignment: (
+    assignmentId: string,
+    operation: () => Promise<unknown>
+  ) => mockConLock(assignmentId, operation),
 }));
 
 vi.mock("@/lib/services/borrarRepositoriosDeAssignment", () => ({
@@ -53,6 +58,10 @@ describe("DELETE /api/assignments/[id]/repos", () => {
     mockGetCurrentUser.mockResolvedValue(admin());
     mockGetAssignment.mockResolvedValue({ id: "a1" });
     mockBorrarRepositorios.mockResolvedValue(result());
+    mockConLock.mockImplementation(
+      async (_assignmentId: string, operation: () => Promise<unknown>) =>
+        operation()
+    );
   });
 
   it.each([
@@ -87,6 +96,7 @@ describe("DELETE /api/assignments/[id]/repos", () => {
       assignmentId: "a1",
       requestedBy: "docente",
     });
+    expect(mockConLock).toHaveBeenCalledWith("a1", expect.any(Function));
   });
 
   it("devuelve 200 con el resumen de éxito", async () => {
@@ -142,5 +152,20 @@ describe("DELETE /api/assignments/[id]/repos", () => {
     });
 
     expect(response.status).toBe(500);
+  });
+
+  it("devuelve un 500 genérico si falla el borrado", async () => {
+    mockBorrarRepositorios.mockRejectedValue(
+      new Error("GitHub devolvió información interna")
+    );
+
+    const response = await DELETE(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(body).toEqual({ error: "Error interno del servidor" });
+    expect(JSON.stringify(body)).not.toContain("información interna");
   });
 });

--- a/src/app/api/assignments/[id]/repos/route.ts
+++ b/src/app/api/assignments/[id]/repos/route.ts
@@ -1,27 +1,34 @@
 import { NextResponse } from "next/server";
-import { guardAdmin } from "@/lib/api-auth";
-import { getAssignment, getEntregas, clearReposDeAssignment } from "@/lib/repositories";
-import { deleteRepo } from "@/lib/github";
+import { getCurrentUser } from "@/lib/session";
+import { getAssignment } from "@/lib/repositories";
+import { borrarRepositoriosDeAssignment } from "@/lib/services/borrarRepositoriosDeAssignment";
+import { internalServerError } from "@/lib/api-errors";
 
 export async function DELETE(_req: Request, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
-  const unauthorized = await guardAdmin();
-  if (unauthorized) return unauthorized;
+  try {
+    const user = await getCurrentUser();
+    if (!user?.isAdmin) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
 
-  const assignment = await getAssignment(params.id);
-  if (!assignment) {
-    return NextResponse.json({ error: "Assignment no encontrado" }, { status: 404 });
+    const assignment = await getAssignment(params.id);
+    if (!assignment) {
+      return NextResponse.json(
+        { error: "Assignment no encontrado" },
+        { status: 404 }
+      );
+    }
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: params.id,
+      requestedBy: user.githubUsername,
+    });
+
+    return NextResponse.json(result);
+  } catch (error) {
+    return internalServerError("DELETE /api/assignments/[id]/repos", error, {
+      assignmentId: params.id,
+    });
   }
-
-  const entregas = await getEntregas(params.id);
-  const repoNames = entregas.map((entrega) => entrega.repoName).filter(Boolean) as string[];
-
-  if (repoNames.length === 0) {
-    return NextResponse.json({ ok: true, deleted: 0 });
-  }
-
-  await Promise.all(repoNames.map((name) => deleteRepo(name)));
-  await clearReposDeAssignment(params.id);
-
-  return NextResponse.json({ ok: true, deleted: repoNames.length });
 }

--- a/src/app/api/assignments/[id]/repos/route.ts
+++ b/src/app/api/assignments/[id]/repos/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from "next/server";
 import { getCurrentUser } from "@/lib/session";
-import { getAssignment } from "@/lib/repositories";
+import {
+  conLockBorradoReposAssignment,
+  getAssignment,
+} from "@/lib/repositories";
 import { borrarRepositoriosDeAssignment } from "@/lib/services/borrarRepositoriosDeAssignment";
 import { internalServerError } from "@/lib/api-errors";
 
@@ -20,10 +23,12 @@ export async function DELETE(_req: Request, props: { params: Promise<{ id: strin
       );
     }
 
-    const result = await borrarRepositoriosDeAssignment({
-      assignmentId: params.id,
-      requestedBy: user.githubUsername,
-    });
+    const result = await conLockBorradoReposAssignment(params.id, () =>
+      borrarRepositoriosDeAssignment({
+        assignmentId: params.id,
+        requestedBy: user.githubUsername,
+      })
+    );
 
     return NextResponse.json(result);
   } catch (error) {

--- a/src/domain/entities/RepoDeletionAttempt.ts
+++ b/src/domain/entities/RepoDeletionAttempt.ts
@@ -1,0 +1,64 @@
+import {
+  Entity,
+  Enum,
+  Index,
+  PrimaryKey,
+  Property,
+} from "@mikro-orm/core";
+import { randomUUID } from "node:crypto";
+
+export type RepoDeletionStatus =
+  | "pending"
+  | "deleted"
+  | "already_absent"
+  | "failed";
+
+@Entity({ tableName: "repo_deletion_attempt" })
+@Index({
+  name: "repo_deletion_attempt_assignment_started_idx",
+  properties: ["assignmentId", "startedAt"],
+})
+@Index({
+  name: "repo_deletion_attempt_operation_idx",
+  properties: ["operationId"],
+})
+@Index({
+  name: "repo_deletion_attempt_entrega_started_idx",
+  properties: ["entregaId", "startedAt"],
+})
+export class RepoDeletionAttempt {
+  @PrimaryKey({ type: "uuid" })
+  id: string = randomUUID();
+
+  @Property({ type: "uuid" })
+  operationId!: string;
+
+  // Se conservan como IDs escalares, sin FK, para que el historial sobreviva
+  // al borrado posterior del assignment o de la entrega.
+  @Property({ type: "uuid" })
+  assignmentId!: string;
+
+  @Property({ type: "uuid" })
+  entregaId!: string;
+
+  @Property({ type: "string" })
+  repoName!: string;
+
+  @Property({ type: "string" })
+  requestedBy!: string;
+
+  @Enum({
+    items: ["pending", "deleted", "already_absent", "failed"],
+    default: "pending",
+  })
+  status: RepoDeletionStatus = "pending";
+
+  @Property({ type: "datetime" })
+  startedAt: Date = new Date();
+
+  @Property({ type: "datetime", nullable: true })
+  completedAt?: Date;
+
+  @Property({ type: "text", nullable: true })
+  error?: string;
+}

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -24,3 +24,7 @@ export {
   AssignmentNoGrupalError,
 } from "./Grupo";
 export { Entrega } from "./Entrega";
+export {
+  RepoDeletionAttempt,
+  type RepoDeletionStatus,
+} from "./RepoDeletionAttempt";

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,0 +1,47 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mockDelete = vi.fn();
+
+vi.mock("@octokit/rest", () => ({
+  Octokit: class {
+    repos = { delete: mockDelete };
+  },
+}));
+
+vi.mock("@octokit/auth-app", () => ({ createAppAuth: vi.fn() }));
+
+import { deleteRepo } from "./github";
+
+function requestError(status: number, message: string) {
+  return Object.assign(new Error(message), { status });
+}
+
+describe("deleteRepo", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("devuelve deleted cuando GitHub elimina el repositorio", async () => {
+    mockDelete.mockResolvedValue(undefined);
+
+    await expect(deleteRepo("tp-ana")).resolves.toBe("deleted");
+    expect(mockDelete).toHaveBeenCalledWith({
+      owner: expect.any(String),
+      repo: "tp-ana",
+    });
+  });
+
+  it("trata un 404 como éxito idempotente", async () => {
+    mockDelete.mockRejectedValue(requestError(404, "Not Found"));
+
+    await expect(deleteRepo("tp-ausente")).resolves.toBe("already_absent");
+  });
+
+  it("propaga errores distintos de 404", async () => {
+    mockDelete.mockRejectedValue(requestError(403, "Forbidden"));
+
+    await expect(deleteRepo("tp-prohibido")).rejects.toThrow(
+      "permisos suficientes"
+    );
+  });
+});

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -173,12 +173,15 @@ export async function listarReposDeAssignment(
 
 // ── Eliminar un repo ─────────────────────────────────────────
 
-export async function deleteRepo(repoName: string): Promise<void> {
+export type DeleteRepoResult = "deleted" | "already_absent";
+
+export async function deleteRepo(repoName: string): Promise<DeleteRepoResult> {
   const octokit = getOctokit();
   try {
     await octokit.repos.delete({ owner: ORG, repo: repoName });
+    return "deleted";
   } catch (error) {
-    if (isRequestError(error) && error.status === 404) return;
+    if (isRequestError(error) && error.status === 404) return "already_absent";
     handleOctokitError(error);
   }
 }

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -93,6 +93,25 @@ describe("migrations", () => {
     expect(migration).toContain("hay nombres y paradigmas duplicados");
   });
 
+  it("crea una auditoría durable para cada intento de borrado de repos", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260814140000_repo_deletion_audit.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('create table "repo_deletion_attempt"');
+    expect(migration).toContain('"operation_id" uuid not null');
+    expect(migration).toContain("'pending', 'deleted', 'already_absent', 'failed'");
+    expect(migration).toContain(
+      'repo_deletion_attempt_assignment_started_idx'
+    );
+    expect(migration).not.toContain("foreign key");
+  });
+
   it("mantiene el snapshot alineado con Google Groups y las cascadas", () => {
     const snapshot = JSON.parse(
       readFileSync(
@@ -107,6 +126,9 @@ describe("migrations", () => {
     const grupo = snapshot.tables.find((table) => table.name === "grupo");
     const grupoAlumnos = snapshot.tables.find(
       (table) => table.name === "grupo_alumnos"
+    );
+    const repoDeletionAttempt = snapshot.tables.find(
+      (table) => table.name === "repo_deletion_attempt"
     );
 
     expect(alumno?.columns.google_group_emails_pendientes_baja).toMatchObject({
@@ -141,5 +163,8 @@ describe("migrations", () => {
     expect(grupoAlumnos?.foreignKeys).toHaveProperty(
       "grupo_alumnos_grupo_assignment_foreign"
     );
+    expect(repoDeletionAttempt?.columns).toHaveProperty("operation_id");
+    expect(repoDeletionAttempt?.columns).toHaveProperty("requested_by");
+    expect(repoDeletionAttempt?.foreignKeys).toEqual({});
   });
 });

--- a/src/lib/orm.test.ts
+++ b/src/lib/orm.test.ts
@@ -24,11 +24,29 @@ describe("ORM metadata", () => {
       "GrupalAssignment",
       "Grupo",
       "Entrega",
+      "RepoDeletionAttempt",
     ];
 
     for (const name of entities) {
       expect(meta.has(name), `entidad '${name}' no encontrada`).toBe(true);
     }
+
+    await orm.close(true);
+  });
+
+  it("modela la auditoría de borrados sin FKs destructivas", async () => {
+    const orm = await MikroORM.init({ ...testConfig, connect: false });
+    const audit = orm.getMetadata().get("RepoDeletionAttempt");
+
+    expect(audit.tableName).toBe("repo_deletion_attempt");
+    expect(audit.properties.status.enum).toBe(true);
+    expect(audit.properties.status.items).toEqual([
+      "pending",
+      "deleted",
+      "already_absent",
+      "failed",
+    ]);
+    expect(audit.relations).toHaveLength(0);
 
     await orm.close(true);
   });

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -154,13 +154,13 @@ describe("EntregaRepository", () => {
   it("devuelve solo entregas activas que conservan repoName", async () => {
     const activa = new Entrega();
     activa.repoName = "tp-ana";
-    const sinRepo = new Entrega();
-    mockEm.find.mockResolvedValue([activa, sinRepo]);
+    mockEm.find.mockResolvedValue([activa]);
 
     await expect(getEntregasConRepoActivo("a1")).resolves.toEqual([activa]);
     expect(mockEm.find).toHaveBeenCalledWith(Entrega, {
       assignment: { id: "a1" },
       repoDeleted: false,
+      repoName: { $ne: null },
     });
   });
 });

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -17,6 +17,7 @@ import { Alumno, Assignment, Entrega, Grupo } from "@/domain/entities";
 import {
   createEntrega,
   createOrGetEntrega,
+  getEntregasConRepoActivo,
   getEntregaLogica,
 } from "./EntregaRepository";
 
@@ -148,5 +149,18 @@ describe("EntregaRepository", () => {
         alumnoId: "alumno-1",
       })
     ).resolves.toBe(existing);
+  });
+
+  it("devuelve solo entregas activas que conservan repoName", async () => {
+    const activa = new Entrega();
+    activa.repoName = "tp-ana";
+    const sinRepo = new Entrega();
+    mockEm.find.mockResolvedValue([activa, sinRepo]);
+
+    await expect(getEntregasConRepoActivo("a1")).resolves.toEqual([activa]);
+    expect(mockEm.find).toHaveBeenCalledWith(Entrega, {
+      assignment: { id: "a1" },
+      repoDeleted: false,
+    });
   });
 });

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -104,11 +104,11 @@ export async function getEntregasConRepoActivo(
   assignmentId: string
 ): Promise<Entrega[]> {
   const entityManager = await getEM();
-  const entregas = await entityManager.find(Entrega, {
+  return entityManager.find(Entrega, {
     assignment: { id: assignmentId },
     repoDeleted: false,
+    repoName: { $ne: null },
   });
-  return entregas.filter((entrega) => Boolean(entrega.repoName));
 }
 
 export async function createEntrega(data: {

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -100,13 +100,15 @@ export async function getActiveRepoCountsByAssignment(): Promise<Map<string, num
   return map;
 }
 
-export async function clearReposDeAssignment(assignmentId: string): Promise<void> {
+export async function getEntregasConRepoActivo(
+  assignmentId: string
+): Promise<Entrega[]> {
   const entityManager = await getEM();
-  const entregas = await entityManager.find(Entrega, { assignment: { id: assignmentId } });
-  for (const entrega of entregas) {
-    entrega.repoDeleted = true;
-  }
-  await entityManager.flush();
+  const entregas = await entityManager.find(Entrega, {
+    assignment: { id: assignmentId },
+    repoDeleted: false,
+  });
+  return entregas.filter((entrega) => Boolean(entrega.repoName));
 }
 
 export async function createEntrega(data: {

--- a/src/lib/repositories/RepoDeletionAttemptRepository.test.ts
+++ b/src/lib/repositories/RepoDeletionAttemptRepository.test.ts
@@ -4,7 +4,9 @@ import { QueryOrder } from "@mikro-orm/core";
 const mockTx = {
   findOneOrFail: vi.fn(),
   flush: vi.fn(),
+  getConnection: vi.fn(),
 };
+const mockExecute = vi.fn();
 
 const mockEm = {
   persist: vi.fn(),
@@ -23,6 +25,7 @@ vi.mock("@/lib/db", () => ({
 
 import { Entrega, RepoDeletionAttempt } from "@/domain/entities";
 import {
+  conLockBorradoReposAssignment,
   completarIntentoBorradoRepo,
   fallarIntentoBorradoRepo,
   getRepoDeletionHistory,
@@ -34,9 +37,41 @@ describe("RepoDeletionAttemptRepository", () => {
     vi.clearAllMocks();
     mockEm.flush.mockResolvedValue(undefined);
     mockTx.flush.mockResolvedValue(undefined);
+    mockTx.getConnection.mockReturnValue({ execute: mockExecute });
     mockEm.transactional.mockImplementation(
       async (callback: (transaction: typeof mockTx) => unknown) => callback(mockTx)
     );
+  });
+
+  it("mantiene un lock transaccional durante la operación de un assignment", async () => {
+    mockExecute.mockResolvedValue(undefined);
+    const operation = vi.fn(async () => "resultado");
+
+    await expect(
+      conLockBorradoReposAssignment("a1", operation)
+    ).resolves.toBe("resultado");
+
+    expect(mockExecute).toHaveBeenCalledWith(
+      "select pg_advisory_xact_lock(hashtextextended(?, 0))",
+      ["repo-deletion:a1"]
+    );
+    expect(mockExecute.mock.invocationCallOrder[0]).toBeLessThan(
+      operation.mock.invocationCallOrder[0]!
+    );
+  });
+
+  it("usa una clave distinta para cada assignment", async () => {
+    mockExecute.mockResolvedValue(undefined);
+
+    await conLockBorradoReposAssignment("a1", async () => undefined);
+    await conLockBorradoReposAssignment("a2", async () => undefined);
+
+    expect(mockExecute).toHaveBeenNthCalledWith(1, expect.any(String), [
+      "repo-deletion:a1",
+    ]);
+    expect(mockExecute).toHaveBeenNthCalledWith(2, expect.any(String), [
+      "repo-deletion:a2",
+    ]);
   });
 
   it("crea un intento pendiente con actor y contexto completo", async () => {

--- a/src/lib/repositories/RepoDeletionAttemptRepository.test.ts
+++ b/src/lib/repositories/RepoDeletionAttemptRepository.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { QueryOrder } from "@mikro-orm/core";
+
+const mockTx = {
+  findOneOrFail: vi.fn(),
+  flush: vi.fn(),
+};
+
+const mockEm = {
+  persist: vi.fn(),
+  flush: vi.fn(),
+  findOneOrFail: vi.fn(),
+  count: vi.fn(),
+  find: vi.fn(),
+  transactional: vi.fn(async (callback: (transaction: typeof mockTx) => unknown) =>
+    callback(mockTx)
+  ),
+};
+
+vi.mock("@/lib/db", () => ({
+  getEM: vi.fn(async () => mockEm),
+}));
+
+import { Entrega, RepoDeletionAttempt } from "@/domain/entities";
+import {
+  completarIntentoBorradoRepo,
+  fallarIntentoBorradoRepo,
+  getRepoDeletionHistory,
+  iniciarIntentoBorradoRepo,
+} from "./RepoDeletionAttemptRepository";
+
+describe("RepoDeletionAttemptRepository", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockEm.flush.mockResolvedValue(undefined);
+    mockTx.flush.mockResolvedValue(undefined);
+    mockEm.transactional.mockImplementation(
+      async (callback: (transaction: typeof mockTx) => unknown) => callback(mockTx)
+    );
+  });
+
+  it("crea un intento pendiente con actor y contexto completo", async () => {
+    const attempt = await iniciarIntentoBorradoRepo({
+      operationId: "00000000-0000-4000-8000-000000000001",
+      assignmentId: "00000000-0000-4000-8000-000000000002",
+      entregaId: "00000000-0000-4000-8000-000000000003",
+      repoName: "tp-ana",
+      requestedBy: "docente",
+    });
+
+    expect(attempt).toMatchObject({
+      repoName: "tp-ana",
+      requestedBy: "docente",
+      status: "pending",
+    });
+    expect(mockEm.persist).toHaveBeenCalledWith(attempt);
+    expect(mockEm.flush).toHaveBeenCalled();
+  });
+
+  it.each(["deleted", "already_absent"] as const)(
+    "finaliza %s y marca la entrega como borrada en una transacción",
+    async (status) => {
+      const attempt = new RepoDeletionAttempt();
+      const entrega = new Entrega();
+      entrega.repoDeleted = false;
+      mockTx.findOneOrFail
+        .mockResolvedValueOnce(attempt)
+        .mockResolvedValueOnce(entrega);
+
+      await completarIntentoBorradoRepo({
+        attemptId: "attempt-1",
+        entregaId: "entrega-1",
+        status,
+      });
+
+      expect(attempt.status).toBe(status);
+      expect(attempt.completedAt).toBeInstanceOf(Date);
+      expect(entrega.repoDeleted).toBe(true);
+      expect(mockTx.flush).toHaveBeenCalled();
+    }
+  );
+
+  it("registra el fallo sin modificar la entrega", async () => {
+    const attempt = new RepoDeletionAttempt();
+    mockEm.findOneOrFail.mockResolvedValue(attempt);
+
+    await fallarIntentoBorradoRepo("attempt-1", "GitHub caído");
+
+    expect(attempt).toMatchObject({
+      status: "failed",
+      error: "GitHub caído",
+    });
+    expect(attempt.completedAt).toBeInstanceOf(Date);
+    expect(mockEm.flush).toHaveBeenCalled();
+  });
+
+  it("pagina el historial, ordena lo más reciente primero y ajusta páginas excedidas", async () => {
+    const attempts = [new RepoDeletionAttempt()];
+    mockEm.count.mockResolvedValue(51);
+    mockEm.find.mockResolvedValue(attempts);
+
+    const page = await getRepoDeletionHistory("a1", 99, 25);
+
+    expect(page).toEqual({
+      items: attempts,
+      page: 3,
+      pageSize: 25,
+      total: 51,
+      totalPages: 3,
+    });
+    expect(mockEm.find).toHaveBeenCalledWith(
+      RepoDeletionAttempt,
+      { assignmentId: "a1" },
+      {
+        orderBy: { startedAt: QueryOrder.DESC, id: QueryOrder.DESC },
+        limit: 25,
+        offset: 50,
+      }
+    );
+  });
+});

--- a/src/lib/repositories/RepoDeletionAttemptRepository.ts
+++ b/src/lib/repositories/RepoDeletionAttemptRepository.ts
@@ -1,0 +1,84 @@
+import { QueryOrder } from "@mikro-orm/core";
+import { getEM } from "@/lib/db";
+import {
+  Entrega,
+  RepoDeletionAttempt,
+  type RepoDeletionStatus,
+} from "@/domain/entities";
+
+export type RepoDeletionHistoryPage = {
+  items: RepoDeletionAttempt[];
+  page: number;
+  pageSize: number;
+  total: number;
+  totalPages: number;
+};
+
+export async function iniciarIntentoBorradoRepo(data: {
+  operationId: string;
+  assignmentId: string;
+  entregaId: string;
+  repoName: string;
+  requestedBy: string;
+}): Promise<RepoDeletionAttempt> {
+  const entityManager = await getEM();
+  const attempt = new RepoDeletionAttempt();
+  Object.assign(attempt, data);
+  entityManager.persist(attempt);
+  await entityManager.flush();
+  return attempt;
+}
+
+export async function completarIntentoBorradoRepo(data: {
+  attemptId: string;
+  entregaId: string;
+  status: Exclude<RepoDeletionStatus, "pending" | "failed">;
+}): Promise<void> {
+  const entityManager = await getEM();
+  await entityManager.transactional(async (transaction) => {
+    const [attempt, entrega] = await Promise.all([
+      transaction.findOneOrFail(RepoDeletionAttempt, { id: data.attemptId }),
+      transaction.findOneOrFail(Entrega, { id: data.entregaId }),
+    ]);
+    attempt.status = data.status;
+    attempt.completedAt = new Date();
+    attempt.error = undefined;
+    entrega.repoDeleted = true;
+    await transaction.flush();
+  });
+}
+
+export async function fallarIntentoBorradoRepo(
+  attemptId: string,
+  error: string
+): Promise<void> {
+  const entityManager = await getEM();
+  const attempt = await entityManager.findOneOrFail(RepoDeletionAttempt, {
+    id: attemptId,
+  });
+  attempt.status = "failed";
+  attempt.completedAt = new Date();
+  attempt.error = error;
+  await entityManager.flush();
+}
+
+export async function getRepoDeletionHistory(
+  assignmentId: string,
+  requestedPage: number,
+  pageSize = 25
+): Promise<RepoDeletionHistoryPage> {
+  const entityManager = await getEM();
+  const total = await entityManager.count(RepoDeletionAttempt, { assignmentId });
+  const totalPages = Math.max(1, Math.ceil(total / pageSize));
+  const page = Math.min(Math.max(1, requestedPage), totalPages);
+  const items = await entityManager.find(
+    RepoDeletionAttempt,
+    { assignmentId },
+    {
+      orderBy: { startedAt: QueryOrder.DESC, id: QueryOrder.DESC },
+      limit: pageSize,
+      offset: (page - 1) * pageSize,
+    }
+  );
+  return { items, page, pageSize, total, totalPages };
+}

--- a/src/lib/repositories/RepoDeletionAttemptRepository.ts
+++ b/src/lib/repositories/RepoDeletionAttemptRepository.ts
@@ -14,6 +14,20 @@ export type RepoDeletionHistoryPage = {
   totalPages: number;
 };
 
+export async function conLockBorradoReposAssignment<T>(
+  assignmentId: string,
+  operation: () => Promise<T>
+): Promise<T> {
+  const entityManager = await getEM();
+  return entityManager.transactional(async (transaction) => {
+    await transaction.getConnection().execute(
+      "select pg_advisory_xact_lock(hashtextextended(?, 0))",
+      [`repo-deletion:${assignmentId}`]
+    );
+    return operation();
+  });
+}
+
 export async function iniciarIntentoBorradoRepo(data: {
   operationId: string;
   assignmentId: string;

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -39,10 +39,18 @@ export {
   getEntregaLogica,
   getEntregaCountsByAssignment,
   getActiveRepoCountsByAssignment,
+  getEntregasConRepoActivo,
   createEntrega,
   createOrGetEntrega,
-  clearReposDeAssignment,
 } from "./EntregaRepository";
+
+export {
+  iniciarIntentoBorradoRepo,
+  completarIntentoBorradoRepo,
+  fallarIntentoBorradoRepo,
+  getRepoDeletionHistory,
+  type RepoDeletionHistoryPage,
+} from "./RepoDeletionAttemptRepository";
 
 export {
   getGrupos,

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -49,6 +49,7 @@ export {
   completarIntentoBorradoRepo,
   fallarIntentoBorradoRepo,
   getRepoDeletionHistory,
+  conLockBorradoReposAssignment,
   type RepoDeletionHistoryPage,
 } from "./RepoDeletionAttemptRepository";
 

--- a/src/lib/services/borrarRepositoriosDeAssignment.test.ts
+++ b/src/lib/services/borrarRepositoriosDeAssignment.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { Entrega } from "@/domain/entities";
 
+const { mockLoggerError } = vi.hoisted(() => ({
+  mockLoggerError: vi.fn(),
+}));
+
 const mockDeleteRepo = vi.fn();
 const mockGetActive = vi.fn();
 const mockStart = vi.fn();
@@ -20,7 +24,7 @@ vi.mock("@/lib/repositories", () => ({
 }));
 
 vi.mock("@/lib/logger", () => ({
-  logger: { info: vi.fn(), error: vi.fn() },
+  logger: { info: vi.fn(), error: mockLoggerError },
 }));
 
 import { borrarRepositoriosDeAssignment } from "./borrarRepositoriosDeAssignment";
@@ -127,6 +131,26 @@ describe("borrarRepositoriosDeAssignment", () => {
     );
   });
 
+  it("redacta credenciales presentadas como Bearer", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockDeleteRepo.mockRejectedValue(
+      new Error("GitHub rechazó Bearer secreto123")
+    );
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result.results[0]?.error).toBe(
+      "GitHub rechazó Bearer [REDACTED]"
+    );
+    expect(mockFail).toHaveBeenCalledWith(
+      expect.any(String),
+      "GitHub rechazó Bearer [REDACTED]"
+    );
+  });
+
   it("no toca GitHub si no puede iniciar la auditoría", async () => {
     mockGetActive.mockResolvedValue([entrega(1)]);
     mockStart.mockRejectedValue(new Error("DB caída"));
@@ -140,7 +164,7 @@ describe("borrarRepositoriosDeAssignment", () => {
     expect(mockDeleteRepo).not.toHaveBeenCalled();
   });
 
-  it("reporta un resultado incierto si GitHub respondió pero falla la persistencia", async () => {
+  it("marca el intento como fallido si GitHub respondió pero falla la persistencia", async () => {
     mockGetActive.mockResolvedValue([entrega(1)]);
     mockComplete.mockRejectedValue(new Error("DB caída"));
 
@@ -153,7 +177,30 @@ describe("borrarRepositoriosDeAssignment", () => {
       status: "failed",
       error: expect.stringContaining("no se pudo guardar"),
     });
-    expect(mockFail).not.toHaveBeenCalled();
+    expect(mockFail).toHaveBeenCalledWith(
+      expect.any(String),
+      "GitHub respondió, pero no se pudo guardar el resultado. Reintentá."
+    );
+  });
+
+  it("conserva la respuesta fallida si tampoco puede cerrar el intento", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockComplete.mockRejectedValue(new Error("DB caída"));
+    mockFail.mockRejectedValue(new Error("DB sigue caída"));
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result.results[0]).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("no se pudo guardar"),
+    });
+    expect(mockLoggerError).toHaveBeenCalledWith(
+      expect.objectContaining({ err: expect.any(Error) }),
+      "No se pudo cerrar como fallido el intento de borrado"
+    );
   });
 
   it("un reintento converge cuando GitHub informa que el repo ya no existe", async () => {

--- a/src/lib/services/borrarRepositoriosDeAssignment.test.ts
+++ b/src/lib/services/borrarRepositoriosDeAssignment.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Entrega } from "@/domain/entities";
+
+const mockDeleteRepo = vi.fn();
+const mockGetActive = vi.fn();
+const mockStart = vi.fn();
+const mockComplete = vi.fn();
+const mockFail = vi.fn();
+
+vi.mock("@/lib/github", () => ({
+  deleteRepo: (repoName: string) => mockDeleteRepo(repoName),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  getEntregasConRepoActivo: (assignmentId: string) => mockGetActive(assignmentId),
+  iniciarIntentoBorradoRepo: (data: unknown) => mockStart(data),
+  completarIntentoBorradoRepo: (data: unknown) => mockComplete(data),
+  fallarIntentoBorradoRepo: (attemptId: string, error: string) =>
+    mockFail(attemptId, error),
+}));
+
+vi.mock("@/lib/logger", () => ({
+  logger: { info: vi.fn(), error: vi.fn() },
+}));
+
+import { borrarRepositoriosDeAssignment } from "./borrarRepositoriosDeAssignment";
+
+function entrega(index: number): Entrega {
+  const item = new Entrega();
+  item.id = `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`;
+  item.repoName = `tp-alumno-${index}`;
+  item.repoUrl = `https://github.com/org/tp-alumno-${index}`;
+  return item;
+}
+
+describe("borrarRepositoriosDeAssignment", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActive.mockResolvedValue([]);
+    mockStart.mockImplementation(async (data: { entregaId: string }) => ({
+      id: `attempt-${data.entregaId}`,
+    }));
+    mockDeleteRepo.mockResolvedValue("deleted");
+    mockComplete.mockResolvedValue(undefined);
+    mockFail.mockResolvedValue(undefined);
+  });
+
+  it("devuelve un resultado vacío sin crear una operación", async () => {
+    await expect(
+      borrarRepositoriosDeAssignment({
+        assignmentId: "a1",
+        requestedBy: "docente",
+      })
+    ).resolves.toEqual({
+      ok: true,
+      operationId: null,
+      attempted: 0,
+      deleted: 0,
+      alreadyAbsent: 0,
+      failed: 0,
+      results: [],
+    });
+  });
+
+  it("registra cada intento antes de borrar y resume los éxitos", async () => {
+    const entregas = [entrega(1), entrega(2)];
+    mockGetActive.mockResolvedValue(entregas);
+    mockDeleteRepo
+      .mockResolvedValueOnce("deleted")
+      .mockResolvedValueOnce("already_absent");
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      attempted: 2,
+      deleted: 1,
+      alreadyAbsent: 1,
+      failed: 0,
+    });
+    expect(mockStart).toHaveBeenCalledTimes(2);
+    expect(mockStart.mock.invocationCallOrder[0]).toBeLessThan(
+      mockDeleteRepo.mock.invocationCallOrder[0]!
+    );
+    expect(mockComplete).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "already_absent" })
+    );
+  });
+
+  it("persiste el fallo y deja el repo disponible para reintento", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockDeleteRepo.mockRejectedValue(new Error("GitHub no disponible"));
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result).toMatchObject({ ok: false, failed: 1, deleted: 0 });
+    expect(mockFail).toHaveBeenCalledWith(
+      expect.any(String),
+      "GitHub no disponible"
+    );
+    expect(mockComplete).not.toHaveBeenCalled();
+  });
+
+  it("redacta credenciales antes de persistirlas o devolverlas", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockDeleteRepo.mockRejectedValue(
+      new Error("GitHub rechazó token=github_pat_secreto123")
+    );
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result.results[0]?.error).toBe(
+      "GitHub rechazó token=[REDACTED]"
+    );
+    expect(mockFail).toHaveBeenCalledWith(
+      expect.any(String),
+      "GitHub rechazó token=[REDACTED]"
+    );
+  });
+
+  it("no toca GitHub si no puede iniciar la auditoría", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockStart.mockRejectedValue(new Error("DB caída"));
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result.failed).toBe(1);
+    expect(mockDeleteRepo).not.toHaveBeenCalled();
+  });
+
+  it("reporta un resultado incierto si GitHub respondió pero falla la persistencia", async () => {
+    mockGetActive.mockResolvedValue([entrega(1)]);
+    mockComplete.mockRejectedValue(new Error("DB caída"));
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result.results[0]).toMatchObject({
+      status: "failed",
+      error: expect.stringContaining("no se pudo guardar"),
+    });
+    expect(mockFail).not.toHaveBeenCalled();
+  });
+
+  it("un reintento converge cuando GitHub informa que el repo ya no existe", async () => {
+    const item = entrega(1);
+    mockGetActive
+      .mockResolvedValueOnce([item])
+      .mockResolvedValueOnce([item]);
+    mockDeleteRepo
+      .mockRejectedValueOnce(new Error("timeout"))
+      .mockResolvedValueOnce("already_absent");
+
+    const first = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+    const retry = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(first.failed).toBe(1);
+    expect(retry).toMatchObject({ ok: true, alreadyAbsent: 1, failed: 0 });
+  });
+
+  it("limita a cinco los borrados simultáneos", async () => {
+    mockGetActive.mockResolvedValue(
+      Array.from({ length: 12 }, (_, index) => entrega(index + 1))
+    );
+    let active = 0;
+    let maxActive = 0;
+    mockDeleteRepo.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      active -= 1;
+      return "deleted";
+    });
+
+    const result = await borrarRepositoriosDeAssignment({
+      assignmentId: "a1",
+      requestedBy: "docente",
+    });
+
+    expect(result).toMatchObject({ ok: true, deleted: 12 });
+    expect(maxActive).toBe(5);
+  });
+});

--- a/src/lib/services/borrarRepositoriosDeAssignment.ts
+++ b/src/lib/services/borrarRepositoriosDeAssignment.ts
@@ -33,6 +33,7 @@ function mensajeOperativo(error: unknown): string {
   const message = error instanceof Error ? error.message : "Error desconocido";
   return message
     .replace(/\b(?:github_pat|gh[pousr])_[A-Za-z0-9_]+\b/g, "[REDACTED]")
+    .replace(/\bBearer\s+\S+/gi, "Bearer [REDACTED]")
     .replace(
       /\b(authorization|token|password|cookie)(\s*[:=]\s*)\S+/gi,
       "$1$2[REDACTED]"
@@ -120,15 +121,25 @@ async function borrarRepositorio(data: {
       status: githubResult,
     });
   } catch (error) {
+    const persistenceError =
+      "GitHub respondió, pero no se pudo guardar el resultado. Reintentá.";
     logger.error(
       { err: error, attemptId, operationId, assignmentId, repoName, requestedBy, githubResult },
       "GitHub respondió al borrado, pero no se pudo persistir el resultado"
     );
+    try {
+      await fallarIntentoBorradoRepo(attemptId, persistenceError);
+    } catch (auditError) {
+      logger.error(
+        { err: auditError, attemptId, operationId, assignmentId, repoName },
+        "No se pudo cerrar como fallido el intento de borrado"
+      );
+    }
     return {
       entregaId: entrega.id,
       repoName,
       status: "failed",
-      error: "GitHub respondió, pero no se pudo guardar el resultado. Reintentá.",
+      error: persistenceError,
     };
   }
 

--- a/src/lib/services/borrarRepositoriosDeAssignment.ts
+++ b/src/lib/services/borrarRepositoriosDeAssignment.ts
@@ -1,0 +1,180 @@
+import { randomUUID } from "node:crypto";
+import { deleteRepo, type DeleteRepoResult } from "@/lib/github";
+import { logger } from "@/lib/logger";
+import {
+  completarIntentoBorradoRepo,
+  fallarIntentoBorradoRepo,
+  getEntregasConRepoActivo,
+  iniciarIntentoBorradoRepo,
+} from "@/lib/repositories";
+import type { Entrega } from "@/domain/entities";
+
+const MAX_CONCURRENT_DELETIONS = 5;
+const MAX_ERROR_LENGTH = 1000;
+
+export type RepoDeletionItemResult = {
+  entregaId: string;
+  repoName: string;
+  status: "deleted" | "already_absent" | "failed";
+  error?: string;
+};
+
+export type DeleteAssignmentReposResult = {
+  ok: boolean;
+  operationId: string | null;
+  attempted: number;
+  deleted: number;
+  alreadyAbsent: number;
+  failed: number;
+  results: RepoDeletionItemResult[];
+};
+
+function mensajeOperativo(error: unknown): string {
+  const message = error instanceof Error ? error.message : "Error desconocido";
+  return message
+    .replace(/\b(?:github_pat|gh[pousr])_[A-Za-z0-9_]+\b/g, "[REDACTED]")
+    .replace(
+      /\b(authorization|token|password|cookie)(\s*[:=]\s*)\S+/gi,
+      "$1$2[REDACTED]"
+    )
+    .slice(0, MAX_ERROR_LENGTH);
+}
+
+async function mapConConcurrenciaLimitada<T, R>(
+  items: T[],
+  limit: number,
+  operation: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const index = nextIndex++;
+      results[index] = await operation(items[index]!);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, () => worker())
+  );
+  return results;
+}
+
+async function borrarRepositorio(data: {
+  entrega: Entrega;
+  assignmentId: string;
+  operationId: string;
+  requestedBy: string;
+}): Promise<RepoDeletionItemResult> {
+  const { entrega, assignmentId, operationId, requestedBy } = data;
+  const repoName = entrega.repoName!;
+  let attemptId: string;
+
+  try {
+    const attempt = await iniciarIntentoBorradoRepo({
+      operationId,
+      assignmentId,
+      entregaId: entrega.id,
+      repoName,
+      requestedBy,
+    });
+    attemptId = attempt.id;
+  } catch (error) {
+    logger.error(
+      { err: error, operationId, assignmentId, entregaId: entrega.id, repoName, requestedBy },
+      "No se pudo iniciar la auditoría de borrado del repositorio"
+    );
+    return {
+      entregaId: entrega.id,
+      repoName,
+      status: "failed",
+      error: "No se pudo registrar el inicio del borrado. Reintentá.",
+    };
+  }
+
+  let githubResult: DeleteRepoResult;
+  try {
+    githubResult = await deleteRepo(repoName);
+  } catch (error) {
+    const message = mensajeOperativo(error);
+    try {
+      await fallarIntentoBorradoRepo(attemptId, message);
+    } catch (auditError) {
+      logger.error(
+        { err: auditError, attemptId, operationId, assignmentId, repoName },
+        "No se pudo persistir el fallo del borrado"
+      );
+    }
+    logger.error(
+      { err: error, attemptId, operationId, assignmentId, repoName, requestedBy },
+      "Falló el borrado del repositorio"
+    );
+    return { entregaId: entrega.id, repoName, status: "failed", error: message };
+  }
+
+  try {
+    await completarIntentoBorradoRepo({
+      attemptId,
+      entregaId: entrega.id,
+      status: githubResult,
+    });
+  } catch (error) {
+    logger.error(
+      { err: error, attemptId, operationId, assignmentId, repoName, requestedBy, githubResult },
+      "GitHub respondió al borrado, pero no se pudo persistir el resultado"
+    );
+    return {
+      entregaId: entrega.id,
+      repoName,
+      status: "failed",
+      error: "GitHub respondió, pero no se pudo guardar el resultado. Reintentá.",
+    };
+  }
+
+  logger.info(
+    { attemptId, operationId, assignmentId, repoName, requestedBy, status: githubResult },
+    "Borrado de repositorio registrado"
+  );
+  return { entregaId: entrega.id, repoName, status: githubResult };
+}
+
+export async function borrarRepositoriosDeAssignment(data: {
+  assignmentId: string;
+  requestedBy: string;
+}): Promise<DeleteAssignmentReposResult> {
+  const entregas = await getEntregasConRepoActivo(data.assignmentId);
+  if (entregas.length === 0) {
+    return {
+      ok: true,
+      operationId: null,
+      attempted: 0,
+      deleted: 0,
+      alreadyAbsent: 0,
+      failed: 0,
+      results: [],
+    };
+  }
+
+  const operationId = randomUUID();
+  const results = await mapConConcurrenciaLimitada(
+    entregas,
+    MAX_CONCURRENT_DELETIONS,
+    (entrega) => borrarRepositorio({ ...data, entrega, operationId })
+  );
+  const deleted = results.filter((result) => result.status === "deleted").length;
+  const alreadyAbsent = results.filter(
+    (result) => result.status === "already_absent"
+  ).length;
+  const failed = results.filter((result) => result.status === "failed").length;
+
+  return {
+    ok: failed === 0,
+    operationId,
+    attempted: results.length,
+    deleted,
+    alreadyAbsent,
+    failed,
+    results,
+  };
+}

--- a/tests/migrations/repo-deletion-audit.integration.test.ts
+++ b/tests/migrations/repo-deletion-audit.integration.test.ts
@@ -1,0 +1,122 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import ormConfig from "../../mikro-orm.config";
+
+const PREVIOUS_MIGRATION =
+  "Migration20260813190000_group_membership_invariants";
+const AUDIT_MIGRATION = "Migration20260814140000_repo_deletion_audit";
+
+function getSafeTestDatabaseUrl(): string {
+  const value = process.env.MIGRATION_TEST_DATABASE_URL;
+  if (!value) {
+    throw new Error(
+      "MIGRATION_TEST_DATABASE_URL es obligatoria para ejecutar pruebas de migraciones"
+    );
+  }
+  const url = new URL(value);
+  const databaseName = url.pathname.slice(1);
+  if (!databaseName.endsWith("_test")) {
+    throw new Error("La base de migraciones debe terminar en _test");
+  }
+  return value;
+}
+
+async function resetPublicSchema(orm: MikroORM): Promise<void> {
+  const connection = orm.em.getConnection();
+  await connection.execute('drop schema if exists "public" cascade');
+  await connection.execute('create schema "public"');
+}
+
+describe("Migration20260814140000_repo_deletion_audit", () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      ...ormConfig,
+      clientUrl: getSafeTestDatabaseUrl(),
+      debug: false,
+      migrations: { ...ormConfig.migrations, snapshot: false },
+    });
+    await resetPublicSchema(orm);
+    await orm.getMigrator().up({ to: PREVIOUS_MIGRATION });
+  });
+
+  afterAll(async () => {
+    if (!orm) return;
+    await resetPublicSchema(orm);
+    await orm.close(true);
+  });
+
+  it("persiste la auditoría aunque luego se borren assignment y entrega", async () => {
+    const connection = orm.em.getConnection();
+    const comisionId = randomUUID();
+    const assignmentId = randomUUID();
+    const entregaId = randomUUID();
+    const attemptId = randomUUID();
+    const operationId = randomUUID();
+
+    await connection.execute(
+      `insert into "comision"
+        ("id", "anio", "spreadsheet_id", "activa", "column_config")
+       values (?, 2026, ?, false, '{}'::jsonb)`,
+      [comisionId, `sheet-${comisionId}`]
+    );
+    await connection.execute(
+      `insert into "assignment"
+        ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+         "created_at", "comision_id", "inscripciones_cerradas")
+       values (?, 'TP auditado', ?, 'org/template', 'funcional', 'individual',
+         now(), ?, false)`,
+      [assignmentId, `tp-${assignmentId}`, comisionId]
+    );
+    await connection.execute(
+      `insert into "entrega"
+        ("id", "assignment_id", "github_usernames", "repo_name", "repo_url",
+         "created_at", "repo_deleted")
+       values (?, ?, '{}', 'tp-auditado', 'https://github.com/org/tp-auditado',
+         now(), false)`,
+      [entregaId, assignmentId]
+    );
+
+    await orm.getMigrator().up({ to: AUDIT_MIGRATION });
+    await connection.execute(
+      `insert into "repo_deletion_attempt"
+        ("id", "operation_id", "assignment_id", "entrega_id", "repo_name",
+         "requested_by", "status", "started_at")
+       values (?, ?, ?, ?, 'tp-auditado', 'docente', 'pending', now())`,
+      [attemptId, operationId, assignmentId, entregaId]
+    );
+
+    await expect(
+      connection.execute(
+        `update "repo_deletion_attempt" set "status" = 'desconocido' where "id" = ?`,
+        [attemptId]
+      )
+    ).rejects.toThrow();
+
+    await connection.execute('delete from "assignment" where "id" = ?', [
+      assignmentId,
+    ]);
+    const rows = await connection.execute<
+      { assignment_id: string; entrega_id: string; status: string }[]
+    >(
+      `select "assignment_id", "entrega_id", "status"
+         from "repo_deletion_attempt" where "id" = ?`,
+      [attemptId]
+    );
+    expect(rows).toEqual([
+      { assignment_id: assignmentId, entrega_id: entregaId, status: "pending" },
+    ]);
+
+    const { up } = await orm.getSchemaGenerator().getUpdateSchemaMigrationSQL();
+    expect(up).not.toContain('"repo_deletion_attempt"');
+
+    await orm.getMigrator().down({ migrations: [AUDIT_MIGRATION] });
+    const tables = await connection.execute<{ table_name: string }[]>(
+      `select table_name from information_schema.tables
+        where table_schema = 'public' and table_name = 'repo_deletion_attempt'`
+    );
+    expect(tables).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Resumen

- registra cada intento de borrado antes de modificar GitHub y persiste resultados por repositorio
- trata 404 como éxito idempotente, limita la concurrencia a cinco y permite reintentar solo los fallidos
- devuelve un resumen detallado al administrador y agrega un historial paginado por assignment
- incorpora una migración durable sin foreign keys destructivas

## Validación

- pnpm test:run: 1006 tests pasaron
- pnpm test:migrations: 12 pruebas PostgreSQL pasaron
- pnpm exec tsc --noEmit: pasó
- pnpm build: pasó
- pnpm lint: sin errores, 10 warnings preexistentes
- git diff --check: pasó

Closes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funciones**
  * La eliminación de repositorios ahora muestra resultados detallados, incluidos éxitos, repositorios ya inexistentes y fallos.
  * Se permite reintentar eliminaciones fallidas.
  * El detalle de cada asignación incluye un historial paginado de eliminaciones, con fechas, administrador, estado y errores.

* **Correcciones**
  * Se consideran únicamente los repositorios activos al calcular los totales.
  * Las respuestas de repositorios inexistentes se tratan como eliminaciones completadas sin error.

* **Auditoría**
  * Se conserva un registro de cada intento de eliminación para facilitar el seguimiento y la revisión de errores.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->