### PR TITLE
Usar nombres legibles en repositorios grupales

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,7 +406,12 @@ Una vez en producción, entrar como admin y crear al menos una comisión activa 
 
 Los repos se crean con la convención:
 - Individual: `{slug}-{github-username}` → `kata-funcional-juangarcia`
-- Grupal: `{slug}-{grupo-id}` → `tp-funcional-los-lambdas`
+- Grupal: `{slug}-{nombre-grupo-normalizado}` → `tp-funcional-los-lambdas`
+
+El nombre grupal se normaliza a minúsculas, sin acentos y con guiones en
+lugar de espacios o caracteres especiales. Por ejemplo, `Los Lógicos ++`
+genera `los-logicos`. Dos nombres del mismo assignment que generen el mismo
+identificador se consideran duplicados.
 
 ## Estructura del proyecto
 

--- a/migrations/.snapshot-pdep_classroom.json
+++ b/migrations/.snapshot-pdep_classroom.json
@@ -1101,6 +1101,22 @@
           "enumItems": [],
           "mappedType": "string"
         },
+        "nombre_normalizado": {
+          "name": "nombre_normalizado",
+          "type": "varchar(255)",
+          "unsigned": false,
+          "autoincrement": false,
+          "primary": false,
+          "nullable": false,
+          "unique": false,
+          "length": 255,
+          "precision": null,
+          "scale": null,
+          "default": null,
+          "comment": null,
+          "enumItems": [],
+          "mappedType": "string"
+        },
         "assignment_id": {
           "name": "assignment_id",
           "type": "uuid",
@@ -1145,12 +1161,11 @@
         {
           "columnNames": [
             "assignment_id",
-            "nombre",
-            "paradigma"
+            "nombre_normalizado"
           ],
           "composite": true,
           "constraint": true,
-          "keyName": "grupo_assignment_nombre_paradigma_unique_idx",
+          "keyName": "grupo_assignment_nombre_normalizado_unique_idx",
           "unique": true,
           "primary": false
         }

--- a/migrations/Migration20260814160000_group_repo_name.ts
+++ b/migrations/Migration20260814160000_group_repo_name.ts
@@ -1,0 +1,68 @@
+import { Migration } from "@mikro-orm/migrations";
+
+function normalizarNombreGrupoHistorico(nombre: string): string {
+  return nombre
+    .trim()
+    .toLowerCase()
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
+export class Migration20260814160000_group_repo_name extends Migration {
+  override async up(): Promise<void> {
+    await this.execute(
+      'alter table "grupo" add column "nombre_normalizado" varchar(255) null;'
+    );
+
+    const grupos = (await this.execute(
+      'select "id", "nombre" from "grupo"'
+    )) as { id: string; nombre: string }[];
+
+    for (const grupo of grupos) {
+      const nombreNormalizado = normalizarNombreGrupoHistorico(grupo.nombre);
+      if (!nombreNormalizado) {
+        throw new Error(
+          `No se puede normalizar el nombre del grupo ${grupo.id}: no contiene letras ni números.`
+        );
+      }
+      await this.execute(
+        'update "grupo" set "nombre_normalizado" = ? where "id" = ?',
+        [nombreNormalizado, grupo.id]
+      );
+    }
+
+    const colisiones = (await this.execute(`
+      select "assignment_id", "nombre_normalizado"
+      from "grupo"
+      group by "assignment_id", "nombre_normalizado"
+      having count(*) > 1
+    `)) as { assignment_id: string; nombre_normalizado: string }[];
+    if (colisiones.length > 0) {
+      throw new Error(
+        "No se puede garantizar la unicidad normalizada de grupos: hay nombres que generan el mismo identificador dentro de un assignment."
+      );
+    }
+
+    await this.execute(
+      'alter table "grupo" alter column "nombre_normalizado" set not null;'
+    );
+    await this.execute(
+      'alter table "grupo" drop constraint "grupo_assignment_nombre_paradigma_unique_idx";'
+    );
+    await this.execute(
+      'alter table "grupo" add constraint "grupo_assignment_nombre_normalizado_unique_idx" unique ("assignment_id", "nombre_normalizado");'
+    );
+  }
+
+  override async down(): Promise<void> {
+    await this.execute(
+      'alter table "grupo" drop constraint "grupo_assignment_nombre_normalizado_unique_idx";'
+    );
+    await this.execute(
+      'alter table "grupo" add constraint "grupo_assignment_nombre_paradigma_unique_idx" unique ("assignment_id", "nombre", "paradigma");'
+    );
+    await this.execute('alter table "grupo" drop column "nombre_normalizado";');
+  }
+}

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -145,6 +145,7 @@ function makeGrupo(overrides?: Partial<Grupo>): Grupo {
   const grupo = new Grupo();
   grupo.id = "g1";
   grupo.nombre = "Grupo 1";
+  grupo.nombreNormalizado = "grupo-1";
   grupo.paradigma = "objetos";
   grupo.maxIntegrantes = 3;
   grupo.creadoPor = "usuario1";

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import { Entrega, GrupoNoAsignadoError } from "@/domain/entities";
 import { AccesoAssignmentProhibidoError } from "@/lib/services/assignmentAuthorization";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 
 const {
   mockGetCurrentUser,
@@ -158,6 +159,22 @@ describe("POST /api/assignments/[id]/accept", () => {
     mockAceptarAssignment.mockRejectedValue(new FakeAlumnoNoRegistradoError("Completá tu registro"));
     const response = await POST(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
     expect(response.status).toBe(400);
+  });
+
+  it("devuelve 400 si el nombre completo del repositorio supera el límite", async () => {
+    mockAceptarAssignment.mockRejectedValue(
+      new NombreRepositorioDemasiadoLargoError("a".repeat(101))
+    );
+
+    const response = await POST(makeRequest(), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "El nombre del repositorio generado supera el límite de 100 caracteres de GitHub.",
+    });
   });
 
   it("devuelve 401 si no hay sesión", async () => {

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -3,6 +3,7 @@ import { getCurrentUser } from "@/lib/session";
 import { GrupoNoAsignadoError } from "@/domain/entities";
 import { checkRateLimit } from "@/lib/rate-limit";
 import { internalServerError } from "@/lib/api-errors";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 import {
   aceptarAssignment,
   AlumnoNoRegistradoError,
@@ -34,7 +35,11 @@ export async function POST(_req: Request, props: { params: Promise<{ id: string 
     if (error instanceof AccesoAssignmentProhibidoError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
     }
-    if (error instanceof GrupoNoAsignadoError || error instanceof AlumnoNoRegistradoError) {
+    if (
+      error instanceof GrupoNoAsignadoError ||
+      error instanceof AlumnoNoRegistradoError ||
+      error instanceof NombreRepositorioDemasiadoLargoError
+    ) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
     return internalServerError(

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -9,6 +9,7 @@ import {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
+  NombreGrupoInvalidoError,
 } from "@/domain/entities";
 
 // ── Mocks ────────────────────────────────────────────────────
@@ -230,7 +231,21 @@ describe("POST /api/assignments/[id]/grupos", () => {
 
     expect(response.status).toBe(409);
     await expect(response.json()).resolves.toEqual({
-      error: 'Ya existe un grupo llamado "Los Lambdas" para este TP.',
+      error:
+        'Ya existe un grupo con el mismo nombre o identificador normalizado que "Los Lambdas" para este TP.',
+    });
+  });
+
+  it("devuelve 400 si el nombre no genera un identificador válido", async () => {
+    mockCrearGrupo.mockRejectedValue(new NombreGrupoInvalidoError("+++"));
+
+    const response = await POST(makeRequest({ nombre: "+++" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error: "El nombre del grupo debe incluir al menos una letra o un número.",
     });
   });
 

--- a/src/app/api/assignments/[id]/grupos/route.test.ts
+++ b/src/app/api/assignments/[id]/grupos/route.test.ts
@@ -11,6 +11,7 @@ import {
   NombreGrupoDuplicadoError,
   NombreGrupoInvalidoError,
 } from "@/domain/entities";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 
 // ── Mocks ────────────────────────────────────────────────────
 
@@ -246,6 +247,22 @@ describe("POST /api/assignments/[id]/grupos", () => {
     expect(response.status).toBe(400);
     await expect(response.json()).resolves.toEqual({
       error: "El nombre del grupo debe incluir al menos una letra o un número.",
+    });
+  });
+
+  it("devuelve 400 si el nombre completo del repositorio supera el límite", async () => {
+    mockCrearGrupo.mockRejectedValue(
+      new NombreRepositorioDemasiadoLargoError("a".repeat(101))
+    );
+
+    const response = await POST(makeRequest({ nombre: "Los Lambdas" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({
+      error:
+        "El nombre del repositorio generado supera el límite de 100 caracteres de GitHub.",
     });
   });
 

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -15,6 +15,7 @@ import {
   NombreGrupoInvalidoError,
 } from "@/domain/entities";
 import { internalServerError } from "@/lib/api-errors";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 import type { Grupo } from "@/domain/entities";
 import {
   AccesoAssignmentProhibidoError,
@@ -130,7 +131,10 @@ export async function POST(req: Request, props: { params: Promise<{ id: string }
     if (error instanceof NombreGrupoDuplicadoError) {
       return NextResponse.json({ error: error.message }, { status: 409 });
     }
-    if (error instanceof NombreGrupoInvalidoError) {
+    if (
+      error instanceof NombreGrupoInvalidoError ||
+      error instanceof NombreRepositorioDemasiadoLargoError
+    ) {
       return NextResponse.json({ error: error.message }, { status: 400 });
     }
     return internalServerError("POST /api/assignments/[id]/grupos", error, {

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -12,6 +12,7 @@ import {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
+  NombreGrupoInvalidoError,
 } from "@/domain/entities";
 import { internalServerError } from "@/lib/api-errors";
 import type { Grupo } from "@/domain/entities";
@@ -22,7 +23,7 @@ import {
 } from "@/lib/services/assignmentAuthorization";
 
 const CrearGrupoSchema = z.object({
-  nombre: z.string().min(1).max(100),
+  nombre: z.string().trim().min(1).max(100),
 });
 
 function serializarGrupo(grupo: Grupo) {
@@ -128,6 +129,9 @@ export async function POST(req: Request, props: { params: Promise<{ id: string }
     }
     if (error instanceof NombreGrupoDuplicadoError) {
       return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    if (error instanceof NombreGrupoInvalidoError) {
+      return NextResponse.json({ error: error.message }, { status: 400 });
     }
     return internalServerError("POST /api/assignments/[id]/grupos", error, {
       assignmentId: params.id,

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -12,6 +12,7 @@ function fakeAlumno(github: string): Alumno {
 function fakeGrupo(id: string, usernames: string[]): Grupo {
   return {
     id,
+    nombreNormalizado: `nombre-${id}`,
     alumnos: { getItems: () => usernames.map(fakeAlumno) },
     usernamesDeMiembros: () => usernames,
     usernamesCanonicos: () => usernames.map(Alumno.normalizarUsername),
@@ -110,13 +111,17 @@ describe("GrupalAssignment", () => {
     expect(getAlumnos).not.toHaveBeenCalled();
   });
 
-  it("resolverParticipantesPara devuelve los usernames del grupo y su id", async () => {
+  it("resolverParticipantesPara devuelve miembros, id y nombre normalizado", async () => {
     const grupal = nuevoGrupal();
     const buscar = vi.fn().mockResolvedValue(
       fakeGrupo("los-lambdas", ["ana", "bob"])
     );
     const participantes = await grupal.resolverParticipantesPara({ githubUsername: "ana" }, buscar);
-    expect(participantes).toEqual({ usernames: ["ana", "bob"], grupoId: "los-lambdas" });
+    expect(participantes).toEqual({
+      usernames: ["ana", "bob"],
+      grupoId: "los-lambdas",
+      grupoNombreNormalizado: "nombre-los-lambdas",
+    });
     expect(buscar).toHaveBeenCalledWith("a1", "ana");
   });
 

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -30,10 +30,17 @@ export type BuscadorDeGrupoDelAlumno = (
   githubUsername: string
 ) => Promise<Grupo | null>;
 
-export interface ParticipantesResueltos {
-  usernames: string[];
-  grupoId?: string;
-}
+export type ParticipantesResueltos =
+  | {
+      usernames: string[];
+      grupoId?: undefined;
+      grupoNombreNormalizado?: undefined;
+    }
+  | {
+      usernames: string[];
+      grupoId: string;
+      grupoNombreNormalizado: string;
+    };
 
 // Single Table Inheritance: todos los assignments en una sola tabla,
 // discriminados por la columna `tipo`

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -62,6 +62,7 @@ export class GrupalAssignment extends Assignment {
     return {
       usernames: grupo.usernamesDeMiembros(),
       grupoId: grupo.id,
+      grupoNombreNormalizado: grupo.nombreNormalizado,
     };
   }
 

--- a/src/domain/entities/Grupo.test.ts
+++ b/src/domain/entities/Grupo.test.ts
@@ -21,6 +21,7 @@ function nuevoGrupo(maxIntegrantes: number, miembros: Alumno[] = []): Grupo {
   const grupo = new Grupo();
   grupo.id = "g1";
   grupo.nombre = "Los Lambdas";
+  grupo.nombreNormalizado = "los-lambdas";
   grupo.paradigma = "funcional";
   grupo.maxIntegrantes = maxIntegrantes;
   grupo.creadoPor = miembros[0]?.githubUsername ?? "alguien";

--- a/src/domain/entities/Grupo.ts
+++ b/src/domain/entities/Grupo.ts
@@ -39,8 +39,17 @@ export class NombreGrupoDuplicadoError extends Error {
     public readonly assignmentId: string,
     public readonly nombre: string
   ) {
-    super(`Ya existe un grupo llamado "${nombre}" para este TP.`);
+    super(
+      `Ya existe un grupo con el mismo nombre o identificador normalizado que "${nombre}" para este TP.`
+    );
     this.name = "NombreGrupoDuplicadoError";
+  }
+}
+
+export class NombreGrupoInvalidoError extends Error {
+  constructor(public readonly nombre: string) {
+    super("El nombre del grupo debe incluir al menos una letra o un número.");
+    this.name = "NombreGrupoInvalidoError";
   }
 }
 
@@ -67,8 +76,8 @@ export class AssignmentNoGrupalError extends Error {
   properties: ["id", "assignment"],
 })
 @Unique({
-  name: "grupo_assignment_nombre_paradigma_unique_idx",
-  properties: ["assignment", "nombre", "paradigma"],
+  name: "grupo_assignment_nombre_normalizado_unique_idx",
+  properties: ["assignment", "nombreNormalizado"],
 })
 export class Grupo {
   @PrimaryKey({ type: "uuid" })
@@ -76,6 +85,9 @@ export class Grupo {
 
   @Property({ type: 'string' })
   nombre!: string;
+
+  @Property({ type: "string" })
+  nombreNormalizado!: string;
 
   @Enum({ items: ["funcional", "logico", "objetos"] })
   paradigma!: Paradigma;

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -20,6 +20,7 @@ export {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
+  NombreGrupoInvalidoError,
   GrupoLlenoError,
   AssignmentNoGrupalError,
 } from "./Grupo";

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -17,6 +17,7 @@ vi.mock("@octokit/rest", () => ({
 vi.mock("@octokit/auth-app", () => ({ createAppAuth: vi.fn() }));
 
 import { crearEntrega, deleteRepo } from "./github";
+import { NombreRepositorioDemasiadoLargoError } from "./naming";
 
 function requestError(status: number, message: string) {
   return Object.assign(new Error(message), { status });
@@ -81,5 +82,18 @@ describe("crearEntrega", () => {
       expect.objectContaining({ name: "tp-los-lambdas" })
     );
     expect(mockAddCollaborator).toHaveBeenCalledTimes(2);
+  });
+
+  it("rechaza un nombre demasiado largo antes de invocar GitHub", async () => {
+    await expect(
+      crearEntrega({
+        templateRepo: "pdep-mn-utn/template",
+        repoName: "a".repeat(101),
+        usernames: ["ana"],
+      })
+    ).rejects.toBeInstanceOf(NombreRepositorioDemasiadoLargoError);
+
+    expect(mockCreateUsingTemplate).not.toHaveBeenCalled();
+    expect(mockAddCollaborator).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/github.test.ts
+++ b/src/lib/github.test.ts
@@ -1,16 +1,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockDelete = vi.fn();
+const mockCreateUsingTemplate = vi.fn();
+const mockAddCollaborator = vi.fn();
 
 vi.mock("@octokit/rest", () => ({
   Octokit: class {
-    repos = { delete: mockDelete };
+    repos = {
+      delete: mockDelete,
+      createUsingTemplate: mockCreateUsingTemplate,
+      addCollaborator: mockAddCollaborator,
+    };
   },
 }));
 
 vi.mock("@octokit/auth-app", () => ({ createAppAuth: vi.fn() }));
 
-import { deleteRepo } from "./github";
+import { crearEntrega, deleteRepo } from "./github";
 
 function requestError(status: number, message: string) {
   return Object.assign(new Error(message), { status });
@@ -43,5 +49,37 @@ describe("deleteRepo", () => {
     await expect(deleteRepo("tp-prohibido")).rejects.toThrow(
       "permisos suficientes"
     );
+  });
+});
+
+describe("crearEntrega", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("usa sin recalcular el nombre de repositorio recibido", async () => {
+    mockCreateUsingTemplate.mockResolvedValue({
+      data: {
+        html_url: "https://github.com/pdep-mn-utn/tp-los-lambdas",
+        full_name: "pdep-mn-utn/tp-los-lambdas",
+      },
+    });
+    mockAddCollaborator.mockResolvedValue(undefined);
+
+    await expect(
+      crearEntrega({
+        templateRepo: "pdep-mn-utn/template",
+        repoName: "tp-los-lambdas",
+        usernames: ["ana", "bob"],
+      })
+    ).resolves.toEqual({
+      repoName: "tp-los-lambdas",
+      repoUrl: "https://github.com/pdep-mn-utn/tp-los-lambdas",
+    });
+
+    expect(mockCreateUsingTemplate).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "tp-los-lambdas" })
+    );
+    expect(mockAddCollaborator).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { buildRepoName, extractTemplateName } from "./naming";
+import { extractTemplateName } from "./naming";
 import { handleOctokitError, isRequestError } from "./github-errors";
 
 const ORG = process.env.GITHUB_ORG ?? "pdep-mn-utn";
@@ -119,29 +119,22 @@ export async function addCollaborators(
 
 export async function crearEntrega(opts: {
   templateRepo: string;
-  slug: string;
+  repoName: string;
   usernames: string[];
-  grupoId?: string;
   descripcion?: string;
 }): Promise<{ repoUrl: string; repoName: string }> {
-  const repoName = buildRepoName({
-    slug: opts.slug,
-    usernames: opts.usernames,
-    grupoId: opts.grupoId,
-  });
-
   const templateName = extractTemplateName(opts.templateRepo);
 
   const { repoUrl } = await createRepoFromTemplate({
     templateRepo: templateName,
-    newRepoName: repoName,
+    newRepoName: opts.repoName,
     description: opts.descripcion,
     isPrivate: true,
   });
 
-  await addCollaborators(repoName, opts.usernames);
+  await addCollaborators(opts.repoName, opts.usernames);
 
-  return { repoUrl, repoName };
+  return { repoUrl, repoName: opts.repoName };
 }
 
 // ── Listar repos de un assignment ───────────────────────────

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,6 +1,6 @@
 import { Octokit } from "@octokit/rest";
 import { createAppAuth } from "@octokit/auth-app";
-import { extractTemplateName } from "./naming";
+import { extractTemplateName, validarRepoName } from "./naming";
 import { handleOctokitError, isRequestError } from "./github-errors";
 
 const ORG = process.env.GITHUB_ORG ?? "pdep-mn-utn";
@@ -123,18 +123,19 @@ export async function crearEntrega(opts: {
   usernames: string[];
   descripcion?: string;
 }): Promise<{ repoUrl: string; repoName: string }> {
+  const repoName = validarRepoName(opts.repoName);
   const templateName = extractTemplateName(opts.templateRepo);
 
   const { repoUrl } = await createRepoFromTemplate({
     templateRepo: templateName,
-    newRepoName: opts.repoName,
+    newRepoName: repoName,
     description: opts.descripcion,
     isPrivate: true,
   });
 
-  await addCollaborators(opts.repoName, opts.usernames);
+  await addCollaborators(repoName, opts.usernames);
 
-  return { repoUrl, repoName: opts.repoName };
+  return { repoUrl, repoName };
 }
 
 // ── Listar repos de un assignment ───────────────────────────

--- a/src/lib/migrations.test.ts
+++ b/src/lib/migrations.test.ts
@@ -112,6 +112,24 @@ describe("migrations", () => {
     expect(migration).not.toContain("foreign key");
   });
 
+  it("persiste y garantiza el nombre normalizado de cada grupo", () => {
+    const migration = readFileSync(
+      join(
+        process.cwd(),
+        "migrations",
+        "Migration20260814160000_group_repo_name.ts"
+      ),
+      "utf8"
+    );
+
+    expect(migration).toContain('add column "nombre_normalizado"');
+    expect(migration).toContain(
+      'constraint "grupo_assignment_nombre_normalizado_unique_idx"'
+    );
+    expect(migration).toContain("no contiene letras ni números");
+    expect(migration).toContain("hay nombres que generan el mismo identificador");
+  });
+
   it("mantiene el snapshot alineado con Google Groups y las cascadas", () => {
     const snapshot = JSON.parse(
       readFileSync(
@@ -151,9 +169,10 @@ describe("migrations", () => {
     );
     expect(grupo?.indexes).toContainEqual(
       expect.objectContaining({
-        keyName: "grupo_assignment_nombre_paradigma_unique_idx",
+        keyName: "grupo_assignment_nombre_normalizado_unique_idx",
       })
     );
+    expect(grupo?.columns).toHaveProperty("nombre_normalizado");
     expect(grupoAlumnos?.columns).toHaveProperty("assignment_id");
     expect(grupoAlumnos?.indexes).toContainEqual(
       expect.objectContaining({

--- a/src/lib/naming.test.ts
+++ b/src/lib/naming.test.ts
@@ -6,39 +6,26 @@ import { buildRepoName, slugify, extractTemplateName } from "./naming";
 describe("buildRepoName", () => {
   it("individual: slug-username", () => {
     expect(
-      buildRepoName({ slug: "kata-funcional", usernames: ["juangarcia"] })
+      buildRepoName({ slug: "kata-funcional", githubUsername: "juangarcia" })
     ).toBe("kata-funcional-juangarcia");
   });
 
-  it("grupal con grupoId: slug-grupoid", () => {
+  it("grupal con nombre normalizado: slug-nombregrupo", () => {
     expect(
       buildRepoName({
         slug: "tp-funcional",
-        usernames: ["juangarcia", "mariaperez"],
-        grupoId: "los-lambdas",
+        grupoNombreNormalizado: "los-lambdas",
       })
     ).toBe("tp-funcional-los-lambdas");
   });
 
-  it("grupal sin grupoId: slug-usuario1-usuario2-usuario3 (max 3)", () => {
-    expect(
-      buildRepoName({
-        slug: "tp-logico",
-        usernames: ["alice", "bob", "charlie", "diana"],
-      })
-    ).toBe("tp-logico-alice-bob-charlie");
-  });
-
   it("normaliza a lowercase", () => {
     expect(
-      buildRepoName({ slug: "Kata-Funcional", usernames: ["JuanGarcia"] })
+      buildRepoName({
+        slug: "Kata-Funcional",
+        githubUsername: "JuanGarcia",
+      })
     ).toBe("kata-funcional-juangarcia");
-  });
-
-  it("grupal con un solo miembro sin grupoId", () => {
-    expect(
-      buildRepoName({ slug: "tp-objetos", usernames: ["solo"] })
-    ).toBe("tp-objetos-solo");
   });
 });
 
@@ -69,6 +56,10 @@ describe("slugify", () => {
 
   it("string vacío devuelve vacío", () => {
     expect(slugify("")).toBe("");
+  });
+
+  it("solo caracteres no permitidos devuelve vacío", () => {
+    expect(slugify("  +++ /._  ")).toBe("");
   });
 });
 

--- a/src/lib/naming.test.ts
+++ b/src/lib/naming.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { buildRepoName, slugify, extractTemplateName } from "./naming";
+import {
+  buildRepoName,
+  extractTemplateName,
+  GITHUB_REPO_NAME_MAX_LENGTH,
+  NombreRepositorioDemasiadoLargoError,
+  slugify,
+} from "./naming";
 
 // ── buildRepoName ───────────────────────────────────────────
 
@@ -26,6 +32,35 @@ describe("buildRepoName", () => {
         githubUsername: "JuanGarcia",
       })
     ).toBe("kata-funcional-juangarcia");
+  });
+
+  it("acepta el nombre completo cuando tiene exactamente el límite de GitHub", () => {
+    const repoName = buildRepoName({
+      slug: "a".repeat(90),
+      githubUsername: "b".repeat(9),
+    });
+
+    expect(repoName).toHaveLength(GITHUB_REPO_NAME_MAX_LENGTH);
+  });
+
+  it("rechaza el nombre individual completo cuando supera el límite de GitHub", () => {
+    expect(() =>
+      buildRepoName({
+        slug: "a".repeat(91),
+        githubUsername: "b".repeat(9),
+      })
+    ).toThrow(NombreRepositorioDemasiadoLargoError);
+  });
+
+  it("rechaza el nombre grupal completo cuando supera el límite de GitHub", () => {
+    expect(() =>
+      buildRepoName({
+        slug: "a".repeat(90),
+        grupoNombreNormalizado: "b".repeat(10),
+      })
+    ).toThrow(
+      "El nombre del repositorio generado supera el límite de 100 caracteres de GitHub."
+    );
   });
 });
 

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -1,6 +1,24 @@
 // Funciones puras de naming y lógica de negocio.
 // Separadas de github.ts para poder testear sin Octokit.
 
+export const GITHUB_REPO_NAME_MAX_LENGTH = 100;
+
+export class NombreRepositorioDemasiadoLargoError extends Error {
+  constructor(public readonly repoName: string) {
+    super(
+      `El nombre del repositorio generado supera el límite de ${GITHUB_REPO_NAME_MAX_LENGTH} caracteres de GitHub.`
+    );
+    this.name = "NombreRepositorioDemasiadoLargoError";
+  }
+}
+
+export function validarRepoName(repoName: string): string {
+  if (repoName.length > GITHUB_REPO_NAME_MAX_LENGTH) {
+    throw new NombreRepositorioDemasiadoLargoError(repoName);
+  }
+  return repoName;
+}
+
 /**
  * Genera el nombre del repo para una entrega.
  * Individual: `{slug}-{username}`
@@ -16,7 +34,7 @@ export function buildRepoName(
       ? opts.grupoNombreNormalizado
       : opts.githubUsername;
 
-  return `${opts.slug}-${suffix}`.toLowerCase();
+  return validarRepoName(`${opts.slug}-${suffix}`.toLowerCase());
 }
 
 /**

--- a/src/lib/naming.ts
+++ b/src/lib/naming.ts
@@ -4,18 +4,17 @@
 /**
  * Genera el nombre del repo para una entrega.
  * Individual: `{slug}-{username}`
- * Grupal: `{slug}-{grupoId}`
+ * Grupal: `{slug}-{nombreGrupoNormalizado}`
  */
-export function buildRepoName(opts: {
-  slug: string;
-  usernames: string[];
-  grupoId?: string;
-}): string {
-  const suffix = opts.grupoId
-    ? opts.grupoId
-    : opts.usernames.length === 1
-      ? opts.usernames[0]
-      : opts.usernames.slice(0, 3).join("-");
+export function buildRepoName(
+  opts:
+    | { slug: string; githubUsername: string }
+    | { slug: string; grupoNombreNormalizado: string }
+): string {
+  const suffix =
+    "grupoNombreNormalizado" in opts
+      ? opts.grupoNombreNormalizado
+      : opts.githubUsername;
 
   return `${opts.slug}-${suffix}`.toLowerCase();
 }

--- a/src/lib/orm.test.ts
+++ b/src/lib/orm.test.ts
@@ -79,8 +79,8 @@ describe("ORM metadata", () => {
     );
     expect(grupo.uniques).toContainEqual(
       expect.objectContaining({
-        name: "grupo_assignment_nombre_paradigma_unique_idx",
-        properties: ["assignment", "nombre", "paradigma"],
+        name: "grupo_assignment_nombre_normalizado_unique_idx",
+        properties: ["assignment", "nombreNormalizado"],
       })
     );
     expect(config.schemaGenerator?.skipTables).toContain("grupo_alumnos");

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -55,6 +55,7 @@ import {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
+  NombreGrupoInvalidoError,
   GrupoLlenoError,
   AssignmentNoGrupalError,
 } from "@/domain/entities";
@@ -107,6 +108,7 @@ function fakeGrupo(
   const grupo = new Grupo();
   grupo.id = id;
   grupo.nombre = `grupo-${id}`;
+  grupo.nombreNormalizado = `grupo-${id}`;
   grupo.paradigma = assignment.paradigma;
   grupo.assignment = assignment;
   grupo.maxIntegrantes = maxIntegrantes;
@@ -134,7 +136,7 @@ function uniqueMembershipError(): Error {
 function uniqueGroupNameError(): Error {
   return Object.assign(
     new Error(
-      'duplicate key value violates unique constraint "grupo_assignment_nombre_paradigma_unique_idx"'
+      'duplicate key value violates unique constraint "grupo_assignment_nombre_normalizado_unique_idx"'
     ),
     { code: "23505" }
   );
@@ -175,11 +177,12 @@ describe("crearGrupo", () => {
     const grupo = await crearGrupo({
       assignmentId: "a1",
       alumnoId: "alumno-ana",
-      nombre: "Los Lambdas",
+      nombre: "  Los Lógicos ++  ",
       esAdmin: false,
     });
 
-    expect(grupo.nombre).toBe("Los Lambdas");
+    expect(grupo.nombre).toBe("Los Lógicos ++");
+    expect(grupo.nombreNormalizado).toBe("los-logicos");
     expect(grupo.paradigma).toBe("funcional");
     expect(grupo.maxIntegrantes).toBe(3);
     expect(grupo.assignment).toBe(assignment);
@@ -187,6 +190,19 @@ describe("crearGrupo", () => {
     expect(grupo.alumnos.contains(ana)).toBe(true);
     expect(mockTx.persist).toHaveBeenCalledWith(grupo);
     expect(mockTx.flush).toHaveBeenCalled();
+  });
+
+  it("rechaza un nombre que queda vacío después de normalizar", async () => {
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: " +++ ",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(NombreGrupoInvalidoError);
+
+    expect(getEM).not.toHaveBeenCalled();
   });
 
   it("lanza AssignmentNoEncontradoError si el assignment no existe", async () => {
@@ -525,8 +541,7 @@ describe("upsertGrupoConMiembro", () => {
       1,
       Grupo,
       {
-        nombre: grupo.nombre,
-        paradigma: "funcional",
+        nombreNormalizado: grupo.nombreNormalizado,
         assignment: { id: "a1" },
       },
       { lockMode: LockMode.PESSIMISTIC_WRITE }
@@ -603,6 +618,7 @@ describe("upsertGrupoConMiembro", () => {
     const ana = fakeAlumno("alumno-ana", "ana");
     const ganador = fakeGrupo("g-ganador", assignment, []);
     ganador.nombre = "Los Lambdas";
+    ganador.nombreNormalizado = "los-lambdas";
     mockTx.findOne
       .mockResolvedValueOnce(null)
       .mockResolvedValueOnce(null)
@@ -627,6 +643,27 @@ describe("upsertGrupoConMiembro", () => {
       { refresh: true }
     );
     expect(ganador.alumnos.contains(ana)).toBe(true);
+  });
+
+  it("rechaza nombres distintos que generan el mismo identificador", async () => {
+    const assignment = fakeGrupal();
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const existente = fakeGrupo("g1", assignment, []);
+    existente.nombre = "Los Lógicos";
+    existente.nombreNormalizado = "los-logicos";
+    mockTx.findOne.mockResolvedValueOnce(existente);
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: "Los Logicos!",
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toBeInstanceOf(NombreGrupoDuplicadoError);
+
+    expect(mockTx.populate).not.toHaveBeenCalled();
+    expect(mockTx.flush).not.toHaveBeenCalled();
   });
 
   it("devuelve un conflicto explícito si el reintento también colisiona", async () => {

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -66,6 +66,7 @@ import {
   AssignmentNoEncontradoError,
   GrupoNoEncontradoError,
 } from "@/lib/services/assignmentAuthorization";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 
 // ── Helpers ──────────────────────────────────────────────────
 
@@ -91,6 +92,7 @@ function fakeComision(id = "c1"): Comision {
 function fakeGrupal(overrides: Partial<GrupalAssignment> = {}): GrupalAssignment {
   const grupal = new GrupalAssignment();
   grupal.id = "a1";
+  grupal.slug = "tp-funcional";
   grupal.paradigma = "funcional";
   grupal.maxIntegrantes = 3;
   grupal.inscripcionesCerradas = false;
@@ -203,6 +205,24 @@ describe("crearGrupo", () => {
     ).rejects.toBeInstanceOf(NombreGrupoInvalidoError);
 
     expect(getEM).not.toHaveBeenCalled();
+  });
+
+  it("rechaza un nombre que haría superar el límite del repositorio", async () => {
+    mockTx.findOne.mockResolvedValueOnce(
+      fakeGrupal({ slug: "a".repeat(90) })
+    );
+
+    await expect(
+      crearGrupo({
+        assignmentId: "a1",
+        alumnoId: "alumno-ana",
+        nombre: "b".repeat(10),
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(NombreRepositorioDemasiadoLargoError);
+
+    expect(mockTx.findOneOrFail).not.toHaveBeenCalled();
+    expect(mockTx.persist).not.toHaveBeenCalled();
   });
 
   it("lanza AssignmentNoEncontradoError si el assignment no existe", async () => {
@@ -521,6 +541,23 @@ describe("unirseAGrupo", () => {
 });
 
 describe("upsertGrupoConMiembro", () => {
+  it("rechaza antes de persistir un nombre de Sheets que supera el límite del repositorio", async () => {
+    const assignment = fakeGrupal({ slug: "a".repeat(90) });
+    const ana = fakeAlumno("alumno-ana", "ana");
+
+    await expect(
+      upsertGrupoConMiembro({
+        nombreGrupo: "b".repeat(10),
+        paradigma: "funcional",
+        assignment,
+        alumno: ana,
+      })
+    ).rejects.toBeInstanceOf(NombreRepositorioDemasiadoLargoError);
+
+    expect(getEM).not.toHaveBeenCalled();
+    expect(mockTx.persist).not.toHaveBeenCalled();
+  });
+
   it("bloquea el grupo, valida las invariantes y agrega al alumno", async () => {
     const assignment = fakeGrupal();
     const ana = fakeAlumno("alumno-ana", "ana");

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -8,9 +8,11 @@ import {
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
+  NombreGrupoInvalidoError,
   AssignmentNoGrupalError,
 } from "@/domain/entities";
 import type { Paradigma } from "@/types";
+import { slugify } from "@/lib/naming";
 import {
   AssignmentNoEncontradoError,
   GrupoNoEncontradoError,
@@ -21,7 +23,17 @@ import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 const INSCRIPCION_UNICA_CONSTRAINT =
   "grupo_alumnos_assignment_alumno_unique_idx";
 const NOMBRE_GRUPO_UNICO_CONSTRAINT =
-  "grupo_assignment_nombre_paradigma_unique_idx";
+  "grupo_assignment_nombre_normalizado_unique_idx";
+
+function prepararNombreGrupo(nombre: string): {
+  nombre: string;
+  nombreNormalizado: string;
+} {
+  const nombreVisible = nombre.trim();
+  const nombreNormalizado = slugify(nombreVisible);
+  if (!nombreNormalizado) throw new NombreGrupoInvalidoError(nombre);
+  return { nombre: nombreVisible, nombreNormalizado };
+}
 
 function esViolacionDeRestriccionUnica(
   error: unknown,
@@ -137,7 +149,8 @@ export async function crearGrupo(params: {
   nombre: string;
   esAdmin: boolean;
 }): Promise<Grupo> {
-  const { assignmentId, alumnoId, nombre, esAdmin } = params;
+  const { assignmentId, alumnoId, esAdmin } = params;
+  const { nombre, nombreNormalizado } = prepararNombreGrupo(params.nombre);
   const entityManager = await getEM();
 
   return traducirConflictoDeNombreGrupo(assignmentId, nombre, () =>
@@ -182,6 +195,7 @@ export async function crearGrupo(params: {
 
           const grupo = new Grupo();
           grupo.nombre = nombre;
+          grupo.nombreNormalizado = nombreNormalizado;
           grupo.paradigma = assignment.paradigma;
           grupo.assignment = assignment;
           grupo.maxIntegrantes = assignment.maxIntegrantes;
@@ -297,7 +311,10 @@ async function ejecutarUpsertGrupoConMiembro(params: {
   assignment: GrupalAssignment;
   alumno: Alumno;
 }): Promise<Grupo> {
-  const { nombreGrupo, paradigma, assignment, alumno } = params;
+  const { paradigma, assignment, alumno } = params;
+  const { nombre: nombreGrupo, nombreNormalizado } = prepararNombreGrupo(
+    params.nombreGrupo
+  );
   const entityManager = await getEM();
 
   return traducirConflictoDeInscripcion(
@@ -308,8 +325,7 @@ async function ejecutarUpsertGrupoConMiembro(params: {
         const existente = await transaction.findOne(
           Grupo,
           {
-            nombre: nombreGrupo,
-            paradigma,
+            nombreNormalizado,
             assignment: { id: assignment.id },
           },
           { lockMode: LockMode.PESSIMISTIC_WRITE }
@@ -317,11 +333,18 @@ async function ejecutarUpsertGrupoConMiembro(params: {
 
         let grupo: Grupo;
         if (existente) {
+          if (existente.nombre !== nombreGrupo) {
+            throw new NombreGrupoDuplicadoError(
+              assignment.id,
+              nombreGrupo
+            );
+          }
           grupo = existente;
           await transaction.populate(grupo, ["alumnos"], { refresh: true });
         } else {
           grupo = new Grupo();
           grupo.nombre = nombreGrupo;
+          grupo.nombreNormalizado = nombreNormalizado;
           grupo.paradigma = paradigma;
           grupo.assignment = assignment;
           grupo.maxIntegrantes = assignment.maxIntegrantes;

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -12,7 +12,7 @@ import {
   AssignmentNoGrupalError,
 } from "@/domain/entities";
 import type { Paradigma } from "@/types";
-import { slugify } from "@/lib/naming";
+import { buildRepoName, slugify } from "@/lib/naming";
 import {
   AssignmentNoEncontradoError,
   GrupoNoEncontradoError,
@@ -166,6 +166,10 @@ export async function crearGrupo(params: {
       if (!(assignment instanceof GrupalAssignment)) {
         throw new AssignmentNoGrupalError(assignmentId);
       }
+      buildRepoName({
+        slug: assignment.slug,
+        grupoNombreNormalizado: nombreNormalizado,
+      });
 
       const alumno = await transaction.findOneOrFail(
         Alumno,
@@ -315,6 +319,10 @@ async function ejecutarUpsertGrupoConMiembro(params: {
   const { nombre: nombreGrupo, nombreNormalizado } = prepararNombreGrupo(
     params.nombreGrupo
   );
+  buildRepoName({
+    slug: assignment.slug,
+    grupoNombreNormalizado: nombreNormalizado,
+  });
   const entityManager = await getEM();
 
   return traducirConflictoDeInscripcion(

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -41,6 +41,7 @@ import {
   AssignmentNoEncontradoError,
 } from "./aceptarAssignment";
 import { AccesoAssignmentProhibidoError } from "./assignmentAuthorization";
+import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 
 function makeComision(id = "c1"): Comision {
   const comision = new Comision(2026, "sheet-test");
@@ -159,6 +160,25 @@ describe("aceptarAssignment", () => {
         repoName: "kata-funcional-juangarcia",
       })
     );
+  });
+
+  it("rechaza una entrega individual cuyo nombre completo supera el límite", async () => {
+    mockGetAssignment.mockResolvedValue(
+      makeAssignment({ slug: "a".repeat(90) })
+    );
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ githubUsername: "b".repeat(10) })
+    );
+
+    await expect(
+      aceptarAssignment(
+        "a1",
+        makeUser({ githubUsername: "b".repeat(10) })
+      )
+    ).rejects.toBeInstanceOf(NombreRepositorioDemasiadoLargoError);
+
+    expect(mockRepoExists).not.toHaveBeenCalled();
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
   });
 
   it("mantiene el requisito funcional de alumno para un admin que acepta un TP individual", async () => {

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -96,9 +96,14 @@ function makeEntrega(overrides?: Partial<Entrega>): Entrega {
   return Object.assign(entrega, overrides);
 }
 
-function makeGrupo(githubUsernames: string[], id = "los-lambdas") {
+function makeGrupo(
+  githubUsernames: string[],
+  id = "grupo-uuid-1",
+  nombreNormalizado = "los-lambdas"
+) {
   return {
     id,
+    nombreNormalizado,
     usernamesDeMiembros: () => githubUsernames,
   };
 }
@@ -142,7 +147,7 @@ describe("aceptarAssignment", () => {
     expect(mockCrearEntrega).toHaveBeenCalledWith(
       expect.objectContaining({
         templateRepo: "kata-template",
-        slug: "kata-funcional",
+        repoName: "kata-funcional-juangarcia",
         usernames: ["juangarcia"],
       })
     );
@@ -177,11 +182,18 @@ describe("aceptarAssignment", () => {
     await aceptarAssignment("a1", makeUser());
 
     expect(mockGetAlumnoByGithub).toHaveBeenCalledWith("juangarcia");
+    expect(mockCrearEntrega).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoName: "kata-funcional-los-lambdas",
+        usernames: ["juangarcia", "mariaperez"],
+      })
+    );
     expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
       expect.objectContaining({
         assignmentId: "a1",
         alumnoId: undefined,
-        grupoId: "los-lambdas",
+        grupoId: "grupo-uuid-1",
+        repoName: "kata-funcional-los-lambdas",
         githubUsernames: ["juangarcia", "mariaperez"],
       })
     );

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -47,10 +47,21 @@ export async function aceptarAssignment(
     getGrupoDeAlumnoEnAssignment
   );
 
-  const { usernames, grupoId } = participantes;
+  const { usernames, grupoId, grupoNombreNormalizado } = participantes;
   if (!grupoId && !alumno) throw new AlumnoNoRegistradoError(user.githubUsername);
 
-  const repoName = buildRepoName({ slug: assignment.slug, usernames, grupoId });
+  if (grupoId && !grupoNombreNormalizado) {
+    throw new Error(`El grupo ${grupoId} no tiene un nombre normalizado.`);
+  }
+  const repoName = grupoId
+    ? buildRepoName({
+        slug: assignment.slug,
+        grupoNombreNormalizado,
+      })
+    : buildRepoName({
+        slug: assignment.slug,
+        githubUsername: usernames[0]!,
+      });
   const createLocalEntrega = (createdRepoName: string, repoUrl: string) =>
     createOrGetEntrega({
       assignmentId: assignment.id,
@@ -69,9 +80,8 @@ export async function aceptarAssignment(
   try {
     const resultado = await crearEntrega({
       templateRepo: assignment.nombreDelTemplate(),
-      slug: assignment.slug,
+      repoName,
       usernames,
-      grupoId,
       descripcion: `${assignment.titulo} — PdeP`,
     });
     return createLocalEntrega(resultado.repoName, resultado.repoUrl);

--- a/tests/migrations/group-membership-invariants.integration.test.ts
+++ b/tests/migrations/group-membership-invariants.integration.test.ts
@@ -23,6 +23,7 @@ vi.mock("@/lib/db", () => ({
 import {
   AlumnoYaEnGrupoDelAssignmentError,
   GrupoLlenoError,
+  NombreGrupoDuplicadoError,
 } from "../../src/domain/entities";
 import {
   crearGrupo,
@@ -35,6 +36,9 @@ const PREVIOUS_MIGRATION =
   "Migration20260610120000_add_google_group_state_to_alumno";
 const MEMBERSHIP_MIGRATION =
   "Migration20260813190000_group_membership_invariants";
+const GROUP_REPO_NAMING_MIGRATION =
+  "Migration20260814160000_group_repo_name";
+let groupRepoNamingReady = false;
 
 function getSafeTestDatabaseUrl(): string {
   const value = process.env.MIGRATION_TEST_DATABASE_URL;
@@ -113,12 +117,28 @@ async function seedGroups(
   }
 
   for (const [index, grupoId] of grupoIds.entries()) {
-    await connection.execute(
-      `insert into "grupo"
-        ("id", "nombre", "paradigma", "max_integrantes", "creado_por", "assignment_id")
-       values (?, ?, 'funcional', ?, 'test', ?)`,
-      [grupoId, `Grupo ${index}`, options.maxIntegrantes, assignmentId]
-    );
+    if (groupRepoNamingReady) {
+      await connection.execute(
+        `insert into "grupo"
+          ("id", "nombre", "nombre_normalizado", "paradigma",
+           "max_integrantes", "creado_por", "assignment_id")
+         values (?, ?, ?, 'funcional', ?, 'test', ?)`,
+        [
+          grupoId,
+          `Grupo ${index}`,
+          `grupo-${index}`,
+          options.maxIntegrantes,
+          assignmentId,
+        ]
+      );
+    } else {
+      await connection.execute(
+        `insert into "grupo"
+          ("id", "nombre", "paradigma", "max_integrantes", "creado_por", "assignment_id")
+         values (?, ?, 'funcional', ?, 'test', ?)`,
+        [grupoId, `Grupo ${index}`, options.maxIntegrantes, assignmentId]
+      );
+    }
   }
 
   return { comisionId, assignmentId, alumnoIds, grupoIds };
@@ -129,6 +149,7 @@ function expectOneConcurrentConflict(
   ErrorType:
     | typeof AlumnoYaEnGrupoDelAssignmentError
     | typeof GrupoLlenoError
+    | typeof NombreGrupoDuplicadoError
 ): void {
   expect(results.filter((result) => result.status === "fulfilled")).toHaveLength(1);
   const rejected = results.filter(
@@ -270,14 +291,87 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
       'drop constraint "grupo_alumnos_grupo_assignment_foreign"'
     );
     expect(up).not.toContain('drop constraint "grupo_id_assignment_unique"');
-    expect(up).not.toContain(
-      'drop constraint "grupo_assignment_nombre_paradigma_unique_idx"'
-    );
   });
 
   beforeEach(async () => {
     if (!migrationReady) return;
     await orm.em.getConnection().execute('truncate table "comision" cascade');
+  });
+
+  it("rechaza nombres históricos que normalizan a vacío", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 0,
+      grupos: 1,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `update "grupo" set "nombre" = '+++' where "id" = ?`,
+      [seed.grupoIds[0]]
+    );
+
+    await expect(
+      orm.getMigrator().up({ to: GROUP_REPO_NAMING_MIGRATION })
+    ).rejects.toThrow("no contiene letras ni números");
+
+    const columns = await connection.execute<{ column_name: string }[]>(
+      `select column_name from information_schema.columns
+       where table_name = 'grupo' and column_name = 'nombre_normalizado'`
+    );
+    expect(columns).toEqual([]);
+  });
+
+  it("rechaza nombres históricos distintos que generan el mismo identificador", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 0,
+      grupos: 2,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `update "grupo" set "nombre" = case "id"
+         when ? then 'Los Lógicos'
+         else 'los-logicos!'
+       end
+       where "assignment_id" = ?`,
+      [seed.grupoIds[0], seed.assignmentId]
+    );
+
+    await expect(
+      orm.getMigrator().up({ to: GROUP_REPO_NAMING_MIGRATION })
+    ).rejects.toThrow("hay nombres que generan el mismo identificador");
+  });
+
+  it("migra nombres, revierte y deja el schema final alineado", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 0,
+      grupos: 1,
+      maxIntegrantes: 2,
+    });
+    const connection = orm.em.getConnection();
+    await connection.execute(
+      `update "grupo" set "nombre" = 'Los Lógicos ++' where "id" = ?`,
+      [seed.grupoIds[0]]
+    );
+
+    await orm.getMigrator().up({ to: GROUP_REPO_NAMING_MIGRATION });
+    const rows = await connection.execute<{ nombre_normalizado: string }[]>(
+      `select "nombre_normalizado" from "grupo" where "id" = ?`,
+      [seed.grupoIds[0]]
+    );
+    expect(rows).toEqual([{ nombre_normalizado: "los-logicos" }]);
+
+    await orm.getMigrator().down({ migrations: [GROUP_REPO_NAMING_MIGRATION] });
+    const columnsAfterDown = await connection.execute<{ column_name: string }[]>(
+      `select column_name from information_schema.columns
+       where table_name = 'grupo' and column_name = 'nombre_normalizado'`
+    );
+    expect(columnsAfterDown).toEqual([]);
+
+    await orm.getMigrator().up({ to: GROUP_REPO_NAMING_MIGRATION });
+    groupRepoNamingReady = true;
+    const { up } = await orm.getSchemaGenerator().getUpdateSchemaMigrationSQL();
+    expect(up).not.toContain('alter table "grupo"');
   });
 
   it("serializa dos joins que compiten por el último cupo", async () => {
@@ -434,5 +528,33 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
       [seed.assignmentId, seed.assignmentId]
     );
     expect(rows[0]).toEqual({ grupos: "1", membresias: "2" });
+  });
+
+  it("rechaza dos creaciones concurrentes cuyos nombres normalizan igual", async () => {
+    const seed = await seedGroups(orm, {
+      alumnos: 2,
+      grupos: 0,
+      maxIntegrantes: 3,
+    });
+
+    const results = await Promise.allSettled(
+      ["Los Lógicos", "los-logicos!"].map((nombre, index) =>
+        crearGrupo({
+          assignmentId: seed.assignmentId,
+          alumnoId: seed.alumnoIds[index]!,
+          nombre,
+          esAdmin: false,
+        })
+      )
+    );
+
+    expectOneConcurrentConflict(results, NombreGrupoDuplicadoError);
+    const grupos = await orm.em.getConnection().execute<
+      { nombre_normalizado: string }[]
+    >(
+      `select "nombre_normalizado" from "grupo" where "assignment_id" = ?`,
+      [seed.assignmentId]
+    );
+    expect(grupos).toEqual([{ nombre_normalizado: "los-logicos" }]);
   });
 });


### PR DESCRIPTION
## Resumen

- persiste un identificador normalizado y único por assignment para cada grupo
- usa ese identificador en los repositorios grupales en lugar del UUID
- rechaza nombres inválidos y colisiones, incluso bajo concurrencia y sincronización desde Sheets
- agrega una migración transaccional con backfill, rollback y snapshot actualizado
- documenta la nueva convención de nombres

## Validación

- pnpm test:run: 1015 tests pasaron
- pnpm test:migrations: 16 pruebas PostgreSQL pasaron
- pnpm exec tsc --noEmit: pasó
- pnpm build: pasó
- pnpm lint: sin errores, 10 warnings preexistentes
- git diff --check: pasó

Closes #51

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Los repositorios de grupos ahora utilizan nombres normalizados, consistentes y en minúsculas.
  * Se detectan duplicados aunque los nombres visibles difieran por espacios, símbolos o mayúsculas.
  * Los nombres de grupo sin caracteres alfanuméricos se rechazan con un error claro.
  * La creación de repositorios individuales y grupales usa nombres más predecibles.

* **Correcciones**
  * Las solicitudes con nombres de grupo inválidos ahora devuelven una respuesta HTTP 400.
  * Se validan y conservan correctamente los nombres normalizados durante la creación y actualización de grupos.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->