### PR TITLE
Agregar ciclo de vida a los assignments: borrador, publicado, archivado

### DIFF
--- a/migrations/Migration20260814180000_assignment_lifecycle.ts
+++ b/migrations/Migration20260814180000_assignment_lifecycle.ts
@@ -1,0 +1,46 @@
+import { Migration } from "@mikro-orm/migrations";
+
+export class Migration20260814180000_assignment_lifecycle extends Migration {
+  override async up(): Promise<void> {
+    // Nuevas filas nacen en 'borrador'. Los assignments que ya existían antes
+    // de esta migración quedan en 'borrador' por el default y se corrigen
+    // explícitamente a 'publicado' abajo: hoy son visibles para los alumnos,
+    // así que dejar el default los sacaría del flujo activo.
+    this.addSql(`
+      alter table "assignment"
+        add column "estado_nombre" text
+          check ("estado_nombre" in ('borrador', 'publicado', 'archivado'))
+          not null default 'borrador';
+    `);
+
+    this.addSql(`update "assignment" set "estado_nombre" = 'publicado';`);
+
+    this.addSql(`
+      alter table "assignment"
+        add column "publicado_en" timestamptz null,
+        add column "publicado_por" varchar(255) null,
+        add column "archivado_en" timestamptz null,
+        add column "archivado_por" varchar(255) null;
+    `);
+
+    // Auditoría razonable para los assignments preexistentes: no hay usuario
+    // real que los haya publicado, pero sí una fecha de creación conocida.
+    this.addSql(`update "assignment" set "publicado_en" = "created_at";`);
+
+    this.addSql(
+      `create index "assignment_estado_nombre_index" on "assignment" ("estado_nombre");`
+    );
+  }
+
+  override async down(): Promise<void> {
+    this.addSql(`drop index "assignment_estado_nombre_index";`);
+    this.addSql(`
+      alter table "assignment"
+        drop column "estado_nombre",
+        drop column "publicado_en",
+        drop column "publicado_por",
+        drop column "archivado_en",
+        drop column "archivado_por";
+    `);
+  }
+}

--- a/src/app/admin/assignments/[id]/edit/page.tsx
+++ b/src/app/admin/assignments/[id]/edit/page.tsx
@@ -4,6 +4,7 @@ import { listarTemplates } from "@/lib/github";
 import { redirect } from "next/navigation";
 import { AssignmentForm } from "../../assignment-form";
 import { actualizarAssignment } from "../../actions";
+import { EstadoAssignmentBadge } from "@/app/components/EstadoAssignmentBadge";
 export default async function EditAssignmentPage(
   props: {
     params: Promise<{ id: string }>;
@@ -19,7 +20,10 @@ export default async function EditAssignmentPage(
 
   return (
     <div className="max-w-xl">
-      <h1 className="text-2xl font-bold mb-6">Editar Assignment</h1>
+      <div className="flex items-center gap-3 mb-6">
+        <h1 className="text-2xl font-bold">Editar Assignment</h1>
+        <EstadoAssignmentBadge estado={assignment.estadoNombre} />
+      </div>
       <div className="mb-5 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">
         Comisión:{" "}
         <span className="font-medium text-gray-800">
@@ -27,6 +31,8 @@ export default async function EditAssignmentPage(
             ? `${assignment.comision.anio} (${assignment.comision.activa ? "Activa" : "Histórica"})`
             : "Sin comisión"}
         </span>
+        {" · "}
+        El estado se cambia desde el detalle del assignment, no en este formulario.
       </div>
       <AssignmentForm
         action={actualizarAssignment}

--- a/src/app/admin/assignments/[id]/estado-panel.test.tsx
+++ b/src/app/admin/assignments/[id]/estado-panel.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EstadoPanel } from "./estado-panel";
+import type { NombreEstadoAssignment } from "@/types";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockRouterRefresh = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: mockRouterRefresh }),
+}));
+
+function mockFetch(ok: boolean, data: object = {}) {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn().mockResolvedValue({ ok, json: async () => data })
+  );
+}
+
+function makeProps(overrides = {}) {
+  return {
+    assignmentId: "a1",
+    estado: "borrador" as const,
+    accionesDisponibles: ["publicado", "archivado"] as NombreEstadoAssignment[],
+    entregasCount: 0,
+    publicadoEn: null,
+    publicadoPor: null,
+    archivadoEn: null,
+    archivadoPor: null,
+    ...overrides,
+  };
+}
+
+describe("EstadoPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("confirm", vi.fn());
+    mockRouterRefresh.mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("muestra el badge del estado actual", () => {
+    render(<EstadoPanel {...makeProps({ estado: "publicado" })} />);
+    expect(screen.getByTestId("estado-badge")).toHaveTextContent("Publicado");
+  });
+
+  it("renderiza un botón por cada acción disponible", () => {
+    render(
+      <EstadoPanel
+        {...makeProps({ accionesDisponibles: ["publicado", "archivado"] })}
+      />
+    );
+    expect(screen.getByTestId("accion-publicado")).toHaveTextContent("Publicar");
+    expect(screen.getByTestId("accion-archivado")).toHaveTextContent("Archivar");
+  });
+
+  it("no muestra el botón de volver a borrador cuando hay entregas", () => {
+    render(
+      <EstadoPanel
+        {...makeProps({
+          estado: "publicado",
+          accionesDisponibles: ["archivado"],
+          entregasCount: 3,
+        })}
+      />
+    );
+    expect(screen.queryByTestId("accion-borrador")).not.toBeInTheDocument();
+    expect(screen.getByText(/con entregas \(3\)/i)).toBeInTheDocument();
+  });
+
+  it("no llama al endpoint si se cancela la confirmación", async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirm).mockReturnValue(false);
+    mockFetch(true);
+    render(<EstadoPanel {...makeProps()} />);
+
+    await user.click(screen.getByTestId("accion-publicado"));
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it("llama al endpoint con el estado destino al confirmar", async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirm).mockReturnValue(true);
+    mockFetch(true, { estado: "publicado" });
+    render(<EstadoPanel {...makeProps()} />);
+
+    await user.click(screen.getByTestId("accion-publicado"));
+
+    expect(fetch).toHaveBeenCalledWith("/api/assignments/a1/estado", {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ estado: "publicado" }),
+    });
+    await waitFor(() => expect(mockRouterRefresh).toHaveBeenCalled());
+  });
+
+  it("muestra el error si la transición falla (409)", async () => {
+    const user = userEvent.setup();
+    vi.mocked(confirm).mockReturnValue(true);
+    mockFetch(false, { error: "Ya tiene entregas — archivalo en vez de despublicarlo" });
+    render(
+      <EstadoPanel
+        {...makeProps({ estado: "publicado", accionesDisponibles: ["borrador"] })}
+      />
+    );
+
+    await user.click(screen.getByTestId("accion-borrador"));
+
+    expect(
+      await screen.findByText(/archivalo en vez de despublicarlo/)
+    ).toBeInTheDocument();
+  });
+
+  it("muestra la auditoría de publicación y archivado", () => {
+    render(
+      <EstadoPanel
+        {...makeProps({
+          estado: "archivado",
+          accionesDisponibles: ["publicado"],
+          publicadoEn: "2026-03-12T00:00:00.000Z",
+          publicadoPor: "juancete",
+          archivadoEn: "2026-08-01T00:00:00.000Z",
+          archivadoPor: "docente1",
+        })}
+      />
+    );
+    expect(screen.getByText(/@juancete/)).toBeInTheDocument();
+    expect(screen.getByText(/@docente1/)).toBeInTheDocument();
+  });
+});

--- a/src/app/admin/assignments/[id]/estado-panel.test.tsx
+++ b/src/app/admin/assignments/[id]/estado-panel.test.tsx
@@ -133,4 +133,71 @@ describe("EstadoPanel", () => {
     expect(screen.getByText(/@juancete/)).toBeInTheDocument();
     expect(screen.getByText(/@docente1/)).toBeInTheDocument();
   });
+
+  it("formatea la fecha de auditoría en la zona horaria de Argentina, no la del runner", () => {
+    const originalTz = process.env.TZ;
+    process.env.TZ = "UTC";
+    try {
+      // 2026-03-12T00:00:00Z es 2026-03-11 21:00 en Argentina (UTC-3): sin el
+      // timeZone explícito, un runner en UTC mostraría 12/3 en vez de 11/3.
+      render(
+        <EstadoPanel
+          {...makeProps({
+            estado: "publicado",
+            publicadoEn: "2026-03-12T00:00:00.000Z",
+            publicadoPor: "docente1",
+          })}
+        />
+      );
+      expect(screen.getByText(/11\/3\/2026/)).toBeInTheDocument();
+    } finally {
+      process.env.TZ = originalTz;
+    }
+  });
+
+  it("resincroniza estado y acciones cuando cambian las props tras router.refresh()", () => {
+    // El padre real monta <EstadoPanel key={assignment.estadoNombre} .../> —
+    // el test replica esa key para reproducir el remount tras un cambio real
+    // de estado, no un simple rerender con las mismas props "congeladas".
+    const { rerender } = render(
+      <EstadoPanel
+        key="borrador"
+        {...makeProps({ estado: "borrador", accionesDisponibles: ["publicado"] })}
+      />
+    );
+    expect(screen.getByTestId("accion-publicado")).toBeInTheDocument();
+
+    rerender(
+      <EstadoPanel
+        key="publicado"
+        {...makeProps({ estado: "publicado", accionesDisponibles: ["borrador", "archivado"] })}
+      />
+    );
+
+    expect(screen.getByTestId("estado-badge")).toHaveTextContent("Publicado");
+    expect(screen.getByTestId("accion-borrador")).toBeInTheDocument();
+    expect(screen.getByTestId("accion-archivado")).toBeInTheDocument();
+    expect(screen.queryByTestId("accion-publicado")).not.toBeInTheDocument();
+  });
+
+  it("no resincroniza (ni hace falta) si la key no cambia entre renders", () => {
+    const { rerender } = render(
+      <EstadoPanel
+        key="publicado"
+        {...makeProps({ estado: "publicado", accionesDisponibles: ["archivado"] })}
+      />
+    );
+
+    // Mismo componente montado: las props "congeladas" iniciales siguen
+    // siendo las que ve React, tal como pasaría si el padre no cambiara
+    // la key porque el estado real no cambió.
+    rerender(
+      <EstadoPanel
+        key="publicado"
+        {...makeProps({ estado: "publicado", accionesDisponibles: ["archivado"] })}
+      />
+    );
+
+    expect(screen.getByTestId("accion-archivado")).toBeInTheDocument();
+  });
 });

--- a/src/app/admin/assignments/[id]/estado-panel.tsx
+++ b/src/app/admin/assignments/[id]/estado-panel.tsx
@@ -33,6 +33,12 @@ const ACCIONES: Record<
   },
 };
 
+function formatearFechaAuditoria(fecha: string): string {
+  return new Date(fecha).toLocaleDateString("es-AR", {
+    timeZone: "America/Argentina/Buenos_Aires",
+  });
+}
+
 export function EstadoPanel({
   assignmentId,
   estado: initialEstado,
@@ -54,6 +60,12 @@ export function EstadoPanel({
 }) {
   const router = useRouter();
   const { loading, error, call } = useApiCall();
+  // router.refresh() vuelve a ejecutar el Server Component padre, pero como
+  // este panel ya está montado, useState no resincroniza solo con las props
+  // nuevas. En vez de un efecto que dispare un setState extra (cascading
+  // render), el padre monta este componente con `key={estado}`: cuando el
+  // estado real cambia, React lo remonta con las props frescas del servidor
+  // en vez de arrastrar el estado local viejo.
   const [estado, setEstado] = useState(initialEstado);
   const [acciones, setAcciones] = useState(accionesDisponibles);
 
@@ -74,10 +86,10 @@ export function EstadoPanel({
     });
 
     if (resultado) {
+      // Transición inmediata para feedback instantáneo; el efecto de arriba
+      // la reemplaza por los valores reales en cuanto router.refresh() trae
+      // las props actualizadas del servidor.
       setEstado(resultado.estado);
-      // Refleja la única transición desde el nuevo estado que puede
-      // ofrecerse sin volver a consultar al servidor: volver al estado
-      // anterior deja de tener sentido, así que se recalcula al refrescar.
       setAcciones([]);
       router.refresh();
     }
@@ -114,14 +126,14 @@ export function EstadoPanel({
         <p className="text-xs text-gray-400 mt-3">
           {publicadoEn && (
             <>
-              Publicado el {new Date(publicadoEn).toLocaleDateString("es-AR")}
+              Publicado el {formatearFechaAuditoria(publicadoEn)}
               {publicadoPor ? ` por @${publicadoPor}` : ""}
             </>
           )}
           {publicadoEn && archivadoEn && " — "}
           {archivadoEn && (
             <>
-              Archivado el {new Date(archivadoEn).toLocaleDateString("es-AR")}
+              Archivado el {formatearFechaAuditoria(archivadoEn)}
               {archivadoPor ? ` por @${archivadoPor}` : ""}
             </>
           )}

--- a/src/app/admin/assignments/[id]/estado-panel.tsx
+++ b/src/app/admin/assignments/[id]/estado-panel.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { useApiCall } from "@/app/hooks/useApiCall";
+import { EstadoAssignmentBadge } from "@/app/components/EstadoAssignmentBadge";
+import type { NombreEstadoAssignment } from "@/types";
+
+// Config por acción: texto del botón, consecuencia explicada en el confirm()
+// y estilo — dato, no rama de lógica. El destino habilitado por estado ya
+// llega calculado desde el servidor (`transicionesDisponibles`).
+const ACCIONES: Record<
+  NombreEstadoAssignment,
+  { etiquetaBoton: string; confirmacion: string; className: string }
+> = {
+  borrador: {
+    etiquetaBoton: "Volver a borrador",
+    confirmacion:
+      "El TP deja de estar visible para los alumnos. Solo se puede porque todavía no tiene entregas.",
+    className: "bg-gray-600 text-white hover:bg-gray-700",
+  },
+  publicado: {
+    etiquetaBoton: "Publicar",
+    confirmacion:
+      "El TP va a quedar visible para los alumnos de la comisión, que van a poder aceptarlo y crear sus repos.",
+    className: "bg-green-600 text-white hover:bg-green-700",
+  },
+  archivado: {
+    etiquetaBoton: "Archivar",
+    confirmacion:
+      "Los alumnos sin entrega dejan de ver el TP. Los que ya entregaron lo siguen viendo, archivado, con acceso a su repo. No se borran repos ni entregas. Una vez archivado, ya no se puede despublicar.",
+    className: "bg-amber-600 text-white hover:bg-amber-700",
+  },
+};
+
+export function EstadoPanel({
+  assignmentId,
+  estado: initialEstado,
+  accionesDisponibles,
+  entregasCount,
+  publicadoEn,
+  publicadoPor,
+  archivadoEn,
+  archivadoPor,
+}: {
+  assignmentId: string;
+  estado: NombreEstadoAssignment;
+  accionesDisponibles: NombreEstadoAssignment[];
+  entregasCount: number;
+  publicadoEn: string | null;
+  publicadoPor: string | null;
+  archivadoEn: string | null;
+  archivadoPor: string | null;
+}) {
+  const router = useRouter();
+  const { loading, error, call } = useApiCall();
+  const [estado, setEstado] = useState(initialEstado);
+  const [acciones, setAcciones] = useState(accionesDisponibles);
+
+  async function handleTransicion(destino: NombreEstadoAssignment) {
+    if (!confirm(ACCIONES[destino].confirmacion)) return;
+
+    const resultado = await call(async () => {
+      const response = await fetch(`/api/assignments/${assignmentId}/estado`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ estado: destino }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? `Error ${response.status}`);
+      }
+      return (await response.json()) as { estado: NombreEstadoAssignment };
+    });
+
+    if (resultado) {
+      setEstado(resultado.estado);
+      // Refleja la única transición desde el nuevo estado que puede
+      // ofrecerse sin volver a consultar al servidor: volver al estado
+      // anterior deja de tener sentido, así que se recalcula al refrescar.
+      setAcciones([]);
+      router.refresh();
+    }
+  }
+
+  return (
+    <div className="bg-white border border-gray-200 rounded-lg p-6 mb-6">
+      <div className="flex flex-wrap items-center justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <span className="text-sm font-medium text-gray-500">Estado:</span>
+          <EstadoAssignmentBadge estado={estado} />
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          {acciones.map((destino) => (
+            <button
+              key={destino}
+              onClick={() => handleTransicion(destino)}
+              disabled={loading}
+              data-testid={`accion-${destino}`}
+              className={`text-sm px-4 py-2 rounded-lg font-medium transition-colors disabled:opacity-50 disabled:cursor-not-allowed ${ACCIONES[destino].className}`}
+            >
+              {ACCIONES[destino].etiquetaBoton}
+            </button>
+          ))}
+          {estado === "publicado" && !acciones.includes("borrador") && (
+            <span className="text-xs text-gray-500">
+              Con entregas ({entregasCount}) solo se puede archivar.
+            </span>
+          )}
+        </div>
+      </div>
+      {error && <p className="text-sm text-red-600 mt-3">{error}</p>}
+      {(publicadoEn || archivadoEn) && (
+        <p className="text-xs text-gray-400 mt-3">
+          {publicadoEn && (
+            <>
+              Publicado el {new Date(publicadoEn).toLocaleDateString("es-AR")}
+              {publicadoPor ? ` por @${publicadoPor}` : ""}
+            </>
+          )}
+          {publicadoEn && archivadoEn && " — "}
+          {archivadoEn && (
+            <>
+              Archivado el {new Date(archivadoEn).toLocaleDateString("es-AR")}
+              {archivadoPor ? ` por @${archivadoPor}` : ""}
+            </>
+          )}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/app/admin/assignments/[id]/page.test.tsx
+++ b/src/app/admin/assignments/[id]/page.test.tsx
@@ -85,6 +85,28 @@ vi.mock("./grupos-panel", () => ({
   ),
 }));
 
+vi.mock("./estado-panel", () => ({
+  EstadoPanel: ({
+    assignmentId,
+    estado,
+    accionesDisponibles,
+    entregasCount,
+  }: {
+    assignmentId: string;
+    estado: string;
+    accionesDisponibles: string[];
+    entregasCount: number;
+  }) => (
+    <div
+      data-testid="estado-panel"
+      data-assignment={assignmentId}
+      data-estado={estado}
+      data-acciones={accionesDisponibles.join(",")}
+      data-entregas={entregasCount}
+    />
+  ),
+}));
+
 import AssignmentDetailPage from "./page";
 
 // ── Helpers ──────────────────────────────────────────────────
@@ -331,7 +353,9 @@ describe("Admin Assignment Detail Page", () => {
     });
 
     it("calcula correctamente los pendientes para individual", async () => {
-      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      mockGetAssignment.mockResolvedValue(
+        makeIndividualAssignment({ estadoNombre: "publicado" })
+      );
       mockGetEntregas.mockResolvedValue([makeEntrega()]);
       mockGetAlumnos.mockResolvedValue([
         makeAlumno({ id: "al1" }),
@@ -344,7 +368,9 @@ describe("Admin Assignment Detail Page", () => {
     });
 
     it("calcula correctamente los pendientes para grupal", async () => {
-      mockGetAssignment.mockResolvedValue(makeGrupalAssignment());
+      mockGetAssignment.mockResolvedValue(
+        makeGrupalAssignment({ estadoNombre: "publicado" })
+      );
       mockGetEntregas.mockResolvedValue([makeEntrega()]);
       mockGetGruposDeAssignment.mockResolvedValue([
         makeGrupo({ id: "g1" }),
@@ -358,11 +384,59 @@ describe("Admin Assignment Detail Page", () => {
     });
 
     it("no muestra pendientes negativos", async () => {
-      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      mockGetAssignment.mockResolvedValue(
+        makeIndividualAssignment({ estadoNombre: "publicado" })
+      );
       mockGetEntregas.mockResolvedValue([makeEntrega(), makeEntrega({ id: "e2" })]);
       mockGetAlumnos.mockResolvedValue([makeAlumno()]);
       const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
       expect(renderToStaticMarkup(element)).toContain(">0<");
+    });
+
+    it("oculta Pendientes cuando el assignment está en borrador", async () => {
+      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
+      expect(renderToStaticMarkup(element)).not.toContain("Pendientes");
+    });
+
+    it("muestra Pendientes cuando el assignment está publicado", async () => {
+      mockGetAssignment.mockResolvedValue(
+        makeIndividualAssignment({ estadoNombre: "publicado" })
+      );
+      const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
+      expect(renderToStaticMarkup(element)).toContain("Pendientes");
+    });
+  });
+
+  describe("ciclo de vida", () => {
+    it("muestra el badge con el estado del assignment", async () => {
+      mockGetAssignment.mockResolvedValue(
+        makeIndividualAssignment({ estadoNombre: "archivado" })
+      );
+      const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
+      const markup = renderToStaticMarkup(element);
+      expect(markup).toContain('data-testid="estado-badge"');
+      expect(markup).toContain("Archivado");
+    });
+
+    it("pasa las acciones disponibles y el conteo de entregas al panel de estado", async () => {
+      mockGetAssignment.mockResolvedValue(makeIndividualAssignment());
+      mockGetEntregas.mockResolvedValue([makeEntrega()]);
+      const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
+      const markup = renderToStaticMarkup(element);
+      expect(markup).toContain('data-estado="borrador"');
+      expect(markup).toContain('data-acciones="publicado,archivado"');
+      expect(markup).toContain('data-entregas="1"');
+    });
+
+    it("no ofrece volver a borrador cuando el publicado ya tiene entregas", async () => {
+      mockGetAssignment.mockResolvedValue(
+        makeIndividualAssignment({ estadoNombre: "publicado" })
+      );
+      mockGetEntregas.mockResolvedValue([makeEntrega()]);
+      const element = await AssignmentDetailPage({ params: Promise.resolve({ id: "a1" }) });
+      const markup = renderToStaticMarkup(element);
+      expect(markup).toContain('data-acciones="archivado"');
     });
   });
 

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -12,9 +12,11 @@ import { EntregasTable } from "./entregas-table";
 import { DeleteReposButton } from "../delete-repos-button";
 import { GruposPanel } from "./grupos-panel";
 import type { GrupoAdminResumen, AlumnoSinGrupoResumen } from "./grupos-panel";
-import { GrupalAssignment, Alumno } from "@/domain/entities";
+import { GrupalAssignment, Alumno, transicionesDisponibles } from "@/domain/entities";
 import type { Grupo } from "@/domain/entities";
 import { RepoDeletionHistory } from "./repo-deletion-history";
+import { EstadoAssignmentBadge } from "@/app/components/EstadoAssignmentBadge";
+import { EstadoPanel } from "./estado-panel";
 
 export default async function AssignmentDetailPage(
   props: {
@@ -55,6 +57,10 @@ export default async function AssignmentDetailPage(
 
   const aceptadas = entregas.length;
   const pendientes = Math.max(0, total - aceptadas);
+
+  const accionesDeEstado = transicionesDisponibles(assignment.estado, assignment.id, {
+    tieneEntregas: aceptadas > 0,
+  });
 
   const alumnosPorUsername = new Map<string, Alumno>(
     alumnos.map((alumno) => [alumno.usernameCanonico, alumno])
@@ -120,6 +126,7 @@ export default async function AssignmentDetailPage(
             ← Volver
           </Link>
           <h1 className="text-2xl font-bold">{assignment.titulo}</h1>
+          <EstadoAssignmentBadge estado={assignment.estadoNombre} />
         </div>
         <div className="flex items-center gap-3">
           <DeleteReposButton
@@ -138,6 +145,17 @@ export default async function AssignmentDetailPage(
           </Link>
         </div>
       </div>
+
+      <EstadoPanel
+        assignmentId={assignment.id}
+        estado={assignment.estadoNombre}
+        accionesDisponibles={accionesDeEstado}
+        entregasCount={aceptadas}
+        publicadoEn={assignment.publicadoEn?.toISOString() ?? null}
+        publicadoPor={assignment.publicadoPor ?? null}
+        archivadoEn={assignment.archivadoEn?.toISOString() ?? null}
+        archivadoPor={assignment.archivadoPor ?? null}
+      />
 
       {/* Metadata del assignment */}
       <div className="bg-white border border-gray-200 rounded-lg p-6 mb-6">
@@ -163,16 +181,22 @@ export default async function AssignmentDetailPage(
         </p>
       </div>
 
-      {/* Contadores */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      {/* Contadores: "Pendientes" no aplica a un borrador, todavía no aceptable. */}
+      <div
+        className={`grid gap-4 mb-6 ${
+          assignment.estadoNombre === "borrador" ? "grid-cols-2" : "grid-cols-3"
+        }`}
+      >
         <div className="bg-white border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-3xl font-bold text-pdep-600">{aceptadas}</div>
           <div className="text-sm text-gray-500 mt-1">Aceptadas</div>
         </div>
-        <div className="bg-white border border-gray-200 rounded-lg p-4 text-center">
-          <div className="text-3xl font-bold text-amber-600">{pendientes}</div>
-          <div className="text-sm text-gray-500 mt-1">Pendientes</div>
-        </div>
+        {assignment.estadoNombre !== "borrador" && (
+          <div className="bg-white border border-gray-200 rounded-lg p-4 text-center">
+            <div className="text-3xl font-bold text-amber-600">{pendientes}</div>
+            <div className="text-sm text-gray-500 mt-1">Pendientes</div>
+          </div>
+        )}
         <div className="bg-white border border-gray-200 rounded-lg p-4 text-center">
           <div className="text-3xl font-bold text-gray-600">{total}</div>
           <div className="text-sm text-gray-500 mt-1">

--- a/src/app/admin/assignments/[id]/page.tsx
+++ b/src/app/admin/assignments/[id]/page.tsx
@@ -147,6 +147,10 @@ export default async function AssignmentDetailPage(
       </div>
 
       <EstadoPanel
+        // El estado real es la key: cuando cambia (post router.refresh()),
+        // React remonta el panel en vez de arrastrar el estado local
+        // optimista que quedó tras la transición anterior.
+        key={assignment.estadoNombre}
         assignmentId={assignment.id}
         estado={assignment.estadoNombre}
         accionesDisponibles={accionesDeEstado}

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -73,13 +73,13 @@ describe("Admin Assignments page", () => {
 
   it("siempre llama a requireAdmin", async () => {
     mockGetAssignments.mockResolvedValue([]);
-    await AdminAssignmentsPage();
+    await AdminAssignmentsPage({});
     expect(mockRequireAdmin).toHaveBeenCalledOnce();
   });
 
   it("muestra el link para crear un nuevo assignment", async () => {
     mockGetAssignments.mockResolvedValue([]);
-    const element = await AdminAssignmentsPage();
+    const element = await AdminAssignmentsPage({});
     const html = renderToStaticMarkup(element);
     expect(html).toContain("href=\"/admin/assignments/new\"");
     expect(html).toContain("Nuevo Assignment");
@@ -88,14 +88,14 @@ describe("Admin Assignments page", () => {
   describe("estado vacío", () => {
     it("muestra mensaje cuando no hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("No hay assignments todavía");
     });
 
     it("no muestra filas cuando no hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).not.toContain("Kata Funcional");
     });
@@ -104,7 +104,7 @@ describe("Admin Assignments page", () => {
   describe("con assignments", () => {
     it("no muestra el estado vacío cuando hay assignments", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).not.toContain("No hay assignments todavía");
     });
@@ -113,7 +113,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ titulo: "TP Lógico" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("TP Lógico");
     });
@@ -122,7 +122,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ paradigma: "objetos" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("objetos");
     });
@@ -131,7 +131,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ tipo: "grupal" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("grupal");
     });
@@ -140,7 +140,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ templateRepo: "mi-template-especial" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("mi-template-especial");
     });
@@ -150,7 +150,7 @@ describe("Admin Assignments page", () => {
       comision.activa = true;
       mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
 
       expect(html).toContain("2027");
@@ -162,7 +162,7 @@ describe("Admin Assignments page", () => {
       comision.activa = false;
       mockGetAssignments.mockResolvedValue([makeAssignment({ comision })]);
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
 
       expect(html).toContain("2025");
@@ -174,7 +174,7 @@ describe("Admin Assignments page", () => {
         makeAssignment({ comision: undefined }),
       ]);
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
 
       expect(html).toContain("Sin comisión");
@@ -182,7 +182,7 @@ describe("Admin Assignments page", () => {
 
     it("muestra las cabeceras de la tabla", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment()]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("Título");
       expect(html).toContain("Estado");
@@ -197,7 +197,7 @@ describe("Admin Assignments page", () => {
 
     it("muestra el link de editar por cada assignment", async () => {
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "a1" })]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain('href="/admin/assignments/a1/edit"');
       expect(html).toContain("Editar");
@@ -207,7 +207,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ id: "tp-1", titulo: "Kata Funcional" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("Eliminar Kata Funcional");
     });
@@ -218,7 +218,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "tp-1" })]);
       mockGetEntregaCountsByAssignment.mockResolvedValue(new Map());
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain(">0<");
     });
@@ -227,7 +227,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "tp-1" })]);
       mockGetEntregaCountsByAssignment.mockResolvedValue(new Map([["tp-1", 3]]));
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain(">3<");
     });
@@ -238,7 +238,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "a1" })]);
       mockGetActiveRepoCountsByAssignment.mockResolvedValue(new Map([["a1", 3]]));
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("Borrar repos (3)");
     });
@@ -247,7 +247,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([makeAssignment({ id: "a1" })]);
       mockGetActiveRepoCountsByAssignment.mockResolvedValue(new Map());
 
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).not.toContain("Borrar repos");
     });
@@ -258,7 +258,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ deadline: new Date("2026-06-30") }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       // Localización es-AR: "30/6/2026" o similar
       expect(html).toContain("2026");
@@ -269,7 +269,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ deadline: undefined }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("—");
     });
@@ -280,7 +280,7 @@ describe("Admin Assignments page", () => {
       mockGetAssignments.mockResolvedValue([
         makeAssignment({ estadoNombre: "archivado" }),
       ]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain('data-testid="estado-badge"');
       expect(html).toContain("Archivado");
@@ -288,7 +288,7 @@ describe("Admin Assignments page", () => {
 
     it("muestra los chips de filtro por estado", async () => {
       mockGetAssignments.mockResolvedValue([]);
-      const element = await AdminAssignmentsPage();
+      const element = await AdminAssignmentsPage({});
       const html = renderToStaticMarkup(element);
       expect(html).toContain("Todos");
       expect(html).toContain('href="/admin/assignments?estado=borrador"');

--- a/src/app/admin/assignments/page.test.tsx
+++ b/src/app/admin/assignments/page.test.tsx
@@ -14,7 +14,7 @@ vi.mock("@/lib/session", () => ({
 }));
 
 vi.mock("@/lib/repositories", () => ({
-  getAssignments: () => mockGetAssignments(),
+  getAssignments: (filtro?: unknown) => mockGetAssignments(filtro),
   getEntregaCountsByAssignment: () => mockGetEntregaCountsByAssignment(),
   getActiveRepoCountsByAssignment: () => mockGetActiveRepoCountsByAssignment(),
 }));
@@ -185,6 +185,7 @@ describe("Admin Assignments page", () => {
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
       expect(html).toContain("Título");
+      expect(html).toContain("Estado");
       expect(html).toContain("Paradigma");
       expect(html).toContain("Tipo");
       expect(html).toContain("Comisión");
@@ -271,6 +272,46 @@ describe("Admin Assignments page", () => {
       const element = await AdminAssignmentsPage();
       const html = renderToStaticMarkup(element);
       expect(html).toContain("—");
+    });
+  });
+
+  describe("estado", () => {
+    it("muestra el badge de estado por assignment", async () => {
+      mockGetAssignments.mockResolvedValue([
+        makeAssignment({ estadoNombre: "archivado" }),
+      ]);
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-testid="estado-badge"');
+      expect(html).toContain("Archivado");
+    });
+
+    it("muestra los chips de filtro por estado", async () => {
+      mockGetAssignments.mockResolvedValue([]);
+      const element = await AdminAssignmentsPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("Todos");
+      expect(html).toContain('href="/admin/assignments?estado=borrador"');
+      expect(html).toContain('href="/admin/assignments?estado=publicado"');
+      expect(html).toContain('href="/admin/assignments?estado=archivado"');
+    });
+
+    it("pasa el filtro al repositorio cuando el estado es válido", async () => {
+      mockGetAssignments.mockResolvedValue([]);
+      const element = await AdminAssignmentsPage({
+        searchParams: Promise.resolve({ estado: "archivado" }),
+      });
+      renderToStaticMarkup(element);
+      expect(mockGetAssignments).toHaveBeenCalledWith({ estado: "archivado" });
+    });
+
+    it("ignora un estado desconocido en el query string", async () => {
+      mockGetAssignments.mockResolvedValue([]);
+      const element = await AdminAssignmentsPage({
+        searchParams: Promise.resolve({ estado: "basura" }),
+      });
+      renderToStaticMarkup(element);
+      expect(mockGetAssignments).toHaveBeenCalledWith(undefined);
     });
   });
 });

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -20,9 +20,9 @@ import {
   DataEmpty,
 } from "@/app/components/DataTable";
 
-export default async function AdminAssignmentsPage(
-  props: { searchParams?: Promise<{ estado?: string }> } = {}
-) {
+export default async function AdminAssignmentsPage(props: {
+  searchParams?: Promise<{ estado?: string }>;
+}) {
   const emptySearchParams: { estado?: string } = {};
   const searchParams = await (props.searchParams ?? Promise.resolve(emptySearchParams));
   await requireAdmin();

--- a/src/app/admin/assignments/page.tsx
+++ b/src/app/admin/assignments/page.tsx
@@ -7,6 +7,9 @@ import {
 import Link from "next/link";
 import { DeleteAssignmentButton } from "./delete-button";
 import { DeleteReposButton } from "./delete-repos-button";
+import { NOMBRES_ESTADO_ASSIGNMENT } from "@/domain/entities";
+import type { NombreEstadoAssignment } from "@/types";
+import { EstadoAssignmentBadge } from "@/app/components/EstadoAssignmentBadge";
 import {
   DataTable,
   DataHeader,
@@ -17,18 +20,28 @@ import {
   DataEmpty,
 } from "@/app/components/DataTable";
 
-export default async function AdminAssignmentsPage() {
+export default async function AdminAssignmentsPage(
+  props: { searchParams?: Promise<{ estado?: string }> } = {}
+) {
+  const emptySearchParams: { estado?: string } = {};
+  const searchParams = await (props.searchParams ?? Promise.resolve(emptySearchParams));
   await requireAdmin();
 
+  const estadoFilter = NOMBRES_ESTADO_ASSIGNMENT.includes(
+    searchParams.estado as NombreEstadoAssignment
+  )
+    ? (searchParams.estado as NombreEstadoAssignment)
+    : undefined;
+
   const [assignments, entregasCounts, activeRepoCounts] = await Promise.all([
-    getAssignments(),
+    getAssignments(estadoFilter ? { estado: estadoFilter } : undefined),
     getEntregaCountsByAssignment(),
     getActiveRepoCountsByAssignment(),
   ]);
 
   const sorted = [...assignments].sort(
-    (a, b) =>
-      new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    (anterior, siguiente) =>
+      new Date(siguiente.createdAt).getTime() - new Date(anterior.createdAt).getTime()
   );
 
   return (
@@ -43,12 +56,44 @@ export default async function AdminAssignmentsPage() {
         </Link>
       </div>
 
+      {/* Filtro por estado */}
+      <div className="flex flex-wrap gap-2 mb-6">
+        <Link
+          href="/admin/assignments"
+          className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+            !estadoFilter
+              ? "bg-pdep-600 text-white"
+              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+          }`}
+        >
+          Todos
+        </Link>
+        {NOMBRES_ESTADO_ASSIGNMENT.map((estado) => (
+          <Link
+            key={estado}
+            href={`/admin/assignments?estado=${estado}`}
+            className={`px-3 py-1 rounded-full text-sm font-medium transition-colors ${
+              estadoFilter === estado
+                ? "bg-pdep-600 text-white"
+                : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+            }`}
+          >
+            {estado.charAt(0).toUpperCase() + estado.slice(1)}
+          </Link>
+        ))}
+      </div>
+
       {sorted.length === 0 ? (
-        <DataEmpty>No hay assignments todavía. Creá el primero.</DataEmpty>
+        <DataEmpty>
+          {estadoFilter
+            ? `No hay assignments en estado ${estadoFilter}.`
+            : "No hay assignments todavía. Creá el primero."}
+        </DataEmpty>
       ) : (
-        <DataTable columns="2fr 1fr 1fr 1fr 1.5fr 90px 110px 180px">
+        <DataTable columns="2fr 100px 1fr 1fr 1fr 1.5fr 90px 110px 180px">
           <DataHeader>
             <DataHeaderCell>Título</DataHeaderCell>
+            <DataHeaderCell>Estado</DataHeaderCell>
             <DataHeaderCell>Paradigma</DataHeaderCell>
             <DataHeaderCell>Tipo</DataHeaderCell>
             <DataHeaderCell>Comisión</DataHeaderCell>
@@ -62,6 +107,9 @@ export default async function AdminAssignmentsPage() {
               <DataRow key={assignment.id}>
                 <DataCell label="Título" heading>
                   {assignment.titulo}
+                </DataCell>
+                <DataCell label="Estado">
+                  <EstadoAssignmentBadge estado={assignment.estadoNombre} />
                 </DataCell>
                 <DataCell label="Paradigma">
                   <span className="text-xs bg-pdep-100 text-pdep-700 px-2 py-0.5 rounded-full">

--- a/src/app/api/assignments/[id]/accept/route.test.ts
+++ b/src/app/api/assignments/[id]/accept/route.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import type { PdepUser } from "@/types";
 import { Entrega, GrupoNoAsignadoError } from "@/domain/entities";
-import { AccesoAssignmentProhibidoError } from "@/lib/services/assignmentAuthorization";
+import {
+  AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
+} from "@/lib/services/assignmentAuthorization";
 import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 
 const {
@@ -144,6 +147,14 @@ describe("POST /api/assignments/[id]/accept", () => {
   it("devuelve 403 si el alumno pertenece a otra comisión", async () => {
     mockAceptarAssignment.mockRejectedValue(
       new AccesoAssignmentProhibidoError("a1")
+    );
+    const response = await POST(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
+    expect(response.status).toBe(403);
+  });
+
+  it("devuelve 403 si el assignment no está publicado", async () => {
+    mockAceptarAssignment.mockRejectedValue(
+      new AssignmentNoDisponibleError("a1")
     );
     const response = await POST(makeRequest(), { params: Promise.resolve({ id: "a1" }) });
     expect(response.status).toBe(403);

--- a/src/app/api/assignments/[id]/accept/route.ts
+++ b/src/app/api/assignments/[id]/accept/route.ts
@@ -9,7 +9,10 @@ import {
   AlumnoNoRegistradoError,
   AssignmentNoEncontradoError,
 } from "@/lib/services/aceptarAssignment";
-import { AccesoAssignmentProhibidoError } from "@/lib/services/assignmentAuthorization";
+import {
+  AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
+} from "@/lib/services/assignmentAuthorization";
 
 export async function POST(_req: Request, props: { params: Promise<{ id: string }> }) {
   const params = await props.params;
@@ -33,6 +36,9 @@ export async function POST(_req: Request, props: { params: Promise<{ id: string 
       return NextResponse.json({ error: error.message }, { status: 404 });
     }
     if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof AssignmentNoDisponibleError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
     }
     if (

--- a/src/app/api/assignments/[id]/estado/route.test.ts
+++ b/src/app/api/assignments/[id]/estado/route.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockGetCurrentUser = vi.fn();
+const mockCambiarEstadoAssignment = vi.fn();
+
+const {
+  FakeAssignmentNoEncontradoError,
+  FakeTransicionDeEstadoInvalidaError,
+} = vi.hoisted(() => ({
+  FakeAssignmentNoEncontradoError: class AssignmentNoEncontradoError extends Error {},
+  FakeTransicionDeEstadoInvalidaError: class TransicionDeEstadoInvalidaError extends Error {},
+}));
+
+vi.mock("@/lib/session", () => ({
+  getCurrentUser: () => mockGetCurrentUser(),
+}));
+
+vi.mock("@/lib/repositories", () => ({
+  cambiarEstadoAssignment: (id: string, estado: string, porUsuario: string) =>
+    mockCambiarEstadoAssignment(id, estado, porUsuario),
+}));
+
+vi.mock("@/lib/services/assignmentAuthorization", () => ({
+  AssignmentNoEncontradoError: FakeAssignmentNoEncontradoError,
+}));
+
+vi.mock("@/domain/entities", () => ({
+  TransicionDeEstadoInvalidaError: FakeTransicionDeEstadoInvalidaError,
+}));
+
+import { PATCH } from "./route";
+
+// ── Helpers ──────────────────────────────────────────────────
+
+function makeAssignment(overrides = {}) {
+  return {
+    id: "a1",
+    estadoNombre: "publicado",
+    estado: { etiqueta: () => "Publicado" },
+    publicadoEn: new Date("2026-08-14T00:00:00.000Z"),
+    publicadoPor: "docente1",
+    archivadoEn: undefined,
+    archivadoPor: undefined,
+    ...overrides,
+  };
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/assignments/a1/estado", {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("PATCH /api/assignments/[id]/estado", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "docente1",
+      isAdmin: true,
+    });
+    mockCambiarEstadoAssignment.mockResolvedValue(makeAssignment());
+  });
+
+  it("devuelve 401 si no hay sesión", async () => {
+    mockGetCurrentUser.mockResolvedValue(null);
+    const response = await PATCH(makeRequest({ estado: "publicado" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockCambiarEstadoAssignment).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 401 si el usuario no es admin", async () => {
+    mockGetCurrentUser.mockResolvedValue({
+      githubUsername: "ana",
+      isAdmin: false,
+    });
+    const response = await PATCH(makeRequest({ estado: "publicado" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(401);
+    expect(mockCambiarEstadoAssignment).not.toHaveBeenCalled();
+  });
+
+  it("devuelve 400 si el body tiene un estado desconocido", async () => {
+    const response = await PATCH(makeRequest({ estado: "vigente" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(400);
+    expect(mockCambiarEstadoAssignment).not.toHaveBeenCalled();
+  });
+
+  it("publica y devuelve 200 con la auditoría", async () => {
+    const response = await PATCH(makeRequest({ estado: "publicado" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.estado).toBe("publicado");
+    expect(data.etiqueta).toBe("Publicado");
+    expect(data.publicadoPor).toBe("docente1");
+    expect(mockCambiarEstadoAssignment).toHaveBeenCalledWith(
+      "a1",
+      "publicado",
+      "docente1"
+    );
+  });
+
+  it("devuelve 404 si el assignment no existe", async () => {
+    mockCambiarEstadoAssignment.mockRejectedValue(
+      new FakeAssignmentNoEncontradoError("Assignment no encontrado")
+    );
+    const response = await PATCH(makeRequest({ estado: "publicado" }), {
+      params: Promise.resolve({ id: "no-existe" }),
+    });
+    expect(response.status).toBe(404);
+  });
+
+  it("devuelve 409 con el motivo si la transición no está permitida", async () => {
+    mockCambiarEstadoAssignment.mockRejectedValue(
+      new FakeTransicionDeEstadoInvalidaError(
+        'No se puede pasar de "publicado" a "borrador": tiene entregas — archivalo en vez de despublicarlo'
+      )
+    );
+    const response = await PATCH(makeRequest({ estado: "borrador" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(409);
+    const data = await response.json();
+    expect(data.error).toContain("archivalo");
+  });
+
+  it("devuelve 500 para errores inesperados", async () => {
+    mockCambiarEstadoAssignment.mockRejectedValue(new Error("DB explotó"));
+    const response = await PATCH(makeRequest({ estado: "publicado" }), {
+      params: Promise.resolve({ id: "a1" }),
+    });
+    expect(response.status).toBe(500);
+  });
+});

--- a/src/app/api/assignments/[id]/estado/route.ts
+++ b/src/app/api/assignments/[id]/estado/route.ts
@@ -1,0 +1,59 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { getCurrentUser } from "@/lib/session";
+import { cambiarEstadoAssignment } from "@/lib/repositories";
+import { AssignmentNoEncontradoError } from "@/lib/services/assignmentAuthorization";
+import { TransicionDeEstadoInvalidaError } from "@/domain/entities";
+import { internalServerError } from "@/lib/api-errors";
+
+const EstadoSchema = z.object({
+  estado: z.enum(["borrador", "publicado", "archivado"]),
+});
+
+export async function PATCH(req: Request, props: { params: Promise<{ id: string }> }) {
+  const params = await props.params;
+  try {
+    // No usa guardAdmin(): además de verificar el rol, necesita el
+    // githubUsername del admin para sellar la auditoría de la transición
+    // (mismo patrón que DELETE /api/assignments/[id]/repos).
+    const user = await getCurrentUser();
+    if (!user?.isAdmin) {
+      return NextResponse.json({ error: "No autorizado" }, { status: 401 });
+    }
+
+    const body = await req.json().catch(() => null);
+    const parsed = EstadoSchema.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "Datos inválidos", fields: parsed.error.flatten().fieldErrors },
+        { status: 400 }
+      );
+    }
+
+    const assignment = await cambiarEstadoAssignment(
+      params.id,
+      parsed.data.estado,
+      user.githubUsername
+    );
+
+    return NextResponse.json({
+      id: assignment.id,
+      estado: assignment.estadoNombre,
+      etiqueta: assignment.estado.etiqueta(),
+      publicadoEn: assignment.publicadoEn ?? null,
+      publicadoPor: assignment.publicadoPor ?? null,
+      archivadoEn: assignment.archivadoEn ?? null,
+      archivadoPor: assignment.archivadoPor ?? null,
+    });
+  } catch (error) {
+    if (error instanceof AssignmentNoEncontradoError) {
+      return NextResponse.json({ error: error.message }, { status: 404 });
+    }
+    if (error instanceof TransicionDeEstadoInvalidaError) {
+      return NextResponse.json({ error: error.message }, { status: 409 });
+    }
+    return internalServerError("PATCH /api/assignments/[id]/estado", error, {
+      assignmentId: params.id,
+    });
+  }
+}

--- a/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
+++ b/src/app/api/assignments/[id]/grupos/[grupoId]/join/route.ts
@@ -10,6 +10,7 @@ import { internalServerError } from "@/lib/api-errors";
 import type { Grupo } from "@/domain/entities";
 import {
   AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
   GrupoNoEncontradoError,
 } from "@/lib/services/assignmentAuthorization";
 
@@ -53,6 +54,9 @@ export async function POST(_req: Request, props: { params: Promise<{ id: string;
       return NextResponse.json({ error: error.message }, { status: 404 });
     }
     if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof AssignmentNoDisponibleError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
     }
     if (error instanceof InscripcionesCerradasError) {

--- a/src/app/api/assignments/[id]/grupos/route.ts
+++ b/src/app/api/assignments/[id]/grupos/route.ts
@@ -19,6 +19,7 @@ import { NombreRepositorioDemasiadoLargoError } from "@/lib/naming";
 import type { Grupo } from "@/domain/entities";
 import {
   AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
   AssignmentNoEncontradoError,
   autorizarAccesoAssignment,
 } from "@/lib/services/assignmentAuthorization";
@@ -108,6 +109,9 @@ export async function POST(req: Request, props: { params: Promise<{ id: string }
       return NextResponse.json({ error: error.message }, { status: 404 });
     }
     if (error instanceof AccesoAssignmentProhibidoError) {
+      return NextResponse.json({ error: error.message }, { status: 403 });
+    }
+    if (error instanceof AssignmentNoDisponibleError) {
       return NextResponse.json({ error: error.message }, { status: 403 });
     }
     if (error instanceof AssignmentNoGrupalError) {

--- a/src/app/api/assignments/[id]/route.test.ts
+++ b/src/app/api/assignments/[id]/route.test.ts
@@ -125,6 +125,20 @@ describe("PATCH /api/assignments/[id]", () => {
     expect(mockUpdateAssignment).toHaveBeenCalledWith("a1", { paradigma: "logico" });
   });
 
+  it("ignora un campo estado en el body: el ciclo de vida solo cambia por su propio endpoint", async () => {
+    mockGetAssignment.mockResolvedValue(makeAssignment());
+    mockUpdateAssignment.mockResolvedValue(makeAssignment());
+
+    const request = makeRequest("PATCH", {
+      titulo: "Nuevo título",
+      estado: "publicado",
+    });
+    await PATCH(request, { params: Promise.resolve({ id: "a1" }) });
+    expect(mockUpdateAssignment).toHaveBeenCalledWith("a1", {
+      titulo: "Nuevo título",
+    });
+  });
+
   it("devuelve 400 con formErrors cuando el body no es JSON válido o es null", async () => {
     mockGetAssignment.mockResolvedValue(makeAssignment());
     const request = new Request("http://localhost/api/assignments/a1", {

--- a/src/app/api/assignments/route.test.ts
+++ b/src/app/api/assignments/route.test.ts
@@ -20,8 +20,16 @@ vi.mock("@/lib/repositories", () => ({
     mockGetEntregasDeUsuario(username),
 }));
 
-function makeAssignment(id: string, esVisiblePara = true) {
-  return { id, esVisibleParaAlumno: () => esVisiblePara };
+// `esVisibleParaAlumno` real depende de si el alumno tiene entrega: el mock
+// respeta ese contrato en vez de devolver un valor fijo, para que los tests
+// verifiquen que route.ts realmente pasa entregasMap.has(id) como argumento.
+function makeAssignment(
+  id: string,
+  esVisiblePara: boolean | ((tieneEntrega: boolean) => boolean) = true
+) {
+  const resolver =
+    typeof esVisiblePara === "function" ? esVisiblePara : () => esVisiblePara;
+  return { id, esVisibleParaAlumno: resolver };
 }
 
 import { GET } from "./route";
@@ -83,6 +91,25 @@ describe("GET /api/assignments", () => {
   it("consulta las entregas del alumno para resolver la visibilidad de archivados", async () => {
     await GET();
     expect(mockGetEntregasDeUsuario).toHaveBeenCalledWith("ana");
+  });
+
+  it("incluye un archivado cuando el alumno tiene entrega, y lo excluye si no", async () => {
+    // esVisibleParaAlumno real: archivado.esVisibleParaAlumno(tieneEntrega) === tieneEntrega
+    mockGetAssignmentsDeComision.mockResolvedValue([
+      makeAssignment("a-archivado-con-entrega", (tieneEntrega) => tieneEntrega),
+      makeAssignment("a-archivado-sin-entrega", (tieneEntrega) => tieneEntrega),
+    ]);
+    mockGetEntregasDeUsuario.mockResolvedValue(
+      new Map([["a-archivado-con-entrega", { id: "e1" }]])
+    );
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.map((assignment: { id: string }) => assignment.id)).toEqual([
+      "a-archivado-con-entrega",
+    ]);
   });
 
   it("devuelve 403 si el usuario no está registrado como alumno", async () => {

--- a/src/app/api/assignments/route.test.ts
+++ b/src/app/api/assignments/route.test.ts
@@ -5,6 +5,7 @@ const mockGetCurrentUser = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
 const mockGetAssignments = vi.fn();
 const mockGetAssignmentsDeComision = vi.fn();
+const mockGetEntregasDeUsuario = vi.fn();
 
 vi.mock("@/lib/session", () => ({
   getCurrentUser: () => mockGetCurrentUser(),
@@ -15,7 +16,13 @@ vi.mock("@/lib/repositories", () => ({
   getAssignments: () => mockGetAssignments(),
   getAssignmentsDeComision: (comisionId: string) =>
     mockGetAssignmentsDeComision(comisionId),
+  getEntregasDeUsuario: (username: string) =>
+    mockGetEntregasDeUsuario(username),
 }));
+
+function makeAssignment(id: string, esVisiblePara = true) {
+  return { id, esVisibleParaAlumno: () => esVisiblePara };
+}
 
 import { GET } from "./route";
 
@@ -37,7 +44,8 @@ describe("GET /api/assignments", () => {
       id: "alumno-ana",
       comision: { id: "c1" },
     });
-    mockGetAssignmentsDeComision.mockResolvedValue([{ id: "a1" }]);
+    mockGetAssignmentsDeComision.mockResolvedValue([makeAssignment("a1")]);
+    mockGetEntregasDeUsuario.mockResolvedValue(new Map());
     mockGetAssignments.mockResolvedValue([{ id: "a1" }, { id: "a2" }]);
   });
 
@@ -57,6 +65,24 @@ describe("GET /api/assignments", () => {
     expect(response.status).toBe(200);
     expect(mockGetAssignmentsDeComision).toHaveBeenCalledWith("c1");
     expect(mockGetAssignments).not.toHaveBeenCalled();
+  });
+
+  it("excluye assignments que el estado del alumno no hace visibles", async () => {
+    mockGetAssignmentsDeComision.mockResolvedValue([
+      makeAssignment("a1", true),
+      makeAssignment("a-oculto", false),
+    ]);
+
+    const response = await GET();
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.map((assignment: { id: string }) => assignment.id)).toEqual(["a1"]);
+  });
+
+  it("consulta las entregas del alumno para resolver la visibilidad de archivados", async () => {
+    await GET();
+    expect(mockGetEntregasDeUsuario).toHaveBeenCalledWith("ana");
   });
 
   it("devuelve 403 si el usuario no está registrado como alumno", async () => {

--- a/src/app/api/assignments/route.ts
+++ b/src/app/api/assignments/route.ts
@@ -4,6 +4,7 @@ import {
   getAlumnoByGithub,
   getAssignments,
   getAssignmentsDeComision,
+  getEntregasDeUsuario,
 } from "@/lib/repositories";
 
 export async function GET() {
@@ -24,6 +25,16 @@ export async function GET() {
     );
   }
 
-  const assignments = await getAssignmentsDeComision(alumno.comision.id);
-  return NextResponse.json(assignments);
+  // getAssignmentsDeComision ya excluye los borradores; acá se resuelve el
+  // filtro fino que depende del alumno: un archivado solo se lista si ya
+  // tiene entrega (mismo criterio que el dashboard).
+  const [assignments, entregasMap] = await Promise.all([
+    getAssignmentsDeComision(alumno.comision.id),
+    getEntregasDeUsuario(user.githubUsername),
+  ]);
+  const visibles = assignments.filter((assignment) =>
+    assignment.esVisibleParaAlumno(entregasMap.has(assignment.id))
+  );
+
+  return NextResponse.json(visibles);
 }

--- a/src/app/assignments/[id]/grupo/page.test.tsx
+++ b/src/app/assignments/[id]/grupo/page.test.tsx
@@ -75,6 +75,8 @@ function makeGrupalAssignment(overrides = {}): GrupalAssignment {
   assignment.maxIntegrantes = 3;
   assignment.inscripcionesCerradas = false;
   assignment.comision = { id: "c1" } as never;
+  // Publicado por defecto: la página exige que el assignment esté disponible.
+  assignment.transicionarA("publicado", { tieneEntregas: false }, "docente1");
   return Object.assign(assignment, overrides);
 }
 

--- a/src/app/assignments/[id]/grupo/page.tsx
+++ b/src/app/assignments/[id]/grupo/page.tsx
@@ -10,7 +10,7 @@ import { GrupalAssignment } from "@/domain/entities";
 import { GrupoSelector } from "./grupo-selector";
 import { MiGrupo } from "./mi-grupo";
 import type { GrupoResumen } from "./mi-grupo";
-import { autorizarAccesoAssignment } from "@/lib/services/assignmentAuthorization";
+import { autorizarAccionSobreAssignment } from "@/lib/services/assignmentAuthorization";
 
 export default async function GrupoPage(
   props: {
@@ -32,7 +32,7 @@ export default async function GrupoPage(
   }
 
   try {
-    autorizarAccesoAssignment(user, alumno, assignment);
+    autorizarAccionSobreAssignment(user, alumno, assignment);
   } catch {
     notFound();
   }

--- a/src/app/components/EstadoAssignmentBadge.test.tsx
+++ b/src/app/components/EstadoAssignmentBadge.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from "@testing-library/react";
+import { EstadoAssignmentBadge } from "./EstadoAssignmentBadge";
+
+describe("EstadoAssignmentBadge", () => {
+  it("muestra la etiqueta de borrador", () => {
+    render(<EstadoAssignmentBadge estado="borrador" />);
+    expect(screen.getByText("Borrador")).toBeInTheDocument();
+  });
+
+  it("muestra la etiqueta de publicado", () => {
+    render(<EstadoAssignmentBadge estado="publicado" />);
+    expect(screen.getByText("Publicado")).toBeInTheDocument();
+  });
+
+  it("muestra la etiqueta de archivado", () => {
+    render(<EstadoAssignmentBadge estado="archivado" />);
+    expect(screen.getByText("Archivado")).toBeInTheDocument();
+  });
+});

--- a/src/app/components/EstadoAssignmentBadge.tsx
+++ b/src/app/components/EstadoAssignmentBadge.tsx
@@ -1,0 +1,37 @@
+import type { NombreEstadoAssignment } from "@/types";
+
+// Tabla de presentación por estado, no una cadena de ifs: cada fila es un
+// dato (etiqueta + clases), no una rama de lógica.
+const ESTILOS_POR_ESTADO: Record<
+  NombreEstadoAssignment,
+  { etiqueta: string; className: string }
+> = {
+  borrador: {
+    etiqueta: "Borrador",
+    className: "bg-gray-100 text-gray-600",
+  },
+  publicado: {
+    etiqueta: "Publicado",
+    className: "bg-green-50 text-green-700",
+  },
+  archivado: {
+    etiqueta: "Archivado",
+    className: "bg-amber-50 text-amber-700",
+  },
+};
+
+export function EstadoAssignmentBadge({
+  estado,
+}: {
+  estado: NombreEstadoAssignment;
+}) {
+  const { etiqueta, className } = ESTILOS_POR_ESTADO[estado];
+  return (
+    <span
+      data-testid="estado-badge"
+      className={`text-xs px-2 py-0.5 rounded-full font-medium ${className}`}
+    >
+      {etiqueta}
+    </span>
+  );
+}

--- a/src/app/dashboard/page.test.tsx
+++ b/src/app/dashboard/page.test.tsx
@@ -78,6 +78,9 @@ function makeAssignment(overrides?: Partial<IndividualAssignment>): IndividualAs
   assignment.paradigma = "funcional";
   assignment.slug = "kata-funcional";
   assignment.createdAt = new Date();
+  // Publicado por defecto: el dashboard de alumno solo muestra lo visible.
+  // Los tests de ciclo de vida overridean `estadoNombre` explícitamente.
+  assignment.transicionarA("publicado", { tieneEntregas: false }, "docente1");
   return Object.assign(assignment, overrides);
 }
 
@@ -92,6 +95,7 @@ function makeGrupalAssignment(overrides?: Partial<GrupalAssignment>): GrupalAssi
   assignment.slug = "tp-grupal";
   assignment.maxIntegrantes = 3;
   assignment.createdAt = new Date();
+  assignment.transicionarA("publicado", { tieneEntregas: false }, "docente1");
   return Object.assign(assignment, overrides);
 }
 
@@ -422,6 +426,76 @@ describe("Dashboard page", () => {
 
       await DashboardPage();
       expect(mockGetGruposDeAlumno).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("ciclo de vida", () => {
+    beforeEach(() => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: false }));
+      mockGetAlumnoByGithub.mockResolvedValue(
+        makeAlumno({ registroConfirmadoEn: { id: "c1" } as any })
+      );
+      mockGetGruposDeAlumno.mockResolvedValue(new Map());
+    });
+
+    it("muestra un archivado con entrega: badge, link al repo, sin botón de aceptar", async () => {
+      const archivado = makeAssignment({ id: "a-archivado" });
+      archivado.transicionarA("archivado", { tieneEntregas: true }, "docente1");
+      const entrega = makeEntrega({ repoUrl: "https://github.com/pdep/a-archivado" });
+      mockGetAssignmentsDeComision.mockResolvedValue([archivado]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map([["a-archivado", entrega]]));
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain('data-testid="estado-badge"');
+      expect(html).toContain("Archivado");
+      expect(html).toContain("Ir al repo");
+      expect(html).not.toContain('data-testid="accept-button"');
+      expect(html).not.toContain("Elegir grupo");
+    });
+
+    it("no muestra un archivado sin entrega", async () => {
+      const archivado = makeAssignment({ id: "a-archivado", titulo: "TP Archivado" });
+      archivado.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+      mockGetAssignmentsDeComision.mockResolvedValue([archivado]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).not.toContain("TP Archivado");
+    });
+
+    it("no muestra un assignment en borrador", async () => {
+      const borrador = makeAssignment({ id: "a-borrador", titulo: "TP Borrador" });
+      borrador.estadoNombre = "borrador";
+      mockGetAssignmentsDeComision.mockResolvedValue([borrador]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).not.toContain("TP Borrador");
+    });
+
+    it("no muestra badge para assignments publicados", async () => {
+      const publicado = makeAssignment({ id: "a-publicado" });
+      mockGetAssignmentsDeComision.mockResolvedValue([publicado]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).not.toContain('data-testid="estado-badge"');
+    });
+
+    it("el admin ve assignments en cualquier estado, incluido borrador", async () => {
+      mockRequireUser.mockResolvedValue(makeUser({ isAdmin: true }));
+      const borrador = makeAssignment({ id: "a-borrador", titulo: "TP Borrador Admin" });
+      borrador.estadoNombre = "borrador";
+      mockGetAssignments.mockResolvedValue([borrador]);
+      mockGetEntregaDeUsuario.mockResolvedValue(new Map());
+
+      const element = await DashboardPage();
+      const html = renderToStaticMarkup(element);
+      expect(html).toContain("TP Borrador Admin");
     });
   });
 

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import {
 import { AcceptButton } from "./accept-button";
 import { redirect } from "next/navigation";
 import type { Grupo } from "@/domain/entities";
+import { EstadoAssignmentBadge } from "@/app/components/EstadoAssignmentBadge";
 
 export default async function DashboardPage() {
   const user = await requireUser();
@@ -46,7 +47,15 @@ export default async function DashboardPage() {
       assignment,
       entrega: entregasMap.get(assignment.id) ?? null,
       grupo: gruposMap.get(assignment.id) ?? null,
-    }));
+    }))
+    // Filtro fino de estado, del lado del alumno: la query de
+    // getAssignmentsDeComision ya excluye los borradores; acá se resuelve
+    // "un archivado solo se ve si ya tenés entrega" (decisión de negocio que
+    // depende de datos por-alumno, no solo del estado). El admin ve todo.
+    .filter(
+      ({ assignment, entrega }) =>
+        user.isAdmin || assignment.esVisibleParaAlumno(entrega !== null)
+    );
 
   return (
     <div>
@@ -76,6 +85,9 @@ export default async function DashboardPage() {
                   <span className="text-xs bg-gray-100 text-gray-600 px-2 py-0.5 rounded-full">
                     {assignment.tipo}
                   </span>
+                  {assignment.estadoNombre !== "publicado" && (
+                    <EstadoAssignmentBadge estado={assignment.estadoNombre} />
+                  )}
                 </div>
                 {assignment.descripcion && (
                   <p className="text-sm text-gray-500">

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -260,6 +260,18 @@ describe("Assignment — ciclo de vida", () => {
     expect(individual.permiteAccionesDeAlumno()).toBe(true);
   });
 
+  it("publicar un assignment ya publicado no resella la auditoría", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    const publicadoEnOriginal = individual.publicadoEn;
+
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente2");
+
+    expect(individual.publicadoPor).toBe("docente1");
+    expect(individual.publicadoEn).toBe(publicadoEnOriginal);
+  });
+
   it("despublicar sin entregas vuelve a borrador", () => {
     const individual = new IndividualAssignment();
     individual.id = "a1";

--- a/src/domain/entities/Assignment.test.ts
+++ b/src/domain/entities/Assignment.test.ts
@@ -4,6 +4,7 @@ import { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
 import type { Assignment } from "./Assignment";
 import { Alumno } from "./Alumno";
 import type { Grupo } from "./Grupo";
+import { TransicionDeEstadoInvalidaError } from "./EstadoAssignment";
 
 function fakeAlumno(github: string): Alumno {
   return Object.assign(new Alumno(), { githubUsername: github });
@@ -236,5 +237,87 @@ describe("Assignment.aplicarCamposExtra", () => {
     grupal.maxIntegrantes = 3;
     grupal.aplicarCamposExtra({});
     expect(grupal.maxIntegrantes).toBe(3);
+  });
+});
+
+describe("Assignment — ciclo de vida", () => {
+  it("nace en borrador, no visible y sin acciones habilitadas", () => {
+    const individual = new IndividualAssignment();
+    expect(individual.estadoNombre).toBe("borrador");
+    expect(individual.esVisibleParaAlumno(false)).toBe(false);
+    expect(individual.esVisibleParaAlumno(true)).toBe(false);
+    expect(individual.permiteAccionesDeAlumno()).toBe(false);
+  });
+
+  it("publicar sella publicadoEn y publicadoPor", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    expect(individual.estadoNombre).toBe("publicado");
+    expect(individual.publicadoPor).toBe("docente1");
+    expect(individual.publicadoEn).toBeInstanceOf(Date);
+    expect(individual.esVisibleParaAlumno(false)).toBe(true);
+    expect(individual.permiteAccionesDeAlumno()).toBe(true);
+  });
+
+  it("despublicar sin entregas vuelve a borrador", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    individual.transicionarA("borrador", { tieneEntregas: false }, "docente1");
+    expect(individual.estadoNombre).toBe("borrador");
+  });
+
+  it("despublicar con entregas lanza TransicionDeEstadoInvalidaError", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    expect(() =>
+      individual.transicionarA("borrador", { tieneEntregas: true }, "docente1")
+    ).toThrow(TransicionDeEstadoInvalidaError);
+    expect(individual.estadoNombre).toBe("publicado");
+  });
+
+  it("archivar sella archivadoEn y archivadoPor, y solo es visible con entrega", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    individual.transicionarA("archivado", { tieneEntregas: true }, "docente1");
+    expect(individual.estadoNombre).toBe("archivado");
+    expect(individual.archivadoPor).toBe("docente1");
+    expect(individual.archivadoEn).toBeInstanceOf(Date);
+    expect(individual.esVisibleParaAlumno(true)).toBe(true);
+    expect(individual.esVisibleParaAlumno(false)).toBe(false);
+    expect(individual.permiteAccionesDeAlumno()).toBe(false);
+  });
+
+  it("un archivado puede volver a publicarse pero no a borrador", () => {
+    const individual = new IndividualAssignment();
+    individual.id = "a1";
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    individual.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+
+    expect(() =>
+      individual.transicionarA("borrador", { tieneEntregas: false }, "docente1")
+    ).toThrow(TransicionDeEstadoInvalidaError);
+
+    individual.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    expect(individual.estadoNombre).toBe("publicado");
+  });
+
+  it("GrupalAssignment.aceptaNuevasInscripciones exige estado publicado además de inscripciones abiertas", () => {
+    const grupal = new GrupalAssignment();
+    grupal.id = "a1";
+    expect(grupal.aceptaNuevasInscripciones()).toBe(false); // borrador
+
+    grupal.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    expect(grupal.aceptaNuevasInscripciones()).toBe(true);
+
+    grupal.inscripcionesCerradas = true;
+    expect(grupal.aceptaNuevasInscripciones()).toBe(false);
+
+    grupal.inscripcionesCerradas = false;
+    grupal.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+    expect(grupal.aceptaNuevasInscripciones()).toBe(false);
   });
 });

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -10,6 +10,11 @@ import { Comision } from "./Comision";
 import type { Alumno } from "./Alumno";
 import type { Grupo } from "./Grupo";
 import type { Paradigma, TipoAssignment } from "@/types";
+import {
+  EstadoAssignment,
+  type ContextoTransicionEstado,
+  type NombreEstadoAssignment,
+} from "./EstadoAssignment";
 
 // Dependencias de lectura que las subclases pueden usar desde sus métodos
 // polimórficos — se pasan como parámetro para que las entidades no importen
@@ -75,6 +80,62 @@ export abstract class Assignment {
 
   @ManyToOne(() => Comision, { nullable: true, deleteRule: "cascade" })
   comision?: Comision;
+
+  // Ciclo de vida: borrador (solo admin) → publicado (visible para alumnos)
+  // → archivado (histórico, preserva entregas). Ver EstadoAssignment.ts para
+  // las reglas de visibilidad y transición — acá solo vive la columna
+  // persistida y su resolución al objeto Strategy correspondiente.
+  @Enum({ items: ["borrador", "publicado", "archivado"] })
+  estadoNombre: NombreEstadoAssignment = "borrador";
+
+  @Property({ nullable: true, type: "datetime" })
+  publicadoEn?: Date;
+
+  @Property({ nullable: true, type: "string" })
+  publicadoPor?: string;
+
+  @Property({ nullable: true, type: "datetime" })
+  archivadoEn?: Date;
+
+  @Property({ nullable: true, type: "string" })
+  archivadoPor?: string;
+
+  get estado(): EstadoAssignment {
+    return EstadoAssignment.desdeNombre(this.estadoNombre);
+  }
+
+  /** `true` si un alumno con o sin entrega debe ver este assignment en su dashboard. */
+  esVisibleParaAlumno(tieneEntrega: boolean): boolean {
+    return this.estado.esVisibleParaAlumno(tieneEntrega);
+  }
+
+  /** `true` si el estado actual habilita aceptar el TP o gestionar grupos. */
+  permiteAccionesDeAlumno(): boolean {
+    return this.estado.permiteAccionesDeAlumno();
+  }
+
+  /**
+   * Aplica la transición de estado, validando contra las reglas del estado
+   * actual, y sella la auditoría (quién y cuándo publicó/archivó). Lanza
+   * `TransicionDeEstadoInvalidaError` si la transición no está permitida.
+   */
+  transicionarA(
+    destino: NombreEstadoAssignment,
+    contexto: ContextoTransicionEstado,
+    porUsuario: string
+  ): void {
+    const nuevoEstado = this.estado.transicionarA(this.id, destino, contexto);
+    this.estadoNombre = nuevoEstado.nombre;
+
+    if (destino === "publicado") {
+      this.publicadoEn = new Date();
+      this.publicadoPor = porUsuario;
+    }
+    if (destino === "archivado") {
+      this.archivadoEn = new Date();
+      this.archivadoPor = porUsuario;
+    }
+  }
 
   /** Etiqueta para el contador "totales" del admin (ej: "Alumnos" / "Grupos"). */
   abstract etiquetaTotales(): string;

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -48,6 +48,23 @@ export type ParticipantesResueltos =
       grupoNombreNormalizado: string;
     };
 
+// Errores de dominio sobre la existencia/disponibilidad de un assignment.
+// Viven acá (no en la capa de servicios) para que los repositorios puedan
+// lanzarlos sin importar hacia arriba desde `@/lib/services`.
+export class AssignmentNoEncontradoError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Assignment no encontrado");
+    this.name = "AssignmentNoEncontradoError";
+  }
+}
+
+export class AssignmentNoDisponibleError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Este TP no está disponible.");
+    this.name = "AssignmentNoDisponibleError";
+  }
+}
+
 // Single Table Inheritance: todos los assignments en una sola tabla,
 // discriminados por la columna `tipo`
 @Entity({ discriminatorColumn: "tipo", abstract: true })
@@ -126,14 +143,20 @@ export abstract class Assignment {
     contexto: ContextoTransicionEstado,
     porUsuario: string
   ): void {
+    const estadoAnterior = this.estadoNombre;
     const nuevoEstado = this.estado.transicionarA(this.id, destino, contexto);
     this.estadoNombre = nuevoEstado.nombre;
 
-    if (destino === "publicado") {
+    // Pedir de nuevo el mismo estado (ej. "publicar" un TP ya publicado) es un
+    // no-op: no resella la auditoría, para no pisar quién y cuándo lo publicó
+    // o archivó realmente con el usuario que hizo el click redundante.
+    if (nuevoEstado.nombre === estadoAnterior) return;
+
+    if (nuevoEstado.nombre === "publicado") {
       this.publicadoEn = new Date();
       this.publicadoPor = porUsuario;
     }
-    if (destino === "archivado") {
+    if (nuevoEstado.nombre === "archivado") {
       this.archivadoEn = new Date();
       this.archivadoPor = porUsuario;
     }

--- a/src/domain/entities/Assignment.ts
+++ b/src/domain/entities/Assignment.ts
@@ -1,6 +1,7 @@
 import {
   Entity,
   Enum,
+  Index,
   ManyToOne,
   PrimaryKey,
   Property,
@@ -50,6 +51,7 @@ export type ParticipantesResueltos =
 // Single Table Inheritance: todos los assignments en una sola tabla,
 // discriminados por la columna `tipo`
 @Entity({ discriminatorColumn: "tipo", abstract: true })
+@Index({ name: "assignment_estado_nombre_index", properties: ["estadoNombre"] })
 export abstract class Assignment {
   @PrimaryKey({ type: "uuid" })
   id: string = randomUUID();

--- a/src/domain/entities/EstadoAssignment.test.ts
+++ b/src/domain/entities/EstadoAssignment.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from "vitest";
+import {
+  EstadoAssignment,
+  TransicionDeEstadoInvalidaError,
+  transicionesDisponibles,
+  type NombreEstadoAssignment,
+} from "./EstadoAssignment";
+
+const ASSIGNMENT_ID = "assignment-1";
+
+function transicionar(
+  desde: NombreEstadoAssignment,
+  hacia: NombreEstadoAssignment,
+  tieneEntregas = false
+) {
+  return EstadoAssignment.desdeNombre(desde).transicionarA(ASSIGNMENT_ID, hacia, {
+    tieneEntregas,
+  });
+}
+
+describe("EstadoAssignment.desdeNombre", () => {
+  it("resuelve las tres instancias por nombre", () => {
+    expect(EstadoAssignment.desdeNombre("borrador").nombre).toBe("borrador");
+    expect(EstadoAssignment.desdeNombre("publicado").nombre).toBe("publicado");
+    expect(EstadoAssignment.desdeNombre("archivado").nombre).toBe("archivado");
+  });
+});
+
+describe("EstadoAssignment.esVisibleParaAlumno", () => {
+  it("borrador nunca es visible, tenga o no entrega", () => {
+    const borrador = EstadoAssignment.desdeNombre("borrador");
+    expect(borrador.esVisibleParaAlumno(false)).toBe(false);
+    expect(borrador.esVisibleParaAlumno(true)).toBe(false);
+  });
+
+  it("publicado siempre es visible", () => {
+    const publicado = EstadoAssignment.desdeNombre("publicado");
+    expect(publicado.esVisibleParaAlumno(false)).toBe(true);
+    expect(publicado.esVisibleParaAlumno(true)).toBe(true);
+  });
+
+  it("archivado es visible solo si el alumno tiene entrega", () => {
+    const archivado = EstadoAssignment.desdeNombre("archivado");
+    expect(archivado.esVisibleParaAlumno(false)).toBe(false);
+    expect(archivado.esVisibleParaAlumno(true)).toBe(true);
+  });
+});
+
+describe("EstadoAssignment.permiteAccionesDeAlumno", () => {
+  it("solo publicado habilita aceptar/gestionar grupo", () => {
+    expect(EstadoAssignment.desdeNombre("borrador").permiteAccionesDeAlumno()).toBe(false);
+    expect(EstadoAssignment.desdeNombre("publicado").permiteAccionesDeAlumno()).toBe(true);
+    expect(EstadoAssignment.desdeNombre("archivado").permiteAccionesDeAlumno()).toBe(false);
+  });
+});
+
+describe("EstadoAssignment.transicionarA — matriz de transiciones", () => {
+  it("borrador → borrador es no-op", () => {
+    expect(transicionar("borrador", "borrador").nombre).toBe("borrador");
+  });
+
+  it("borrador → publicado", () => {
+    expect(transicionar("borrador", "publicado").nombre).toBe("publicado");
+  });
+
+  it("borrador → archivado", () => {
+    expect(transicionar("borrador", "archivado").nombre).toBe("archivado");
+  });
+
+  it("publicado → publicado es no-op", () => {
+    expect(transicionar("publicado", "publicado").nombre).toBe("publicado");
+  });
+
+  it("publicado → borrador sin entregas", () => {
+    expect(transicionar("publicado", "borrador", false).nombre).toBe("borrador");
+  });
+
+  it("publicado → borrador con entregas lanza TransicionDeEstadoInvalidaError", () => {
+    expect(() => transicionar("publicado", "borrador", true)).toThrow(
+      TransicionDeEstadoInvalidaError
+    );
+  });
+
+  it("publicado → archivado, con o sin entregas", () => {
+    expect(transicionar("publicado", "archivado", false).nombre).toBe("archivado");
+    expect(transicionar("publicado", "archivado", true).nombre).toBe("archivado");
+  });
+
+  it("archivado → archivado es no-op", () => {
+    expect(transicionar("archivado", "archivado").nombre).toBe("archivado");
+  });
+
+  it("archivado → publicado (desarchivar)", () => {
+    expect(transicionar("archivado", "publicado").nombre).toBe("publicado");
+  });
+
+  it("archivado → borrador no está permitido", () => {
+    expect(() => transicionar("archivado", "borrador")).toThrow(
+      TransicionDeEstadoInvalidaError
+    );
+  });
+
+  it("transicionesDisponibles: borrador ofrece publicar y archivar", () => {
+    const disponibles = transicionesDisponibles(
+      EstadoAssignment.desdeNombre("borrador"),
+      ASSIGNMENT_ID,
+      { tieneEntregas: false }
+    );
+    expect(disponibles.sort()).toEqual(["archivado", "publicado"]);
+  });
+
+  it("transicionesDisponibles: publicado sin entregas ofrece despublicar y archivar", () => {
+    const disponibles = transicionesDisponibles(
+      EstadoAssignment.desdeNombre("publicado"),
+      ASSIGNMENT_ID,
+      { tieneEntregas: false }
+    );
+    expect(disponibles.sort()).toEqual(["archivado", "borrador"]);
+  });
+
+  it("transicionesDisponibles: publicado con entregas solo ofrece archivar", () => {
+    const disponibles = transicionesDisponibles(
+      EstadoAssignment.desdeNombre("publicado"),
+      ASSIGNMENT_ID,
+      { tieneEntregas: true }
+    );
+    expect(disponibles).toEqual(["archivado"]);
+  });
+
+  it("transicionesDisponibles: archivado solo ofrece publicar", () => {
+    const disponibles = transicionesDisponibles(
+      EstadoAssignment.desdeNombre("archivado"),
+      ASSIGNMENT_ID,
+      { tieneEntregas: false }
+    );
+    expect(disponibles).toEqual(["publicado"]);
+  });
+
+  it("el error de transición inválida incluye assignmentId, desde y hacia", () => {
+    try {
+      transicionar("publicado", "borrador", true);
+      throw new Error("no debería llegar acá");
+    } catch (error) {
+      expect(error).toBeInstanceOf(TransicionDeEstadoInvalidaError);
+      const transicionInvalida = error as TransicionDeEstadoInvalidaError;
+      expect(transicionInvalida.assignmentId).toBe(ASSIGNMENT_ID);
+      expect(transicionInvalida.desde).toBe("publicado");
+      expect(transicionInvalida.hacia).toBe("borrador");
+    }
+  });
+});

--- a/src/domain/entities/EstadoAssignment.ts
+++ b/src/domain/entities/EstadoAssignment.ts
@@ -1,10 +1,10 @@
 export type NombreEstadoAssignment = "borrador" | "publicado" | "archivado";
 
-export const NOMBRES_ESTADO_ASSIGNMENT: NombreEstadoAssignment[] = [
+export const NOMBRES_ESTADO_ASSIGNMENT: readonly NombreEstadoAssignment[] = [
   "borrador",
   "publicado",
   "archivado",
-];
+] as const;
 
 /**
  * Lanzado cuando se pide una transición de estado que la regla del assignment

--- a/src/domain/entities/EstadoAssignment.ts
+++ b/src/domain/entities/EstadoAssignment.ts
@@ -1,0 +1,215 @@
+export type NombreEstadoAssignment = "borrador" | "publicado" | "archivado";
+
+export const NOMBRES_ESTADO_ASSIGNMENT: NombreEstadoAssignment[] = [
+  "borrador",
+  "publicado",
+  "archivado",
+];
+
+/**
+ * Lanzado cuando se pide una transición de estado que la regla del assignment
+ * no permite (ej: despublicar un assignment con entregas). El handler HTTP lo
+ * traduce a 409.
+ */
+export class TransicionDeEstadoInvalidaError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly desde: NombreEstadoAssignment,
+    public readonly hacia: NombreEstadoAssignment,
+    motivo: string
+  ) {
+    super(`No se puede pasar de "${desde}" a "${hacia}": ${motivo}`);
+    this.name = "TransicionDeEstadoInvalidaError";
+  }
+}
+
+/** Contexto que necesita evaluar una transición de estado. */
+export interface ContextoTransicionEstado {
+  tieneEntregas: boolean;
+}
+
+/**
+ * Estado del ciclo de vida de un assignment, modelado como Strategy en vez de
+ * un enum + switch: cada operación que depende del estado (visibilidad para
+ * el alumno, si habilita aceptar/gestionar grupo, a qué estados puede pasar)
+ * se delega al objeto concreto. Evita ifs de tipo repetidos en autorización,
+ * listados y UI.
+ *
+ * Instancias singleton — el estado no tiene datos propios, solo comportamiento.
+ */
+export abstract class EstadoAssignment {
+  abstract get nombre(): NombreEstadoAssignment;
+
+  abstract etiqueta(): string;
+
+  /**
+   * `true` si un alumno con este assignment en este estado debe verlo en su
+   * dashboard. Borrador: nunca. Publicado: siempre. Archivado: solo si ya
+   * tiene una entrega (preserva el acceso al trabajo ya hecho).
+   */
+  abstract esVisibleParaAlumno(tieneEntrega: boolean): boolean;
+
+  /**
+   * `true` si el estado habilita que un alumno acepte el TP o gestione grupos
+   * (crear/unirse). Solo publicado lo permite.
+   */
+  abstract permiteAccionesDeAlumno(): boolean;
+
+  /**
+   * Resuelve la transición a `destino` dado el contexto del assignment.
+   * Devuelve el nuevo estado o lanza `TransicionDeEstadoInvalidaError`.
+   */
+  abstract transicionarA(
+    assignmentId: string,
+    destino: NombreEstadoAssignment,
+    contexto: ContextoTransicionEstado
+  ): EstadoAssignment;
+
+  static desdeNombre(nombre: NombreEstadoAssignment): EstadoAssignment {
+    return ESTADOS_POR_NOMBRE[nombre];
+  }
+}
+
+class Borrador extends EstadoAssignment {
+  get nombre(): NombreEstadoAssignment {
+    return "borrador";
+  }
+
+  etiqueta(): string {
+    return "Borrador";
+  }
+
+  esVisibleParaAlumno(_tieneEntrega: boolean): boolean {
+    return false;
+  }
+
+  permiteAccionesDeAlumno(): boolean {
+    return false;
+  }
+
+  transicionarA(
+    assignmentId: string,
+    destino: NombreEstadoAssignment,
+    _contexto: ContextoTransicionEstado
+  ): EstadoAssignment {
+    if (destino === "borrador") return this;
+    if (destino === "publicado" || destino === "archivado") {
+      return EstadoAssignment.desdeNombre(destino);
+    }
+    throw new TransicionDeEstadoInvalidaError(
+      assignmentId,
+      this.nombre,
+      destino,
+      "estado destino desconocido"
+    );
+  }
+}
+
+class Publicado extends EstadoAssignment {
+  get nombre(): NombreEstadoAssignment {
+    return "publicado";
+  }
+
+  etiqueta(): string {
+    return "Publicado";
+  }
+
+  esVisibleParaAlumno(_tieneEntrega: boolean): boolean {
+    return true;
+  }
+
+  permiteAccionesDeAlumno(): boolean {
+    return true;
+  }
+
+  transicionarA(
+    assignmentId: string,
+    destino: NombreEstadoAssignment,
+    contexto: ContextoTransicionEstado
+  ): EstadoAssignment {
+    if (destino === "publicado") return this;
+    if (destino === "borrador") {
+      if (contexto.tieneEntregas) {
+        throw new TransicionDeEstadoInvalidaError(
+          assignmentId,
+          this.nombre,
+          destino,
+          "tiene entregas — archivalo en vez de despublicarlo"
+        );
+      }
+      return EstadoAssignment.desdeNombre("borrador");
+    }
+    if (destino === "archivado") {
+      return EstadoAssignment.desdeNombre("archivado");
+    }
+    throw new TransicionDeEstadoInvalidaError(
+      assignmentId,
+      this.nombre,
+      destino,
+      "estado destino desconocido"
+    );
+  }
+}
+
+class Archivado extends EstadoAssignment {
+  get nombre(): NombreEstadoAssignment {
+    return "archivado";
+  }
+
+  etiqueta(): string {
+    return "Archivado";
+  }
+
+  esVisibleParaAlumno(tieneEntrega: boolean): boolean {
+    return tieneEntrega;
+  }
+
+  permiteAccionesDeAlumno(): boolean {
+    return false;
+  }
+
+  transicionarA(
+    assignmentId: string,
+    destino: NombreEstadoAssignment,
+    _contexto: ContextoTransicionEstado
+  ): EstadoAssignment {
+    if (destino === "archivado") return this;
+    if (destino === "publicado") {
+      return EstadoAssignment.desdeNombre("publicado");
+    }
+    throw new TransicionDeEstadoInvalidaError(
+      assignmentId,
+      this.nombre,
+      destino,
+      "un archivado solo puede volver a publicarse, no a borrador"
+    );
+  }
+}
+
+const ESTADOS_POR_NOMBRE: Record<NombreEstadoAssignment, EstadoAssignment> = {
+  borrador: new Borrador(),
+  publicado: new Publicado(),
+  archivado: new Archivado(),
+};
+
+/**
+ * Estados a los que `estado` puede transicionar dado el contexto — reusa
+ * `transicionarA` en modo de sondeo (no muta nada: los estados son
+ * singletons sin datos propios) para no duplicar las reglas de transición en
+ * la UI. Usado por el panel admin para decidir qué botones ofrecer.
+ */
+export function transicionesDisponibles(
+  estado: EstadoAssignment,
+  assignmentId: string,
+  contexto: ContextoTransicionEstado
+): NombreEstadoAssignment[] {
+  return NOMBRES_ESTADO_ASSIGNMENT.filter((destino) => {
+    if (destino === estado.nombre) return false;
+    try {
+      estado.transicionarA(assignmentId, destino, contexto);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}

--- a/src/domain/entities/GrupalAssignment.ts
+++ b/src/domain/entities/GrupalAssignment.ts
@@ -44,7 +44,7 @@ export class GrupalAssignment extends Assignment {
   }
 
   aceptaNuevasInscripciones(): boolean {
-    return !this.inscripcionesCerradas;
+    return this.permiteAccionesDeAlumno() && !this.inscripcionesCerradas;
   }
 
   async totalEsperado(fuentes: FuentesDeConteo): Promise<number> {

--- a/src/domain/entities/Grupo.test.ts
+++ b/src/domain/entities/Grupo.test.ts
@@ -197,6 +197,9 @@ describe("GrupalAssignment.aceptaNuevasInscripciones", () => {
     const grupal = new GrupalAssignment();
     grupal.id = "a1";
     grupal.maxIntegrantes = 3;
+    // Publicado por defecto: aceptar inscripciones requiere que el
+    // assignment esté disponible. El test de estado en borrador vive abajo.
+    grupal.transicionarA("publicado", { tieneEntregas: false }, "docente1");
     return grupal;
   }
 
@@ -207,6 +210,13 @@ describe("GrupalAssignment.aceptaNuevasInscripciones", () => {
   it("rechaza cuando el docente cerró las inscripciones", () => {
     const grupal = nuevoGrupal();
     grupal.inscripcionesCerradas = true;
+    expect(grupal.aceptaNuevasInscripciones()).toBe(false);
+  });
+
+  it("rechaza mientras el assignment no esté publicado", () => {
+    const grupal = new GrupalAssignment();
+    grupal.id = "a1";
+    grupal.maxIntegrantes = 3;
     expect(grupal.aceptaNuevasInscripciones()).toBe(false);
   });
 });

--- a/src/domain/entities/Grupo.ts
+++ b/src/domain/entities/Grupo.ts
@@ -70,6 +70,16 @@ export class AssignmentNoGrupalError extends Error {
   }
 }
 
+export class GrupoNoEncontradoError extends Error {
+  constructor(
+    public readonly assignmentId: string,
+    public readonly grupoId: string
+  ) {
+    super("Grupo no encontrado");
+    this.name = "GrupoNoEncontradoError";
+  }
+}
+
 @Entity()
 @Unique({
   name: "grupo_id_assignment_unique",

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -13,6 +13,14 @@ export type {
   ParticipantesResueltos,
   BuscadorDeGrupoDelAlumno,
 } from "./Assignment";
+export {
+  EstadoAssignment,
+  TransicionDeEstadoInvalidaError,
+  transicionesDisponibles,
+  NOMBRES_ESTADO_ASSIGNMENT,
+  type NombreEstadoAssignment,
+  type ContextoTransicionEstado,
+} from "./EstadoAssignment";
 export { IndividualAssignment } from "./IndividualAssignment";
 export { GrupalAssignment, GrupoNoAsignadoError } from "./GrupalAssignment";
 export {

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -7,7 +7,11 @@ export {
   type EstadoGoogleGroup,
 } from "./Alumno";
 export { Comision } from "./Comision";
-export { Assignment } from "./Assignment";
+export {
+  Assignment,
+  AssignmentNoEncontradoError,
+  AssignmentNoDisponibleError,
+} from "./Assignment";
 export type {
   FuentesDeConteo,
   ParticipantesResueltos,
@@ -31,6 +35,7 @@ export {
   NombreGrupoInvalidoError,
   GrupoLlenoError,
   AssignmentNoGrupalError,
+  GrupoNoEncontradoError,
 } from "./Grupo";
 export { Entrega } from "./Entrega";
 export {

--- a/src/lib/repositories/AssignmentRepository.test.ts
+++ b/src/lib/repositories/AssignmentRepository.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const mockEm = {
   find: vi.fn(),
   findOne: vi.fn(),
+  count: vi.fn(),
   persist: vi.fn(),
   flush: vi.fn(),
 };
@@ -12,13 +13,16 @@ vi.mock("@/lib/db", () => ({
 }));
 
 import {
+  cambiarEstadoAssignment,
   ComisionActivaRequeridaError,
   createAssignment,
   getAssignment,
   getAssignments,
   getAssignmentsDeComision,
 } from "./AssignmentRepository";
-import { Assignment, Comision } from "@/domain/entities";
+import { Assignment, Comision, IndividualAssignment } from "@/domain/entities";
+import { AssignmentNoEncontradoError } from "@/lib/services/assignmentAuthorization";
+import { TransicionDeEstadoInvalidaError } from "@/domain/entities/EstadoAssignment";
 
 const assignmentData = {
   titulo: "Kata Funcional",
@@ -35,16 +39,20 @@ describe("AssignmentRepository", () => {
     vi.clearAllMocks();
     mockEm.find.mockResolvedValue([]);
     mockEm.findOne.mockResolvedValue(new Comision(2026, "sheet-1"));
+    mockEm.count.mockResolvedValue(0);
     mockEm.flush.mockResolvedValue(undefined);
   });
 
   describe("getAssignmentsDeComision", () => {
-    it("busca assignments por comisión ordenados por fecha descendente", async () => {
+    it("busca assignments publicados o archivados de la comisión, ordenados por fecha descendente", async () => {
       await getAssignmentsDeComision("c1");
 
       expect(mockEm.find).toHaveBeenCalledWith(
         Assignment,
-        { comision: { id: "c1" } },
+        {
+          comision: { id: "c1" },
+          estadoNombre: { $in: ["publicado", "archivado"] },
+        },
         { orderBy: { createdAt: "DESC" } }
       );
     });
@@ -57,6 +65,16 @@ describe("AssignmentRepository", () => {
       expect(mockEm.find).toHaveBeenCalledWith(
         Assignment,
         {},
+        { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
+      );
+    });
+
+    it("filtra por estado cuando se pide explícitamente", async () => {
+      await getAssignments({ estado: "borrador" });
+
+      expect(mockEm.find).toHaveBeenCalledWith(
+        Assignment,
+        { estadoNombre: "borrador" },
         { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
       );
     });
@@ -95,6 +113,57 @@ describe("AssignmentRepository", () => {
       );
 
       expect(mockEm.persist).not.toHaveBeenCalled();
+      expect(mockEm.flush).not.toHaveBeenCalled();
+    });
+
+    it("nace en estado borrador", async () => {
+      const comision = new Comision(2026, "sheet-1");
+      mockEm.findOne.mockResolvedValueOnce(comision);
+
+      const assignment = await createAssignment(assignmentData);
+
+      expect(assignment.estadoNombre).toBe("borrador");
+    });
+  });
+
+  describe("cambiarEstadoAssignment", () => {
+    function fakeAssignment(): Assignment {
+      const assignment = new IndividualAssignment();
+      assignment.id = "a1";
+      return assignment;
+    }
+
+    it("publica un assignment en borrador y sella la auditoría", async () => {
+      mockEm.findOne.mockResolvedValueOnce(fakeAssignment());
+      mockEm.count.mockResolvedValueOnce(0);
+
+      const assignment = await cambiarEstadoAssignment("a1", "publicado", "docente1");
+
+      expect(assignment.estadoNombre).toBe("publicado");
+      expect(assignment.publicadoPor).toBe("docente1");
+      expect(mockEm.flush).toHaveBeenCalled();
+    });
+
+    it("lanza AssignmentNoEncontradoError si no existe", async () => {
+      mockEm.findOne.mockResolvedValueOnce(null);
+
+      await expect(
+        cambiarEstadoAssignment("a1", "publicado", "docente1")
+      ).rejects.toBeInstanceOf(AssignmentNoEncontradoError);
+      expect(mockEm.flush).not.toHaveBeenCalled();
+    });
+
+    it("rechaza despublicar con entregas y no persiste el cambio", async () => {
+      const publicado = fakeAssignment();
+      publicado.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+      mockEm.findOne.mockResolvedValueOnce(publicado);
+      mockEm.count.mockResolvedValueOnce(3);
+
+      await expect(
+        cambiarEstadoAssignment("a1", "borrador", "docente1")
+      ).rejects.toBeInstanceOf(TransicionDeEstadoInvalidaError);
+
+      expect(publicado.estadoNombre).toBe("publicado");
       expect(mockEm.flush).not.toHaveBeenCalled();
     });
   });

--- a/src/lib/repositories/AssignmentRepository.test.ts
+++ b/src/lib/repositories/AssignmentRepository.test.ts
@@ -1,12 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockEm = {
+const mockEm: {
+  find: ReturnType<typeof vi.fn>;
+  findOne: ReturnType<typeof vi.fn>;
+  count: ReturnType<typeof vi.fn>;
+  persist: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+  transactional: ReturnType<typeof vi.fn>;
+} = {
   find: vi.fn(),
   findOne: vi.fn(),
   count: vi.fn(),
   persist: vi.fn(),
   flush: vi.fn(),
+  transactional: vi.fn(),
 };
+mockEm.transactional.mockImplementation(
+  async (callback: (transaction: typeof mockEm) => unknown) => callback(mockEm)
+);
 
 vi.mock("@/lib/db", () => ({
   getEM: vi.fn(async () => mockEm),
@@ -21,6 +32,7 @@ import {
   getAssignmentsDeComision,
 } from "./AssignmentRepository";
 import { Assignment, Comision, IndividualAssignment } from "@/domain/entities";
+import { LockMode } from "@mikro-orm/core";
 import { AssignmentNoEncontradoError } from "@/lib/services/assignmentAuthorization";
 import { TransicionDeEstadoInvalidaError } from "@/domain/entities/EstadoAssignment";
 
@@ -142,6 +154,20 @@ describe("AssignmentRepository", () => {
       expect(assignment.estadoNombre).toBe("publicado");
       expect(assignment.publicadoPor).toBe("docente1");
       expect(mockEm.flush).toHaveBeenCalled();
+    });
+
+    it("corre dentro de una transacción y bloquea el assignment con PESSIMISTIC_WRITE", async () => {
+      mockEm.findOne.mockResolvedValueOnce(fakeAssignment());
+      mockEm.count.mockResolvedValueOnce(0);
+
+      await cambiarEstadoAssignment("a1", "publicado", "docente1");
+
+      expect(mockEm.transactional).toHaveBeenCalled();
+      expect(mockEm.findOne).toHaveBeenCalledWith(
+        Assignment,
+        { id: "a1" },
+        { lockMode: LockMode.PESSIMISTIC_WRITE }
+      );
     });
 
     it("lanza AssignmentNoEncontradoError si no existe", async () => {

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -1,15 +1,16 @@
 import { getEM, deleteEntity } from "@/lib/db";
+import { LockMode } from "@mikro-orm/core";
 import {
   Assignment,
+  AssignmentNoEncontradoError,
   Comision,
+  Entrega,
   IndividualAssignment,
   GrupalAssignment,
 } from "@/domain/entities";
 import type { AssignmentFormData } from "@/lib/assignment-schema";
 import { slugify } from "@/lib/naming";
 import type { NombreEstadoAssignment, Paradigma } from "@/types";
-import { contarEntregasDeAssignment } from "./EntregaRepository";
-import { AssignmentNoEncontradoError } from "@/lib/services/assignmentAuthorization";
 
 export class ComisionActivaRequeridaError extends Error {
   constructor() {
@@ -123,11 +124,14 @@ export async function setInscripcionesCerradas(
 }
 
 /**
- * Aplica una transición de ciclo de vida. Cuenta las entregas del assignment
- * para que `Assignment.transicionarA` pueda evaluar la guarda de despublicar
- * (bloqueada si hay entregas). Lanza `AssignmentNoEncontradoError` si no
- * existe y deja propagar `TransicionDeEstadoInvalidaError` si la transición
- * no está permitida — en ese caso no se persiste ningún cambio.
+ * Aplica una transición de ciclo de vida. Bloquea el assignment
+ * (PESSIMISTIC_WRITE) y cuenta sus entregas dentro de la misma transacción
+ * para que la guarda de despublicar (bloqueada si hay entregas) vea un
+ * estado consistente aunque un alumno esté aceptando el assignment en
+ * paralelo — ver `crearEntregaSiAssignmentDisponible`, que toma el mismo
+ * lock del otro lado de esa carrera. Lanza `AssignmentNoEncontradoError` si
+ * no existe y deja propagar `TransicionDeEstadoInvalidaError` si la
+ * transición no está permitida — en ese caso no se persiste ningún cambio.
  */
 export async function cambiarEstadoAssignment(
   assignmentId: string,
@@ -135,12 +139,20 @@ export async function cambiarEstadoAssignment(
   porUsuario: string
 ): Promise<Assignment> {
   const entityManager = await getEM();
-  const assignment = await entityManager.findOne(Assignment, { id: assignmentId });
-  if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
 
-  const tieneEntregas = (await contarEntregasDeAssignment(assignmentId)) > 0;
-  assignment.transicionarA(destino, { tieneEntregas }, porUsuario);
+  return entityManager.transactional(async (transaction) => {
+    const assignment = await transaction.findOne(
+      Assignment,
+      { id: assignmentId },
+      { lockMode: LockMode.PESSIMISTIC_WRITE }
+    );
+    if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
 
-  await entityManager.flush();
-  return assignment;
+    const tieneEntregas =
+      (await transaction.count(Entrega, { assignment: { id: assignmentId } })) > 0;
+    assignment.transicionarA(destino, { tieneEntregas }, porUsuario);
+
+    await transaction.flush();
+    return assignment;
+  });
 }

--- a/src/lib/repositories/AssignmentRepository.ts
+++ b/src/lib/repositories/AssignmentRepository.ts
@@ -7,7 +7,9 @@ import {
 } from "@/domain/entities";
 import type { AssignmentFormData } from "@/lib/assignment-schema";
 import { slugify } from "@/lib/naming";
-import type { Paradigma } from "@/types";
+import type { NombreEstadoAssignment, Paradigma } from "@/types";
+import { contarEntregasDeAssignment } from "./EntregaRepository";
+import { AssignmentNoEncontradoError } from "@/lib/services/assignmentAuthorization";
 
 export class ComisionActivaRequeridaError extends Error {
   constructor() {
@@ -16,11 +18,21 @@ export class ComisionActivaRequeridaError extends Error {
   }
 }
 
-export async function getAssignments(): Promise<Assignment[]> {
+// Estados en los que un assignment puede aparecer en superficies de alumno.
+// Borrador nunca; el filtrado fino de "archivado solo si tiene entrega" lo
+// hace el caller (dashboard, /api/assignments) con `esVisibleParaAlumno`.
+const ESTADOS_VISIBLES_PARA_ALUMNO: NombreEstadoAssignment[] = [
+  "publicado",
+  "archivado",
+];
+
+export async function getAssignments(filtro?: {
+  estado?: NombreEstadoAssignment;
+}): Promise<Assignment[]> {
   const entityManager = await getEM();
   return entityManager.find(
     Assignment,
-    {},
+    filtro?.estado ? { estadoNombre: filtro.estado } : {},
     { orderBy: { createdAt: "DESC" }, populate: ["comision"] }
   );
 }
@@ -31,7 +43,10 @@ export async function getAssignmentsDeComision(
   const entityManager = await getEM();
   return entityManager.find(
     Assignment,
-    { comision: { id: comisionId } },
+    {
+      comision: { id: comisionId },
+      estadoNombre: { $in: ESTADOS_VISIBLES_PARA_ALUMNO },
+    },
     { orderBy: { createdAt: "DESC" } }
   );
 }
@@ -103,6 +118,29 @@ export async function setInscripcionesCerradas(
   const assignment = await entityManager.findOne(GrupalAssignment, { id: assignmentId });
   if (!assignment) return null;
   assignment.inscripcionesCerradas = cerradas;
+  await entityManager.flush();
+  return assignment;
+}
+
+/**
+ * Aplica una transición de ciclo de vida. Cuenta las entregas del assignment
+ * para que `Assignment.transicionarA` pueda evaluar la guarda de despublicar
+ * (bloqueada si hay entregas). Lanza `AssignmentNoEncontradoError` si no
+ * existe y deja propagar `TransicionDeEstadoInvalidaError` si la transición
+ * no está permitida — en ese caso no se persiste ningún cambio.
+ */
+export async function cambiarEstadoAssignment(
+  assignmentId: string,
+  destino: NombreEstadoAssignment,
+  porUsuario: string
+): Promise<Assignment> {
+  const entityManager = await getEM();
+  const assignment = await entityManager.findOne(Assignment, { id: assignmentId });
+  if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
+
+  const tieneEntregas = (await contarEntregasDeAssignment(assignmentId)) > 0;
+  assignment.transicionarA(destino, { tieneEntregas }, porUsuario);
+
   await entityManager.flush();
   return assignment;
 }

--- a/src/lib/repositories/EntregaRepository.test.ts
+++ b/src/lib/repositories/EntregaRepository.test.ts
@@ -1,25 +1,44 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const mockEm = {
+const mockEm: {
+  find: ReturnType<typeof vi.fn>;
+  findOne: ReturnType<typeof vi.fn>;
+  findOneOrFail: ReturnType<typeof vi.fn>;
+  getReference: ReturnType<typeof vi.fn>;
+  persist: ReturnType<typeof vi.fn>;
+  flush: ReturnType<typeof vi.fn>;
+  transactional: ReturnType<typeof vi.fn>;
+} = {
   find: vi.fn(),
   findOne: vi.fn(),
   findOneOrFail: vi.fn(),
   getReference: vi.fn(),
   persist: vi.fn(),
   flush: vi.fn(),
+  transactional: vi.fn(),
 };
+mockEm.transactional.mockImplementation(
+  async (callback: (transaction: typeof mockEm) => unknown) => callback(mockEm)
+);
 
 vi.mock("@/lib/db", () => ({
   getEM: vi.fn(async () => mockEm),
 }));
 
+import { LockMode } from "@mikro-orm/core";
 import { Alumno, Assignment, Entrega, Grupo } from "@/domain/entities";
+import { AssignmentNoDisponibleError } from "@/lib/services/assignmentAuthorization";
 import {
   createEntrega,
   createOrGetEntrega,
+  crearEntregaSiAssignmentDisponible,
   getEntregasConRepoActivo,
   getEntregaLogica,
 } from "./EntregaRepository";
+
+function fakeAssignmentDisponible(disponible: boolean) {
+  return { permiteAccionesDeAlumno: () => disponible };
+}
 
 describe("EntregaRepository", () => {
   beforeEach(() => {
@@ -149,6 +168,76 @@ describe("EntregaRepository", () => {
         alumnoId: "alumno-1",
       })
     ).resolves.toBe(existing);
+  });
+
+  describe("crearEntregaSiAssignmentDisponible", () => {
+    it("crea la entrega cuando el assignment está disponible para el alumno", async () => {
+      mockEm.findOne
+        .mockResolvedValueOnce(fakeAssignmentDisponible(true)) // lock del assignment
+        .mockResolvedValueOnce(null) // repo lookup
+        .mockResolvedValueOnce(null); // lógica lookup
+
+      await crearEntregaSiAssignmentDisponible(
+        {
+          assignmentId: "a1",
+          repoName: "kata-juan",
+          repoUrl: "https://github.com/org/kata-juan",
+          githubUsernames: ["juan"],
+          alumnoId: "alumno-1",
+        },
+        false
+      );
+
+      expect(mockEm.transactional).toHaveBeenCalled();
+      expect(mockEm.findOne).toHaveBeenNthCalledWith(
+        1,
+        Assignment,
+        { id: "a1" },
+        { lockMode: LockMode.PESSIMISTIC_WRITE }
+      );
+      expect(mockEm.persist).toHaveBeenCalled();
+    });
+
+    it("rechaza con AssignmentNoDisponibleError si el estado cambió bajo el lock y no es admin", async () => {
+      mockEm.findOne.mockResolvedValueOnce(fakeAssignmentDisponible(false));
+
+      await expect(
+        crearEntregaSiAssignmentDisponible(
+          {
+            assignmentId: "a1",
+            repoName: "kata-juan",
+            repoUrl: "https://github.com/org/kata-juan",
+            githubUsernames: ["juan"],
+            alumnoId: "alumno-1",
+          },
+          false
+        )
+      ).rejects.toBeInstanceOf(AssignmentNoDisponibleError);
+
+      expect(mockEm.persist).not.toHaveBeenCalled();
+    });
+
+    it("permite al admin crear la entrega aunque el assignment no esté disponible", async () => {
+      mockEm.findOne
+        .mockResolvedValueOnce(fakeAssignmentDisponible(false)) // lock del assignment
+        .mockResolvedValueOnce(null) // repo lookup
+        .mockResolvedValueOnce(null); // lógica lookup
+
+      await expect(
+        crearEntregaSiAssignmentDisponible(
+          {
+            assignmentId: "a1",
+            repoName: "kata-juan",
+            repoUrl: "https://github.com/org/kata-juan",
+            githubUsernames: ["juan"],
+            alumnoId: "alumno-1",
+          },
+          true
+        )
+      ).resolves.toBeDefined();
+
+      expect(mockEm.persist).toHaveBeenCalled();
+    });
   });
 
   it("devuelve solo entregas activas que conservan repoName", async () => {

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -8,6 +8,16 @@ export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
   return entityManager.find(Entrega, where, { populate: ["assignment", "grupo"] });
 }
 
+// Conteo puntual vía agregación SQL — a diferencia de getEntregaCountsByAssignment()
+// más abajo, no carga las entregas en memoria. Lo usa la guarda de "¿tiene
+// entregas?" al despublicar un assignment.
+export async function contarEntregasDeAssignment(
+  assignmentId: string
+): Promise<number> {
+  const entityManager = await getEM();
+  return entityManager.count(Entrega, { assignment: { id: assignmentId } });
+}
+
 // Devuelve todas las entregas de un usuario de una sola query,
 // indexadas por assignmentId para lookup O(1) en el template.
 export async function getEntregasDeUsuario(

--- a/src/lib/repositories/EntregaRepository.ts
+++ b/src/lib/repositories/EntregaRepository.ts
@@ -1,6 +1,14 @@
 import { getEM } from "@/lib/db";
+import { LockMode } from "@mikro-orm/core";
+import type { EntityManager } from "@mikro-orm/postgresql";
 import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
-import { Alumno, Assignment, Grupo, Entrega } from "@/domain/entities";
+import {
+  Alumno,
+  Assignment,
+  AssignmentNoDisponibleError,
+  Grupo,
+  Entrega,
+} from "@/domain/entities";
 
 export async function getEntregas(assignmentId?: string): Promise<Entrega[]> {
   const entityManager = await getEM();
@@ -50,8 +58,11 @@ export async function getEntregaDeUsuario(
   );
 }
 
-export async function getEntregaByRepoName(repoName: string): Promise<Entrega | null> {
-  const entityManager = await getEM();
+export async function getEntregaByRepoName(
+  repoName: string,
+  em?: EntityManager
+): Promise<Entrega | null> {
+  const entityManager = em ?? (await getEM());
   return entityManager.findOne(
     Entrega,
     { repoName },
@@ -59,12 +70,15 @@ export async function getEntregaByRepoName(repoName: string): Promise<Entrega | 
   );
 }
 
-export async function getEntregaLogica(data: {
-  assignmentId: string;
-  alumnoId?: string;
-  grupoId?: string;
-}): Promise<Entrega | null> {
-  const entityManager = await getEM();
+export async function getEntregaLogica(
+  data: {
+    assignmentId: string;
+    alumnoId?: string;
+    grupoId?: string;
+  },
+  em?: EntityManager
+): Promise<Entrega | null> {
+  const entityManager = em ?? (await getEM());
   if (data.grupoId) {
     return entityManager.findOne(
       Entrega,
@@ -121,15 +135,18 @@ export async function getEntregasConRepoActivo(
   });
 }
 
-export async function createEntrega(data: {
-  assignmentId: string;
-  repoName: string;
-  repoUrl: string;
-  githubUsernames: string[];
-  alumnoId?: string;
-  grupoId?: string;
-}): Promise<Entrega> {
-  const entityManager = await getEM();
+export async function createEntrega(
+  data: {
+    assignmentId: string;
+    repoName: string;
+    repoUrl: string;
+    githubUsernames: string[];
+    alumnoId?: string;
+    grupoId?: string;
+  },
+  em?: EntityManager
+): Promise<Entrega> {
+  const entityManager = em ?? (await getEM());
 
   const assignment = await entityManager.findOneOrFail(Assignment, { id: data.assignmentId });
 
@@ -158,39 +175,84 @@ function isUniqueViolation(error: unknown): boolean {
   return code === UNIQUE_VIOLATION || /unique constraint|duplicate key/i.test(error.message);
 }
 
-async function findExistingEntrega(data: {
-  assignmentId: string;
-  repoName: string;
-  alumnoId?: string;
-  grupoId?: string;
-}): Promise<Entrega | null> {
-  const entrega = await getEntregaByRepoName(data.repoName);
+async function findExistingEntrega(
+  data: {
+    assignmentId: string;
+    repoName: string;
+    alumnoId?: string;
+    grupoId?: string;
+  },
+  em?: EntityManager
+): Promise<Entrega | null> {
+  const entrega = await getEntregaByRepoName(data.repoName, em);
   if (entrega?.assignment?.id === data.assignmentId) return entrega;
 
-  return getEntregaLogica({
-    assignmentId: data.assignmentId,
-    alumnoId: data.alumnoId,
-    grupoId: data.grupoId,
-  });
+  return getEntregaLogica(
+    {
+      assignmentId: data.assignmentId,
+      alumnoId: data.alumnoId,
+      grupoId: data.grupoId,
+    },
+    em
+  );
 }
 
-export async function createOrGetEntrega(data: {
-  assignmentId: string;
-  repoName: string;
-  repoUrl: string;
-  githubUsernames: string[];
-  alumnoId?: string;
-  grupoId?: string;
-}): Promise<Entrega> {
-  const existing = await findExistingEntrega(data);
+export async function createOrGetEntrega(
+  data: {
+    assignmentId: string;
+    repoName: string;
+    repoUrl: string;
+    githubUsernames: string[];
+    alumnoId?: string;
+    grupoId?: string;
+  },
+  em?: EntityManager
+): Promise<Entrega> {
+  const existing = await findExistingEntrega(data, em);
   if (existing) return existing;
 
   try {
-    return await createEntrega(data);
+    return await createEntrega(data, em);
   } catch (error) {
     if (!isUniqueViolation(error)) throw error;
-    const reconciled = await findExistingEntrega(data);
+    const reconciled = await findExistingEntrega(data, em);
     if (reconciled) return reconciled;
     throw error;
   }
+}
+
+/**
+ * Crea la entrega dentro de una transacción que primero bloquea el
+ * assignment (mismo LockMode que cambiarEstadoAssignment) y vuelve a validar
+ * que el estado siga habilitando la aceptación. Cierra la ventana entre el
+ * chequeo inicial de aceptarAssignment (antes de las llamadas a GitHub, que
+ * no pueden vivir dentro de una transacción de DB) y la persistencia final:
+ * si un admin despublica el assignment mientras un alumno lo está aceptando,
+ * quien llegue segundo a este lock ve el estado real y actúa en consecuencia.
+ */
+export async function crearEntregaSiAssignmentDisponible(
+  data: {
+    assignmentId: string;
+    repoName: string;
+    repoUrl: string;
+    githubUsernames: string[];
+    alumnoId?: string;
+    grupoId?: string;
+  },
+  esAdmin: boolean
+): Promise<Entrega> {
+  const entityManager = await getEM();
+
+  return entityManager.transactional(async (transaction) => {
+    const assignment = await transaction.findOne(
+      Assignment,
+      { id: data.assignmentId },
+      { lockMode: LockMode.PESSIMISTIC_WRITE }
+    );
+    if (!esAdmin && !assignment?.permiteAccionesDeAlumno()) {
+      throw new AssignmentNoDisponibleError(data.assignmentId);
+    }
+
+    return createOrGetEntrega(data, transaction);
+  });
 }

--- a/src/lib/repositories/GrupoRepository.test.ts
+++ b/src/lib/repositories/GrupoRepository.test.ts
@@ -63,6 +63,7 @@ import { IndividualAssignment } from "@/domain/entities/IndividualAssignment";
 import { LockMode, type Collection } from "@mikro-orm/core";
 import {
   AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
   AssignmentNoEncontradoError,
   GrupoNoEncontradoError,
 } from "@/lib/services/assignmentAuthorization";
@@ -97,6 +98,10 @@ function fakeGrupal(overrides: Partial<GrupalAssignment> = {}): GrupalAssignment
   grupal.maxIntegrantes = 3;
   grupal.inscripcionesCerradas = false;
   grupal.comision = fakeComision();
+  // Publicado por defecto: crear/unirse a grupo requiere que el assignment
+  // esté disponible para el alumno. Los tests de ciclo de vida overridean
+  // `estadoNombre` explícitamente.
+  grupal.transicionarA("publicado", { tieneEntregas: false }, "docente1");
   Object.assign(grupal, overrides);
   return grupal;
 }
@@ -287,6 +292,19 @@ describe("crearGrupo", () => {
     expect(mockEm.transactional).toHaveBeenCalledTimes(1);
     expect(mockTx.persist).not.toHaveBeenCalled();
     expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("rechaza crear grupo en un assignment que no está publicado", async () => {
+    const borrador = fakeGrupal();
+    borrador.estadoNombre = "borrador";
+    const ana = fakeAlumno("alumno-ana", "ana");
+    mockTx.findOne.mockResolvedValueOnce(borrador);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      crearGrupo({ assignmentId: "a1", alumnoId: "alumno-ana", nombre: "x", esAdmin: false })
+    ).rejects.toBeInstanceOf(AssignmentNoDisponibleError);
+    expect(mockTx.persist).not.toHaveBeenCalled();
   });
 
   it("permite crear entre comisiones cuando el contexto es administrador", async () => {
@@ -490,6 +508,25 @@ describe("unirseAGrupo", () => {
     ).rejects.toBeInstanceOf(AccesoAssignmentProhibidoError);
 
     expect(mockEm.transactional).toHaveBeenCalledTimes(1);
+    expect(mockTx.flush).not.toHaveBeenCalled();
+  });
+
+  it("rechaza unirse a un grupo de un assignment archivado", async () => {
+    const archivado = fakeGrupal();
+    archivado.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+    const ana = fakeAlumno("alumno-ana", "ana");
+    const grupo = fakeGrupo("g1", archivado, []);
+    mockTx.findOne.mockResolvedValueOnce(grupo);
+    mockTx.findOneOrFail.mockResolvedValueOnce(ana);
+
+    await expect(
+      unirseAGrupo({
+        assignmentId: "a1",
+        grupoId: "g1",
+        alumnoId: "alumno-ana",
+        esAdmin: false,
+      })
+    ).rejects.toBeInstanceOf(AssignmentNoDisponibleError);
     expect(mockTx.flush).not.toHaveBeenCalled();
   });
 

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -16,7 +16,7 @@ import { buildRepoName, slugify } from "@/lib/naming";
 import {
   AssignmentNoEncontradoError,
   GrupoNoEncontradoError,
-  autorizarAccesoAssignment,
+  autorizarAccionSobreAssignment,
 } from "@/lib/services/assignmentAuthorization";
 import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 
@@ -176,7 +176,7 @@ export async function crearGrupo(params: {
         { id: alumnoId },
         { populate: ["comision"] }
       );
-      autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+      autorizarAccionSobreAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
       return traducirConflictoDeInscripcion(
         assignmentId,
@@ -251,7 +251,7 @@ export async function unirseAGrupo(params: {
       { id: alumnoId },
       { populate: ["comision"] }
     );
-    autorizarAccesoAssignment({ isAdmin: esAdmin }, alumno, assignment);
+    autorizarAccionSobreAssignment({ isAdmin: esAdmin }, alumno, assignment);
 
     return traducirConflictoDeInscripcion(
       assignmentId,

--- a/src/lib/repositories/GrupoRepository.ts
+++ b/src/lib/repositories/GrupoRepository.ts
@@ -5,6 +5,8 @@ import {
   Alumno,
   GrupalAssignment,
   Assignment,
+  AssignmentNoEncontradoError,
+  GrupoNoEncontradoError,
   InscripcionesCerradasError,
   AlumnoYaEnGrupoDelAssignmentError,
   NombreGrupoDuplicadoError,
@@ -13,11 +15,7 @@ import {
 } from "@/domain/entities";
 import type { Paradigma } from "@/types";
 import { buildRepoName, slugify } from "@/lib/naming";
-import {
-  AssignmentNoEncontradoError,
-  GrupoNoEncontradoError,
-  autorizarAccionSobreAssignment,
-} from "@/lib/services/assignmentAuthorization";
+import { autorizarAccionSobreAssignment } from "@/lib/services/assignmentAuthorization";
 import { extractDbErrorCode, UNIQUE_VIOLATION } from "./db-errors";
 
 const INSCRIPCION_UNICA_CONSTRAINT =

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -28,6 +28,7 @@ export {
   updateAssignment,
   deleteAssignment,
   setInscripcionesCerradas,
+  cambiarEstadoAssignment,
   ComisionActivaRequeridaError,
 } from "./AssignmentRepository";
 
@@ -40,6 +41,7 @@ export {
   getEntregaCountsByAssignment,
   getActiveRepoCountsByAssignment,
   getEntregasConRepoActivo,
+  contarEntregasDeAssignment,
   createEntrega,
   createOrGetEntrega,
 } from "./EntregaRepository";

--- a/src/lib/repositories/index.ts
+++ b/src/lib/repositories/index.ts
@@ -44,6 +44,7 @@ export {
   contarEntregasDeAssignment,
   createEntrega,
   createOrGetEntrega,
+  crearEntregaSiAssignmentDisponible,
 } from "./EntregaRepository";
 
 export {

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -13,7 +13,7 @@ const mockGetAssignment = vi.fn();
 const mockGetEntregaDeUsuario = vi.fn();
 const mockGetGrupoDeAlumno = vi.fn();
 const mockGetAlumnoByGithub = vi.fn();
-const mockCreateOrGetEntrega = vi.fn();
+const mockCrearEntregaSiAssignmentDisponible = vi.fn();
 const mockCrearEntrega = vi.fn();
 const mockRepoExists = vi.fn();
 const mockAddCollaborators = vi.fn();
@@ -25,7 +25,8 @@ vi.mock("@/lib/repositories", () => ({
   getGrupoDeAlumnoEnAssignment: (assignmentId: string, username: string) =>
     mockGetGrupoDeAlumno(assignmentId, username),
   getAlumnoByGithub: (username: string) => mockGetAlumnoByGithub(username),
-  createOrGetEntrega: (data: unknown) => mockCreateOrGetEntrega(data),
+  crearEntregaSiAssignmentDisponible: (data: unknown, esAdmin: boolean) =>
+    mockCrearEntregaSiAssignmentDisponible(data, esAdmin),
 }));
 
 vi.mock("@/lib/github", () => ({
@@ -125,7 +126,7 @@ describe("aceptarAssignment", () => {
       repoName: "kata-funcional-juangarcia",
       repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
     });
-    mockCreateOrGetEntrega.mockResolvedValue(makeEntrega());
+    mockCrearEntregaSiAssignmentDisponible.mockResolvedValue(makeEntrega());
   });
 
   it("devuelve la entrega existente sin tocar GitHub", async () => {
@@ -136,7 +137,7 @@ describe("aceptarAssignment", () => {
 
     expect(mockRepoExists).not.toHaveBeenCalled();
     expect(mockCrearEntrega).not.toHaveBeenCalled();
-    expect(mockCreateOrGetEntrega).not.toHaveBeenCalled();
+    expect(mockCrearEntregaSiAssignmentDisponible).not.toHaveBeenCalled();
   });
 
   it("falla con error de dominio si el assignment no existe", async () => {
@@ -157,13 +158,14 @@ describe("aceptarAssignment", () => {
         usernames: ["juangarcia"],
       })
     );
-    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalledWith(
       expect.objectContaining({
         assignmentId: "a1",
         alumnoId: "alumno-1",
         grupoId: undefined,
         repoName: "kata-funcional-juangarcia",
-      })
+      }),
+      false
     );
   });
 
@@ -213,14 +215,15 @@ describe("aceptarAssignment", () => {
         usernames: ["juangarcia", "mariaperez"],
       })
     );
-    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalledWith(
       expect.objectContaining({
         assignmentId: "a1",
         alumnoId: undefined,
         grupoId: "grupo-uuid-1",
         repoName: "kata-funcional-los-lambdas",
         githubUsernames: ["juangarcia", "mariaperez"],
-      })
+      }),
+      false
     );
   });
 
@@ -234,11 +237,12 @@ describe("aceptarAssignment", () => {
       "kata-funcional-juangarcia",
       ["juangarcia"]
     );
-    expect(mockCreateOrGetEntrega).toHaveBeenCalledWith(
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalledWith(
       expect.objectContaining({
         repoName: "kata-funcional-juangarcia",
         repoUrl: "https://github.com/pdep-mn-utn/kata-funcional-juangarcia",
-      })
+      }),
+      false
     );
   });
 
@@ -254,7 +258,7 @@ describe("aceptarAssignment", () => {
       "kata-funcional-juangarcia",
       ["juangarcia"]
     );
-    expect(mockCreateOrGetEntrega).toHaveBeenCalled();
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalled();
   });
 
   it("propaga el error de GitHub si el repo no existe después del fallo", async () => {
@@ -278,7 +282,7 @@ describe("aceptarAssignment", () => {
     expect(mockGetEntregaDeUsuario).not.toHaveBeenCalled();
     expect(mockRepoExists).not.toHaveBeenCalled();
     expect(mockCrearEntrega).not.toHaveBeenCalled();
-    expect(mockCreateOrGetEntrega).not.toHaveBeenCalled();
+    expect(mockCrearEntregaSiAssignmentDisponible).not.toHaveBeenCalled();
   });
 
   it("rechaza para alumnos un assignment histórico sin comisión", async () => {
@@ -332,5 +336,22 @@ describe("aceptarAssignment", () => {
     await expect(
       aceptarAssignment("a1", makeUser({ isAdmin: true }))
     ).resolves.toBeInstanceOf(Entrega);
+  });
+
+  it("pasa esAdmin a crearEntregaSiAssignmentDisponible para que revalide bajo lock", async () => {
+    await aceptarAssignment("a1", makeUser({ isAdmin: false }));
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalledWith(
+      expect.any(Object),
+      false
+    );
+
+    mockGetAlumnoByGithub.mockResolvedValue(
+      makeAlumno({ comision: makeComision("c2") })
+    );
+    await aceptarAssignment("a1", makeUser({ isAdmin: true }));
+    expect(mockCrearEntregaSiAssignmentDisponible).toHaveBeenCalledWith(
+      expect.any(Object),
+      true
+    );
   });
 });

--- a/src/lib/services/aceptarAssignment.test.ts
+++ b/src/lib/services/aceptarAssignment.test.ts
@@ -38,6 +38,7 @@ vi.mock("@/lib/github", () => ({
 import {
   aceptarAssignment,
   AlumnoNoRegistradoError,
+  AssignmentNoDisponibleError,
   AssignmentNoEncontradoError,
 } from "./aceptarAssignment";
 import { AccesoAssignmentProhibidoError } from "./assignmentAuthorization";
@@ -72,6 +73,10 @@ function makeAssignment(overrides?: Partial<IndividualAssignment & GrupalAssignm
   assignment.slug = "kata-funcional";
   assignment.createdAt = new Date("2026-01-01");
   assignment.comision = makeComision();
+  // Publicado por defecto: la mayoría de estos tests ejercitan el camino
+  // feliz de aceptar, que requiere que el assignment esté disponible. Los
+  // tests de ciclo de vida overridean `estadoNombre` explícitamente.
+  assignment.transicionarA("publicado", { tieneEntregas: false }, "docente1");
   return Object.assign(assignment, overrides);
 }
 
@@ -288,6 +293,41 @@ describe("aceptarAssignment", () => {
     mockGetAlumnoByGithub.mockResolvedValue(
       makeAlumno({ comision: makeComision("c2") })
     );
+
+    await expect(
+      aceptarAssignment("a1", makeUser({ isAdmin: true }))
+    ).resolves.toBeInstanceOf(Entrega);
+  });
+
+  it("rechaza aceptar un assignment en borrador y no toca GitHub", async () => {
+    const borrador = makeAssignment();
+    borrador.estadoNombre = "borrador";
+    mockGetAssignment.mockResolvedValue(borrador);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AssignmentNoDisponibleError
+    );
+
+    expect(mockGetEntregaDeUsuario).not.toHaveBeenCalled();
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+  });
+
+  it("rechaza aceptar un assignment archivado y no toca GitHub", async () => {
+    const archivado = makeAssignment();
+    archivado.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+    mockGetAssignment.mockResolvedValue(archivado);
+
+    await expect(aceptarAssignment("a1", makeUser())).rejects.toBeInstanceOf(
+      AssignmentNoDisponibleError
+    );
+
+    expect(mockCrearEntrega).not.toHaveBeenCalled();
+  });
+
+  it("permite al administrador aceptar un assignment en borrador", async () => {
+    const borrador = makeAssignment();
+    borrador.estadoNombre = "borrador";
+    mockGetAssignment.mockResolvedValue(borrador);
 
     await expect(
       aceptarAssignment("a1", makeUser({ isAdmin: true }))

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -11,10 +11,13 @@ import { addCollaborators, crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
 import {
   AssignmentNoEncontradoError,
-  autorizarAccesoAssignment,
+  autorizarAccionSobreAssignment,
 } from "./assignmentAuthorization";
 
-export { AssignmentNoEncontradoError } from "./assignmentAuthorization";
+export {
+  AssignmentNoEncontradoError,
+  AssignmentNoDisponibleError,
+} from "./assignmentAuthorization";
 
 export class AlumnoNoRegistradoError extends Error {
   constructor(public readonly githubUsername: string) {
@@ -37,7 +40,7 @@ export async function aceptarAssignment(
     getAlumnoByGithub(user.githubUsername, true),
   ]);
   if (!assignment) throw new AssignmentNoEncontradoError(assignmentId);
-  autorizarAccesoAssignment(user, alumno, assignment);
+  autorizarAccionSobreAssignment(user, alumno, assignment);
 
   const existente = await getEntregaDeUsuario(assignment.id, user.githubUsername);
   if (existente) return existente;

--- a/src/lib/services/aceptarAssignment.ts
+++ b/src/lib/services/aceptarAssignment.ts
@@ -5,7 +5,7 @@ import {
   getAssignment,
   getEntregaDeUsuario,
   getGrupoDeAlumnoEnAssignment,
-  createOrGetEntrega,
+  crearEntregaSiAssignmentDisponible,
 } from "@/lib/repositories";
 import { addCollaborators, crearEntrega, repoExists } from "@/lib/github";
 import { buildRepoName } from "@/lib/naming";
@@ -66,14 +66,17 @@ export async function aceptarAssignment(
         githubUsername: usernames[0]!,
       });
   const createLocalEntrega = (createdRepoName: string, repoUrl: string) =>
-    createOrGetEntrega({
-      assignmentId: assignment.id,
-      repoName: createdRepoName,
-      repoUrl,
-      githubUsernames: usernames,
-      alumnoId: grupoId ? undefined : alumno?.id,
-      grupoId,
-    });
+    crearEntregaSiAssignmentDisponible(
+      {
+        assignmentId: assignment.id,
+        repoName: createdRepoName,
+        repoUrl,
+        githubUsernames: usernames,
+        alumnoId: grupoId ? undefined : alumno?.id,
+        grupoId,
+      },
+      user.isAdmin
+    );
 
   if (await repoExists(repoName)) {
     await addCollaborators(repoName, usernames);

--- a/src/lib/services/assignmentAuthorization.test.ts
+++ b/src/lib/services/assignmentAuthorization.test.ts
@@ -1,8 +1,11 @@
 import { describe, expect, it } from "vitest";
 import {
   AccesoAssignmentProhibidoError,
+  AssignmentNoDisponibleError,
   autorizarAccesoAssignment,
+  autorizarAccionSobreAssignment,
 } from "./assignmentAuthorization";
+import { IndividualAssignment } from "@/domain/entities/IndividualAssignment";
 
 function makeAssignment(comisionId: string | null = "c1") {
   return {
@@ -16,6 +19,14 @@ function makeAlumno(comisionId = "c1") {
     id: "alumno-1",
     comision: { id: comisionId },
   } as never;
+}
+
+function makeAssignmentPublicado(comisionId: string | null = "c1") {
+  const assignment = new IndividualAssignment();
+  assignment.id = "a1";
+  assignment.comision = comisionId ? ({ id: comisionId } as never) : undefined;
+  assignment.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+  return assignment;
 }
 
 describe("autorizarAccesoAssignment", () => {
@@ -66,6 +77,56 @@ describe("autorizarAccesoAssignment", () => {
         null,
         makeAssignment(null)
       )
+    ).not.toThrow();
+  });
+});
+
+describe("autorizarAccionSobreAssignment", () => {
+  it("permite al alumno de la comisión sobre un assignment publicado", () => {
+    expect(() =>
+      autorizarAccionSobreAssignment(
+        { isAdmin: false },
+        makeAlumno("c1"),
+        makeAssignmentPublicado("c1")
+      )
+    ).not.toThrow();
+  });
+
+  it("rechaza al alumno sobre un assignment en borrador", () => {
+    const borrador = new IndividualAssignment();
+    borrador.id = "a1";
+    borrador.comision = { id: "c1" } as never;
+    expect(() =>
+      autorizarAccionSobreAssignment({ isAdmin: false }, makeAlumno("c1"), borrador)
+    ).toThrow(AssignmentNoDisponibleError);
+  });
+
+  it("rechaza al alumno sobre un assignment archivado, aunque sea de su comisión", () => {
+    const archivado = new IndividualAssignment();
+    archivado.id = "a1";
+    archivado.comision = { id: "c1" } as never;
+    archivado.transicionarA("publicado", { tieneEntregas: false }, "docente1");
+    archivado.transicionarA("archivado", { tieneEntregas: false }, "docente1");
+    expect(() =>
+      autorizarAccionSobreAssignment({ isAdmin: false }, makeAlumno("c1"), archivado)
+    ).toThrow(AssignmentNoDisponibleError);
+  });
+
+  it("prioriza el rechazo por comisión sobre el de estado", () => {
+    expect(() =>
+      autorizarAccionSobreAssignment(
+        { isAdmin: false },
+        makeAlumno("c2"),
+        makeAssignmentPublicado("c1")
+      )
+    ).toThrow(AccesoAssignmentProhibidoError);
+  });
+
+  it("permite a los administradores actuar sobre un assignment en cualquier estado", () => {
+    const borrador = new IndividualAssignment();
+    borrador.id = "a1";
+    expect(() =>
+      autorizarAccionSobreAssignment({ isAdmin: true }, null, borrador)
     ).not.toThrow();
   });
 });

--- a/src/lib/services/assignmentAuthorization.ts
+++ b/src/lib/services/assignmentAuthorization.ts
@@ -1,33 +1,21 @@
-import type { Alumno, Assignment } from "@/domain/entities";
+import {
+  AssignmentNoEncontradoError,
+  AssignmentNoDisponibleError,
+  GrupoNoEncontradoError,
+  type Alumno,
+  type Assignment,
+} from "@/domain/entities";
 
-export class AssignmentNoEncontradoError extends Error {
-  constructor(public readonly assignmentId: string) {
-    super("Assignment no encontrado");
-    this.name = "AssignmentNoEncontradoError";
-  }
-}
+// Reexportados desde el dominio: son errores sobre la existencia/disponibilidad
+// de assignments y grupos, no decisiones de política — los repositorios los
+// lanzan directamente y no deberían importar hacia arriba desde `@/lib/services`.
+// Se reexportan acá para no romper los imports existentes de este módulo.
+export { AssignmentNoEncontradoError, AssignmentNoDisponibleError, GrupoNoEncontradoError };
 
 export class AccesoAssignmentProhibidoError extends Error {
   constructor(public readonly assignmentId: string) {
     super("No tenés acceso a este assignment");
     this.name = "AccesoAssignmentProhibidoError";
-  }
-}
-
-export class GrupoNoEncontradoError extends Error {
-  constructor(
-    public readonly assignmentId: string,
-    public readonly grupoId: string
-  ) {
-    super("Grupo no encontrado");
-    this.name = "GrupoNoEncontradoError";
-  }
-}
-
-export class AssignmentNoDisponibleError extends Error {
-  constructor(public readonly assignmentId: string) {
-    super("Este TP no está disponible.");
-    this.name = "AssignmentNoDisponibleError";
   }
 }
 

--- a/src/lib/services/assignmentAuthorization.ts
+++ b/src/lib/services/assignmentAuthorization.ts
@@ -24,6 +24,13 @@ export class GrupoNoEncontradoError extends Error {
   }
 }
 
+export class AssignmentNoDisponibleError extends Error {
+  constructor(public readonly assignmentId: string) {
+    super("Este TP no está disponible.");
+    this.name = "AssignmentNoDisponibleError";
+  }
+}
+
 /**
  * Política única de acceso académico a un assignment.
  *
@@ -43,5 +50,25 @@ export function autorizarAccesoAssignment(
     alumno.comision?.id !== assignment.comision.id
   ) {
     throw new AccesoAssignmentProhibidoError(assignment.id);
+  }
+}
+
+/**
+ * Acceso académico más habilitación por estado: además de pertenecer a la
+ * comisión, el assignment tiene que estar en un estado que permita que un
+ * alumno actúe sobre él (aceptar, crear grupo, unirse a un grupo). Los
+ * administradores conservan el alcance global de `autorizarAccesoAssignment`
+ * — pueden operar sobre un borrador para probar el flujo antes de publicar.
+ */
+export function autorizarAccionSobreAssignment(
+  user: { isAdmin: boolean },
+  alumno: Alumno | null,
+  assignment: Assignment
+): void {
+  autorizarAccesoAssignment(user, alumno, assignment);
+  if (user.isAdmin) return;
+
+  if (!assignment.permiteAccionesDeAlumno()) {
+    throw new AssignmentNoDisponibleError(assignment.id);
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -44,6 +44,8 @@ export const DEFAULT_COLUMN_CONFIG: ColumnConfig = {
 
 export type TipoAssignment = "individual" | "grupal";
 
+export type { NombreEstadoAssignment } from "@/domain/entities/EstadoAssignment";
+
 // ── Session extendida ───────────────────────────────────────
 
 export interface PdepUser {

--- a/tests/migrations/assignment-lifecycle-concurrency.integration.test.ts
+++ b/tests/migrations/assignment-lifecycle-concurrency.integration.test.ts
@@ -1,0 +1,156 @@
+import { randomUUID } from "node:crypto";
+import {
+  afterAll,
+  beforeAll,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import ormConfig from "../../mikro-orm.config";
+
+const ormHolder = vi.hoisted(() => ({ orm: undefined as MikroORM | undefined }));
+
+vi.mock("@/lib/db", () => ({
+  getEM: async () => {
+    if (!ormHolder.orm) throw new Error("ORM de integración no inicializado");
+    return ormHolder.orm.em.fork();
+  },
+}));
+
+import { cambiarEstadoAssignment } from "../../src/lib/repositories/AssignmentRepository";
+import { crearEntregaSiAssignmentDisponible } from "../../src/lib/repositories/EntregaRepository";
+import { TransicionDeEstadoInvalidaError } from "../../src/domain/entities";
+import { AssignmentNoDisponibleError } from "../../src/lib/services/assignmentAuthorization";
+
+const LIFECYCLE_MIGRATION = "Migration20260814180000_assignment_lifecycle";
+
+function getSafeTestDatabaseUrl(): string {
+  const value = process.env.MIGRATION_TEST_DATABASE_URL;
+  if (!value) {
+    throw new Error(
+      "MIGRATION_TEST_DATABASE_URL es obligatoria para ejecutar pruebas de migraciones"
+    );
+  }
+  const url = new URL(value);
+  const databaseName = url.pathname.slice(1);
+  if (!databaseName.endsWith("_test")) {
+    throw new Error("La base de migraciones debe terminar en _test");
+  }
+  return value;
+}
+
+async function resetPublicSchema(orm: MikroORM): Promise<void> {
+  const connection = orm.em.getConnection();
+  await connection.execute('drop schema if exists "public" cascade');
+  await connection.execute('create schema "public"');
+}
+
+async function seedAssignmentPublicado(
+  orm: MikroORM
+): Promise<{ assignmentId: string; comisionId: string }> {
+  const connection = orm.em.getConnection();
+  const comisionId = randomUUID();
+  const assignmentId = randomUUID();
+
+  await connection.execute(
+    `insert into "comision"
+      ("id", "anio", "spreadsheet_id", "activa", "column_config")
+     values (?, 2026, ?, false, '{}'::jsonb)`,
+    [comisionId, `sheet-${comisionId}`]
+  );
+  await connection.execute(
+    `insert into "assignment"
+      ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+       "created_at", "comision_id", "inscripciones_cerradas", "estado_nombre",
+       "publicado_en", "publicado_por")
+     values (?, 'TP concurrente', ?, 'org/template', 'funcional', 'individual',
+       now(), ?, false, 'publicado', now(), 'docente1')`,
+    [assignmentId, `tp-${assignmentId}`, comisionId]
+  );
+
+  return { assignmentId, comisionId };
+}
+
+describe("carrera entre despublicar y aceptar un assignment", () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      ...ormConfig,
+      clientUrl: getSafeTestDatabaseUrl(),
+      debug: false,
+      migrations: { ...ormConfig.migrations, snapshot: false },
+    });
+    await resetPublicSchema(orm);
+    await orm.getMigrator().up({ to: LIFECYCLE_MIGRATION });
+    ormHolder.orm = orm;
+  });
+
+  afterAll(async () => {
+    if (!orm) return;
+    ormHolder.orm = undefined;
+    await resetPublicSchema(orm);
+    await orm.close(true);
+  });
+
+  it(
+    "nunca deja el assignment en borrador con una entrega creada concurrentemente",
+    async () => {
+      const { assignmentId } = await seedAssignmentPublicado(orm);
+
+      const [despublicar, aceptar] = await Promise.allSettled([
+        cambiarEstadoAssignment(assignmentId, "borrador", "docente1"),
+        crearEntregaSiAssignmentDisponible(
+          {
+            assignmentId,
+            repoName: `tp-concurrente-alumno`,
+            repoUrl: "https://github.com/org/tp-concurrente-alumno",
+            githubUsernames: ["alumno1"],
+          },
+          false
+        ),
+      ]);
+
+      // El lock pesimista compartido serializa ambas operaciones: una de las
+      // dos ve el estado real que dejó la otra y actúa en consecuencia. No
+      // importa cuál gana la carrera — lo que no puede pasar es que el
+      // assignment quede en borrador con una entrega persistida.
+      const connection = orm.em.getConnection();
+      const rows = await connection.execute<{ estado_nombre: string }[]>(
+        `select "estado_nombre" from "assignment" where "id" = ?`,
+        [assignmentId]
+      );
+      const entregas = await connection.execute<{ count: string }[]>(
+        `select count(*) from "entrega" where "assignment_id" = ?`,
+        [assignmentId]
+      );
+      const estadoFinal = rows[0]!.estado_nombre;
+      const tieneEntregas = Number(entregas[0]!.count) > 0;
+
+      expect(!(estadoFinal === "borrador" && tieneEntregas)).toBe(true);
+
+      if (estadoFinal === "borrador") {
+        // Despublicar ganó el lock primero: no había entregas todavía, y el
+        // accept que llegó después vio el assignment ya en borrador.
+        expect(despublicar.status).toBe("fulfilled");
+        expect(aceptar.status).toBe("rejected");
+        if (aceptar.status === "rejected") {
+          expect(aceptar.reason).toBeInstanceOf(AssignmentNoDisponibleError);
+        }
+        expect(tieneEntregas).toBe(false);
+      } else {
+        // Aceptar ganó el lock primero: la entrega ya existía cuando
+        // despublicar recontó entregas dentro de su propia transacción.
+        expect(aceptar.status).toBe("fulfilled");
+        expect(despublicar.status).toBe("rejected");
+        if (despublicar.status === "rejected") {
+          expect(despublicar.reason).toBeInstanceOf(TransicionDeEstadoInvalidaError);
+        }
+        expect(tieneEntregas).toBe(true);
+      }
+    },
+    15_000
+  );
+});

--- a/tests/migrations/assignment-lifecycle.integration.test.ts
+++ b/tests/migrations/assignment-lifecycle.integration.test.ts
@@ -1,0 +1,176 @@
+import { randomUUID } from "node:crypto";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { MikroORM } from "@mikro-orm/postgresql";
+import ormConfig from "../../mikro-orm.config";
+
+const PREVIOUS_MIGRATION = "Migration20260814160000_group_repo_name";
+const LIFECYCLE_MIGRATION = "Migration20260814180000_assignment_lifecycle";
+
+function getSafeTestDatabaseUrl(): string {
+  const value = process.env.MIGRATION_TEST_DATABASE_URL;
+  if (!value) {
+    throw new Error(
+      "MIGRATION_TEST_DATABASE_URL es obligatoria para ejecutar pruebas de migraciones"
+    );
+  }
+  const url = new URL(value);
+  const databaseName = url.pathname.slice(1);
+  if (!databaseName.endsWith("_test")) {
+    throw new Error("La base de migraciones debe terminar en _test");
+  }
+  return value;
+}
+
+async function resetPublicSchema(orm: MikroORM): Promise<void> {
+  const connection = orm.em.getConnection();
+  await connection.execute('drop schema if exists "public" cascade');
+  await connection.execute('create schema "public"');
+}
+
+async function insertAssignmentLegacy(
+  connection: ReturnType<MikroORM["em"]["getConnection"]>,
+  params: { id: string; comisionId: string; createdAt: string }
+): Promise<void> {
+  await connection.execute(
+    `insert into "assignment"
+      ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+       "created_at", "comision_id", "inscripciones_cerradas")
+     values (?, 'TP preexistente', ?, 'org/template', 'funcional', 'individual',
+       ?, ?, false)`,
+    [params.id, `tp-${params.id}`, params.createdAt, params.comisionId]
+  );
+}
+
+describe("Migration20260814180000_assignment_lifecycle", () => {
+  let orm: MikroORM;
+
+  beforeAll(async () => {
+    orm = await MikroORM.init({
+      ...ormConfig,
+      clientUrl: getSafeTestDatabaseUrl(),
+      debug: false,
+      migrations: { ...ormConfig.migrations, snapshot: false },
+    });
+    await resetPublicSchema(orm);
+    await orm.getMigrator().up({ to: PREVIOUS_MIGRATION });
+  });
+
+  afterAll(async () => {
+    if (!orm) return;
+    await resetPublicSchema(orm);
+    await orm.close(true);
+  });
+
+  it("backfillea los assignments existentes a 'publicado' y sella publicadoEn", async () => {
+    const connection = orm.em.getConnection();
+    const comisionId = randomUUID();
+    const assignmentId = randomUUID();
+    const createdAt = "2026-01-15T12:00:00.000Z";
+
+    await connection.execute(
+      `insert into "comision"
+        ("id", "anio", "spreadsheet_id", "activa", "column_config")
+       values (?, 2026, ?, false, '{}'::jsonb)`,
+      [comisionId, `sheet-${comisionId}`]
+    );
+    await insertAssignmentLegacy(connection, { id: assignmentId, comisionId, createdAt });
+
+    await orm.getMigrator().up({ to: LIFECYCLE_MIGRATION });
+
+    const rows = await connection.execute<
+      {
+        estado_nombre: string;
+        publicado_en: Date;
+        publicado_por: string | null;
+        archivado_en: Date | null;
+        archivado_por: string | null;
+      }[]
+    >(
+      `select "estado_nombre", "publicado_en", "publicado_por", "archivado_en", "archivado_por"
+         from "assignment" where "id" = ?`,
+      [assignmentId]
+    );
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.estado_nombre).toBe("publicado");
+    expect(rows[0]!.publicado_en).not.toBeNull();
+    expect(new Date(rows[0]!.publicado_en).toISOString()).toBe(createdAt);
+    expect(rows[0]!.publicado_por).toBeNull();
+    expect(rows[0]!.archivado_en).toBeNull();
+    expect(rows[0]!.archivado_por).toBeNull();
+  });
+
+  it("un assignment nuevo insertado después de la migración nace en 'borrador'", async () => {
+    const connection = orm.em.getConnection();
+    const comisionId = randomUUID();
+    const assignmentId = randomUUID();
+
+    await connection.execute(
+      `insert into "comision"
+        ("id", "anio", "spreadsheet_id", "activa", "column_config")
+       values (?, 2027, ?, false, '{}'::jsonb)`,
+      [comisionId, `sheet-${comisionId}`]
+    );
+    await connection.execute(
+      `insert into "assignment"
+        ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+         "created_at", "comision_id", "inscripciones_cerradas")
+       values (?, 'TP nuevo', ?, 'org/template', 'funcional', 'individual',
+         now(), ?, false)`,
+      [assignmentId, `tp-nuevo-${assignmentId}`, comisionId]
+    );
+
+    const rows = await connection.execute<{ estado_nombre: string }[]>(
+      `select "estado_nombre" from "assignment" where "id" = ?`,
+      [assignmentId]
+    );
+    expect(rows[0]!.estado_nombre).toBe("borrador");
+  });
+
+  it("el check constraint rechaza un estado_nombre desconocido", async () => {
+    const connection = orm.em.getConnection();
+    const comisionId = randomUUID();
+    const assignmentId = randomUUID();
+
+    await connection.execute(
+      `insert into "comision"
+        ("id", "anio", "spreadsheet_id", "activa", "column_config")
+       values (?, 2028, ?, false, '{}'::jsonb)`,
+      [comisionId, `sheet-${comisionId}`]
+    );
+
+    await expect(
+      connection.execute(
+        `insert into "assignment"
+          ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+           "created_at", "comision_id", "inscripciones_cerradas", "estado_nombre")
+         values (?, 'TP inválido', ?, 'org/template', 'funcional', 'individual',
+           now(), ?, false, 'invalido')`,
+        [assignmentId, `tp-invalido-${assignmentId}`, comisionId]
+      )
+    ).rejects.toThrow();
+  });
+
+  it("las entidades no divergen del esquema aplicado por la migración", async () => {
+    const { up } = await orm.getSchemaGenerator().getUpdateSchemaMigrationSQL();
+    expect(up).not.toContain('"estado_nombre"');
+    expect(up).not.toContain('"publicado_en"');
+    expect(up).not.toContain('"archivado_en"');
+  });
+
+  it("down() elimina las columnas del ciclo de vida", async () => {
+    await orm.getMigrator().down({ migrations: [LIFECYCLE_MIGRATION] });
+
+    const connection = orm.em.getConnection();
+    const columns = await connection.execute<{ column_name: string }[]>(
+      `select column_name from information_schema.columns
+         where table_schema = 'public' and table_name = 'assignment'
+           and column_name in
+             ('estado_nombre', 'publicado_en', 'publicado_por', 'archivado_en', 'archivado_por')`
+    );
+    expect(columns).toEqual([]);
+
+    // deja la DB como la encontró para no afectar otros tests del archivo
+    await orm.getMigrator().up({ to: LIFECYCLE_MIGRATION });
+  });
+});

--- a/tests/migrations/group-membership-invariants.integration.test.ts
+++ b/tests/migrations/group-membership-invariants.integration.test.ts
@@ -38,7 +38,10 @@ const MEMBERSHIP_MIGRATION =
   "Migration20260813190000_group_membership_invariants";
 const GROUP_REPO_NAMING_MIGRATION =
   "Migration20260814160000_group_repo_name";
+const ASSIGNMENT_LIFECYCLE_MIGRATION =
+  "Migration20260814180000_assignment_lifecycle";
 let groupRepoNamingReady = false;
+let assignmentLifecycleReady = false;
 
 function getSafeTestDatabaseUrl(): string {
   const value = process.env.MIGRATION_TEST_DATABASE_URL;
@@ -91,14 +94,29 @@ async function seedGroups(
      values (?, 2026, ?, false, '{}'::jsonb)`,
     [comisionId, `sheet-${comisionId}`]
   );
-  await connection.execute(
-    `insert into "assignment"
-      ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
-       "created_at", "comision_id", "max_integrantes", "inscripciones_cerradas")
-     values (?, 'TP concurrente', ?, 'org/template', 'funcional', 'grupal',
-       now(), ?, ?, false)`,
-    [assignmentId, `tp-${assignmentId}`, comisionId, options.maxIntegrantes]
-  );
+  // Una vez migrado el ciclo de vida, crearGrupo/unirseAGrupo exigen que el
+  // assignment esté publicado (autorizarAccionSobreAssignment) — antes de esa
+  // migración la columna todavía no existe en el schema bajo prueba.
+  if (assignmentLifecycleReady) {
+    await connection.execute(
+      `insert into "assignment"
+        ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+         "created_at", "comision_id", "max_integrantes", "inscripciones_cerradas",
+         "estado_nombre")
+       values (?, 'TP concurrente', ?, 'org/template', 'funcional', 'grupal',
+         now(), ?, ?, false, 'publicado')`,
+      [assignmentId, `tp-${assignmentId}`, comisionId, options.maxIntegrantes]
+    );
+  } else {
+    await connection.execute(
+      `insert into "assignment"
+        ("id", "titulo", "slug", "template_repo", "paradigma", "tipo",
+         "created_at", "comision_id", "max_integrantes", "inscripciones_cerradas")
+       values (?, 'TP concurrente', ?, 'org/template', 'funcional', 'grupal',
+         now(), ?, ?, false)`,
+      [assignmentId, `tp-${assignmentId}`, comisionId, options.maxIntegrantes]
+    );
+  }
 
   for (const [index, alumnoId] of alumnoIds.entries()) {
     await connection.execute(
@@ -370,8 +388,16 @@ describe.sequential("invariantes concurrentes de membresías de grupos", () => {
 
     await orm.getMigrator().up({ to: GROUP_REPO_NAMING_MIGRATION });
     groupRepoNamingReady = true;
+
+    // Las pruebas de concurrencia de acá en más ejercitan crearGrupo/unirseAGrupo
+    // reales, que ya exigen que el assignment esté publicado (autorizarAccionSobreAssignment).
+    // El schema tiene que estar al día con esa entidad antes de correrlas.
+    await orm.getMigrator().up({ to: ASSIGNMENT_LIFECYCLE_MIGRATION });
+    assignmentLifecycleReady = true;
+
     const { up } = await orm.getSchemaGenerator().getUpdateSchemaMigrationSQL();
     expect(up).not.toContain('alter table "grupo"');
+    expect(up).not.toContain('drop index "assignment_estado_nombre_index"');
   });
 
   it("serializa dos joins que compiten por el último cupo", async () => {


### PR DESCRIPTION
## Resumen

- Modela el ciclo de vida de un assignment (`borrador` → `publicado` → `archivado`) con un objeto de estado (Strategy) en vez de ramificar por valor, y persiste el estado más la auditoría de quién y cuándo publicó o archivó.
- Un assignment nuevo nace en `borrador`; los existentes quedan `publicado` vía migración con backfill (hoy ya eran visibles).
- El servidor aplica la regla en todas las superficies de alumno: listados (dashboard y `/api/assignments`), aceptar, crear grupo y unirse a grupo. Los administradores conservan acceso global.
- Despublicar (`publicado` → `borrador`) solo se permite sin entregas; con entregas, el único camino es archivar.
- Un alumno con entrega en un TP archivado lo sigue viendo con link al repo, pero sin botón de aceptar ni de gestionar grupo. Sin entrega, deja de verlo.
- UI admin: badge de estado, filtro por estado en el listado, y panel de transición en el detalle con confirmación de las consecuencias de cada acción.

Cierra #49.

## Fuera de alcance

Se evaluó agregar programación de publicación a futuro (fecha programada, publicación automática), pero se descartó por ahora: el repo no tiene infraestructura de cron/background jobs, y depender de Vercel Cron en el plan Hobby limita la ejecución a una vez por día, insuficiente para el caso de uso.

## Test plan

- [x] `pnpm test:run` — 1102 tests en verde
- [x] `pnpm lint` — 0 errores
- [x] `pnpm test:migrations` — migración de ciclo de vida verificada (backfill, check constraint, down(), sin diff de schema) contra Postgres real
- [ ] Smoke manual en preview: crear TP (nace borrador, invisible para alumno) → publicar (visible) → aceptar con un alumno → intentar despublicar con entrega (409) → archivar → confirmar que el alumno con entrega lo ve archivado sin botones y otro alumno sin entrega no lo ve

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Nuevas funcionalidades**
  * Añadido el ciclo de vida de las asignaciones: borrador, publicado y archivado.
  * El panel de administración permite consultar, filtrar y cambiar el estado, mostrando fechas y responsables de publicación o archivo.
  * Los alumnos solo pueden ver y gestionar asignaciones disponibles según su estado y entregas.
  * Las asignaciones no disponibles ya no pueden aceptarse ni utilizarse para crear o unirse a grupos.

* **Correcciones**
  * Añadidas respuestas claras para estados inválidos, transiciones no permitidas y asignaciones no disponibles.
  * Las asignaciones existentes se inicializan como publicadas.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->