### PR TITLE
Arreglar TypeError: rol perdido al clonar la sesión

### DIFF
--- a/src/app/perfil/page.tsx
+++ b/src/app/perfil/page.tsx
@@ -6,13 +6,13 @@ import { verificarConsistenciaAlumno } from "@/lib/services/verificarConsistenci
 import { intentarSincronizarGrupos } from "@/lib/services/intentarSincronizarGrupos";
 import { intentarSincronizarGoogleGroup } from "@/lib/services/intentarSincronizarGoogleGroup";
 import { isGoogleGroupsConfigured } from "@/lib/googleGroups";
-import type { PdepUser } from "@/types";
+import type { SessionPdepUser } from "@/types";
 
 export default async function PerfilPage() {
   const session = await auth();
   if (!session) redirect("/login");
 
-  const pdepUser = (session as unknown as { pdepUser: PdepUser }).pdepUser;
+  const pdepUser = (session as unknown as { pdepUser: SessionPdepUser }).pdepUser;
   const githubUsername = pdepUser.githubUsername;
 
   const alumno = await getAlumnoByGithub(githubUsername);

--- a/src/app/registro/page.tsx
+++ b/src/app/registro/page.tsx
@@ -6,13 +6,13 @@ import {
 } from "@/lib/repositories";
 import { redirect } from "next/navigation";
 import { AlumnoForm } from "@/app/components/AlumnoForm";
-import type { PdepUser } from "@/types";
+import type { SessionPdepUser } from "@/types";
 
 export default async function RegistroPage() {
   const session = await auth();
   if (!session) redirect("/login");
 
-  const pdepUser = (session as unknown as { pdepUser: PdepUser }).pdepUser;
+  const pdepUser = (session as unknown as { pdepUser: SessionPdepUser }).pdepUser;
   const githubUsername = pdepUser.githubUsername;
 
   const comisionActiva = await getComisionActiva();

--- a/src/domain/entities/RolDeUsuario.ts
+++ b/src/domain/entities/RolDeUsuario.ts
@@ -189,6 +189,22 @@ export const DOCENTE: RolDeUsuario = new Docente();
 export const ESTUDIANTE: RolDeUsuario = new Estudiante();
 
 /**
+ * Nombre serializable de un rol — lo único de `RolDeUsuario` que puede viajar
+ * dentro del objeto de sesión de NextAuth. Auth.js clona ese objeto
+ * internamente antes de devolverlo desde `auth()`, y el clon no preserva el
+ * prototype de una instancia de clase: como `DOCENTE`/`ESTUDIANTE` no tienen
+ * datos propios (todo su comportamiento vive en el prototype), lo que
+ * sobrevive al clon es un objeto vacío sin métodos. Por eso la sesión guarda
+ * este string, no la instancia — y `rolDesdeNombre` la reconstruye del lado
+ * del consumidor, después del clon.
+ */
+export type NombreRolDeUsuario = "docente" | "alumno";
+
+export function rolDesdeNombre(nombre: NombreRolDeUsuario): RolDeUsuario {
+  return nombre === "docente" ? DOCENTE : ESTUDIANTE;
+}
+
+/**
  * Único punto de decisión de todo el sistema entre docente y alumno — la
  * frontera real (username → rol). Análogo a `EstadoAssignment.desdeNombre`,
  * pero acá no hay columna que leer: el rol se computa desde la lista de

--- a/src/domain/entities/index.ts
+++ b/src/domain/entities/index.ts
@@ -53,8 +53,10 @@ export {
   DOCENTE,
   ESTUDIANTE,
   resolverRol,
+  rolDesdeNombre,
   AccesoAssignmentProhibidoError,
   type ItemDeNavegacion,
   type ContextoDeMembresia,
   type OrigenCambioMembresia,
+  type NombreRolDeUsuario,
 } from "./RolDeUsuario";

--- a/src/lib/auth.config.test.ts
+++ b/src/lib/auth.config.test.ts
@@ -99,4 +99,45 @@ describe("authConfig", () => {
       expect(token.githubUsername).toBe("previo");
     });
   });
+
+  describe("callback session", () => {
+    function callSession(authConfig: typeof AuthConfigType, args: any) {
+      return (authConfig.callbacks!.session as any)(args);
+    }
+
+    it("guarda rolNombre como string, no la instancia de RolDeUsuario", async () => {
+      // Regresión: Auth.js clona el objeto de sesión internamente antes de
+      // devolverlo desde auth(), y ese clon no preserva el prototype de una
+      // instancia de clase — DOCENTE/ESTUDIANTE quedarían como `{}` sin
+      // métodos del otro lado. Por eso acá sólo puede viajar un string.
+      vi.stubEnv("ADMIN_GITHUB_USERNAMES", "");
+      const authConfig = await importAuthConfig();
+      const session = await callSession(authConfig, {
+        session: { user: {} },
+        token: { githubUsername: "ana" },
+      });
+      expect(session.pdepUser.rolNombre).toBe("alumno");
+      expect(session.pdepUser).not.toHaveProperty("rol");
+    });
+
+    it("resuelve rolNombre='docente' para un username en ADMIN_GITHUB_USERNAMES", async () => {
+      vi.stubEnv("ADMIN_GITHUB_USERNAMES", "juancete");
+      const authConfig = await importAuthConfig();
+      const session = await callSession(authConfig, {
+        session: { user: {} },
+        token: { githubUsername: "juancete" },
+      });
+      expect(session.pdepUser.rolNombre).toBe("docente");
+    });
+
+    it("resuelve rolNombre='alumno' para un username fuera de ADMIN_GITHUB_USERNAMES", async () => {
+      vi.stubEnv("ADMIN_GITHUB_USERNAMES", "juancete");
+      const authConfig = await importAuthConfig();
+      const session = await callSession(authConfig, {
+        session: { user: {} },
+        token: { githubUsername: "ana" },
+      });
+      expect(session.pdepUser.rolNombre).toBe("alumno");
+    });
+  });
 });

--- a/src/lib/auth.config.ts
+++ b/src/lib/auth.config.ts
@@ -1,8 +1,8 @@
 import GitHub from "next-auth/providers/github";
 import Credentials from "next-auth/providers/credentials";
 import type { NextAuthConfig } from "next-auth";
-import type { PdepUser } from "@/types";
-import { resolverRol } from "@/domain/entities/RolDeUsuario";
+import type { SessionPdepUser } from "@/types";
+import { resolverRol, DOCENTE } from "@/domain/entities/RolDeUsuario";
 
 const adminUsernames = (process.env.ADMIN_GITHUB_USERNAMES ?? "")
   .split(",")
@@ -55,13 +55,18 @@ export const authConfig: NextAuthConfig = {
 
     async session({ session, token }) {
       const ghUser = (token.githubUsername as string) ?? "";
-      const pdepUser: PdepUser = {
+      // rolNombre, no la instancia de RolDeUsuario: Auth.js clona este
+      // objeto internamente antes de devolverlo desde auth(), y el clon no
+      // preserva el prototype de una clase (ver el comentario de
+      // NombreRolDeUsuario). Los consumidores reconstruyen el rol real con
+      // rolDesdeNombre(...) — getCurrentUser() y getProxyRedirectPath().
+      const pdepUser: SessionPdepUser = {
         githubUsername: ghUser,
         name: session.user?.name ?? ghUser,
         image: session.user?.image ?? "",
-        rol: resolverRol(ghUser, adminUsernames),
+        rolNombre: resolverRol(ghUser, adminUsernames) === DOCENTE ? "docente" : "alumno",
       };
-      (session as unknown as { pdepUser: PdepUser }).pdepUser = pdepUser;
+      (session as unknown as { pdepUser: SessionPdepUser }).pdepUser = pdepUser;
       return session;
     },
   },

--- a/src/lib/proxy-authorization.test.ts
+++ b/src/lib/proxy-authorization.test.ts
@@ -1,5 +1,4 @@
 import { getProxyRedirectPath } from "./proxy-authorization";
-import { DOCENTE, ESTUDIANTE } from "@/domain/entities/RolDeUsuario";
 
 function session(isAdmin: boolean) {
   return {
@@ -7,7 +6,7 @@ function session(isAdmin: boolean) {
       githubUsername: isAdmin ? "docente" : "alumno",
       name: "Usuario",
       image: "",
-      rol: isAdmin ? DOCENTE : ESTUDIANTE,
+      rolNombre: isAdmin ? "docente" : "alumno",
     },
   };
 }
@@ -37,7 +36,7 @@ describe("proxy authorization", () => {
     ).toBeNull();
   });
 
-  it("redirige a /dashboard (sin romper) si la sesión tiene pdepUser pero sin rol", () => {
+  it("redirige a /dashboard (sin romper) si la sesión tiene pdepUser pero sin rolNombre", () => {
     const sessionSinRol = { pdepUser: { githubUsername: "alumno", name: "Usuario", image: "" } };
     expect(
       getProxyRedirectPath({ session: sessionSinRol, pathname: "/admin/assignments" })

--- a/src/lib/proxy-authorization.ts
+++ b/src/lib/proxy-authorization.ts
@@ -1,4 +1,5 @@
-import type { PdepUser } from "@/types";
+import type { SessionPdepUser } from "@/types";
+import { rolDesdeNombre } from "@/domain/entities/RolDeUsuario";
 
 export function getProxyRedirectPath({
   session,
@@ -7,9 +8,12 @@ export function getProxyRedirectPath({
   session: unknown;
   pathname: string;
 }): "/login" | "/dashboard" | null {
-  const pdepUser = (session as { pdepUser?: PdepUser } | null)?.pdepUser;
+  const pdepUser = (session as { pdepUser?: SessionPdepUser } | null)?.pdepUser;
 
   if (!session) return "/login";
-  if (pathname.startsWith("/admin") && !pdepUser?.rol?.puedeAdministrar()) return "/dashboard";
+  if (pathname.startsWith("/admin")) {
+    const puedeAdministrar = pdepUser ? rolDesdeNombre(pdepUser.rolNombre).puedeAdministrar() : false;
+    if (!puedeAdministrar) return "/dashboard";
+  }
   return null;
 }

--- a/src/lib/session.test.ts
+++ b/src/lib/session.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockAuth = vi.fn();
+const mockRedirect = vi.fn().mockImplementation((url: string) => {
+  throw new Error(`redirect:${url}`);
+});
+
+vi.mock("@/lib/auth", () => ({
+  auth: () => mockAuth(),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+import { getCurrentUser, requireUser, requireAdmin } from "./session";
+
+function sessionConRol(githubUsername: string, rolNombre: "docente" | "alumno") {
+  return {
+    pdepUser: { githubUsername, name: githubUsername, image: "", rolNombre },
+  };
+}
+
+describe("getCurrentUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("devuelve null si no hay sesión", async () => {
+    mockAuth.mockResolvedValue(null);
+    expect(await getCurrentUser()).toBeNull();
+  });
+
+  it("devuelve null si la sesión no tiene pdepUser", async () => {
+    mockAuth.mockResolvedValue({});
+    expect(await getCurrentUser()).toBeNull();
+  });
+
+  it("reconstruye un RolDeUsuario real a partir de rolNombre='docente'", async () => {
+    // Regresión: si el objeto de sesión trajera `rol` como una instancia ya
+    // clonada por Auth.js (un objeto vacío sin métodos), este test no lo
+    // detectaría — por eso la sesión mockeada acá sólo tiene `rolNombre`,
+    // igual que lo que Auth.js realmente entrega.
+    mockAuth.mockResolvedValue(sessionConRol("juancete", "docente"));
+    const user = await getCurrentUser();
+    expect(user?.rol.puedeAdministrar()).toBe(true);
+    expect(user?.rol.veBannerDeSincronizacion()).toBe(false);
+  });
+
+  it("reconstruye un RolDeUsuario real a partir de rolNombre='alumno'", async () => {
+    mockAuth.mockResolvedValue(sessionConRol("ana", "alumno"));
+    const user = await getCurrentUser();
+    expect(user?.rol.puedeAdministrar()).toBe(false);
+    expect(user?.rol.veBannerDeSincronizacion()).toBe(true);
+  });
+
+  it("propaga githubUsername, name e image sin tocarlos", async () => {
+    mockAuth.mockResolvedValue({
+      pdepUser: { githubUsername: "ana", name: "Ana García", image: "https://x", rolNombre: "alumno" },
+    });
+    const user = await getCurrentUser();
+    expect(user).toMatchObject({ githubUsername: "ana", name: "Ana García", image: "https://x" });
+  });
+});
+
+describe("requireUser", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirige a /login si no hay usuario", async () => {
+    mockAuth.mockResolvedValue(null);
+    await expect(requireUser()).rejects.toThrow("redirect:/login");
+  });
+
+  it("devuelve el usuario si hay sesión", async () => {
+    mockAuth.mockResolvedValue(sessionConRol("ana", "alumno"));
+    const user = await requireUser();
+    expect(user.githubUsername).toBe("ana");
+  });
+});
+
+describe("requireAdmin", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("redirige a /login si no hay usuario", async () => {
+    mockAuth.mockResolvedValue(null);
+    await expect(requireAdmin()).rejects.toThrow("redirect:/login");
+  });
+
+  it("redirige a /dashboard si el usuario no es docente", async () => {
+    mockAuth.mockResolvedValue(sessionConRol("ana", "alumno"));
+    await expect(requireAdmin()).rejects.toThrow("redirect:/dashboard");
+  });
+
+  it("devuelve el usuario si es docente", async () => {
+    mockAuth.mockResolvedValue(sessionConRol("juancete", "docente"));
+    const user = await requireAdmin();
+    expect(user.githubUsername).toBe("juancete");
+  });
+});

--- a/src/lib/session.ts
+++ b/src/lib/session.ts
@@ -1,11 +1,19 @@
 import { redirect } from "next/navigation";
 import { auth } from "@/lib/auth";
-import type { PdepUser } from "@/types";
+import type { PdepUser, SessionPdepUser } from "@/types";
+import { rolDesdeNombre } from "@/domain/entities/RolDeUsuario";
 
 export async function getCurrentUser(): Promise<PdepUser | null> {
   const session = await auth();
   if (!session) return null;
-  return (session as unknown as { pdepUser: PdepUser }).pdepUser ?? null;
+  const raw = (session as unknown as { pdepUser?: SessionPdepUser }).pdepUser;
+  if (!raw) return null;
+  return {
+    githubUsername: raw.githubUsername,
+    name: raw.name,
+    image: raw.image,
+    rol: rolDesdeNombre(raw.rolNombre),
+  };
 }
 
 export async function requireUser(): Promise<PdepUser> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,5 @@
 import { normalizarGithubUsername } from "@/domain/entities/domain-constants";
-import type { RolDeUsuario } from "@/domain/entities/RolDeUsuario";
+import type { RolDeUsuario, NombreRolDeUsuario } from "@/domain/entities/RolDeUsuario";
 export { normalizarGithubUsername };
 
 // ── Paradigmas ──────────────────────────────────────────────
@@ -54,6 +54,18 @@ export interface PdepUser {
   name: string;
   image: string;
   rol: RolDeUsuario;
+}
+
+// Forma en la que el rol viaja DENTRO del objeto de sesión de NextAuth: un
+// nombre primitivo, no la instancia de `RolDeUsuario` (ver el comentario de
+// `NombreRolDeUsuario`). Todo lo que lee `session.pdepUser` directamente
+// (en vez de pasar por `getCurrentUser()`) tiene que reconstruir el rol real
+// con `rolDesdeNombre(...)` antes de llamar cualquier método sobre él.
+export interface SessionPdepUser {
+  githubUsername: string;
+  name: string;
+  image: string;
+  rolNombre: NombreRolDeUsuario;
 }
 
 export function usernameCanonicoDe(user: PdepUser): string {


### PR DESCRIPTION
## Summary

- **Bug crítico**: `user.rol.veBannerDeSincronizacion is not a function` (y lo mismo para cualquier otro método de `RolDeUsuario`) al renderizar `Nav`/`SyncPendingBanner` en cualquier página logueada. Reproducido con `pnpm dev` + login real.
- Causa raíz: Auth.js clona el objeto `session` internamente antes de devolverlo desde `auth()`. Como `DOCENTE`/`ESTUDIANTE` son instancias sin datos propios (todo su comportamiento vive en el prototype), el clon las deja como `{}` — un objeto vacío sin métodos. Confirmado con un log de diagnóstico en runtime (`Object.getPrototypeOf(pdepUser.rol)` → `[Object: null prototype] {}`).
- El mismo problema afectaba silenciosamente a `getProxyRedirectPath` (usado por `proxy.ts` en el middleware): con `rol` vacío, `puedeAdministrar()` explotaba en vez de evaluar — bloqueando efectivamente a **todos** los usuarios (admin o no) en cualquier ruta bajo `/admin/*`.
- Fix: la sesión ahora guarda `rolNombre: "docente" | "alumno"` (un string, que sí sobrevive el clon) en vez de la instancia de `RolDeUsuario`. Se agrega `rolDesdeNombre(...)` (mismo patrón que `EstadoAssignment.desdeNombre`) para reconstruir el rol real del lado del consumidor — en `getCurrentUser()` y en `getProxyRedirectPath()` — después de que la sesión ya pasó por el clon de Auth.js.
- Nuevo tipo `SessionPdepUser` para lo que efectivamente viaja en la sesión, distinto de `PdepUser` (el tipo que ven los consumidores de `getCurrentUser()`, con el rol ya reconstruido como instancia real).

## Test plan

- [x] Reproducido el error real contra `pnpm dev` (login vía dev-login, `.next` limpio, sin caché) antes del fix.
- [x] Confirmado que con el fix: login como docente → `/admin/assignments` devuelve 200; login como alumno → `/admin/assignments` redirige 307 a `/dashboard`; sin `TypeError` en ningún caso.
- [x] `pnpm test:run` — 1290/1290 en verde, incluye tests nuevos para `session()` callback (`auth.config.test.ts`), `getCurrentUser`/`requireUser`/`requireAdmin` (`session.test.ts`, antes sin cobertura) y el caso de regresión en `proxy-authorization.test.ts`.
- [x] `pnpm lint` — 0 errores (14 warnings preexistentes).
- [x] `pnpm build` — OK.