### PR TITLE
Falla temprano si DATABASE_URL está vacío en la migración de producción

### DIFF
--- a/.github/workflows/migrate-production.yml
+++ b/.github/workflows/migrate-production.yml
@@ -20,6 +20,11 @@ jobs:
       - uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Verificar secret DATABASE_URL
+        if: env.DATABASE_URL == ''
+        run: |
+          echo "::error::El secret DATABASE_URL del environment 'production' está vacío o no existe. Cargarlo con: gh secret set DATABASE_URL --env production"
+          exit 1
       - uses: pnpm/action-setup@v4
         with:
           version: 10.33.2

--- a/README.md
+++ b/README.md
@@ -502,8 +502,9 @@ El workflow sólo puede despacharse cuando existe en la rama por defecto (`maste
 promoción con migraciones, seguir este orden:
 
 1. Abrir el PR `development → master` y confirmar CI verde.
-2. Pausar el auto-deploy de producción de Vercel (`vercel git disconnect`); los previews pueden
-   seguir habilitados.
+2. Pausar los deploys automáticos de Vercel con `vercel git disconnect`. Esto corta producción y
+   también los previews; en este repo los previews ya se cancelan por el `ignoreCommand` de
+   `vercel.json`, así que en la práctica no se pierde nada.
 3. Crear un restore point en Neon y anotar qué commit se va a promover.
 4. Configurar `DATABASE_URL` en GitHub → **Settings → Environments → Production**. Verificar con
    `gh secret list --env production` que existe: un secret con valor vacío también pasa ese
@@ -511,10 +512,13 @@ promoción con migraciones, seguir este orden:
 5. Mergear el PR y anotar el SHA resultante de `master`.
 6. Ejecutar **Actions → Migrate production database → Run workflow** sobre `master` y esperar el
    resultado exitoso.
-7. Promover o redesplegar en Vercel exactamente el SHA migrado; no otro commit más nuevo. Luego
-   reactivar el auto-deploy con `vercel git connect` y verificar con `vercel project inspect
-   pdep-classroom` y `vercel inspect https://tu-dominio.vercel.app` (debe listar el SHA esperado)
-   — ver detalle en `docs/production-runbook.md`.
+7. Promover o redesplegar en Vercel exactamente el SHA migrado; no otro commit más nuevo.
+8. Consultar `GET /api/health` en el dominio de producción; debe responder `200` y
+   `{"ok":true,"database":"ok",...}`.
+9. Recién entonces reactivar el auto-deploy con `vercel git connect` y verificar con
+   `vercel project inspect pdep-classroom` (repo conectado) y `vercel inspect
+   https://tu-dominio.vercel.app` (debe listar el SHA migrado). El canary y el resto de las
+   verificaciones siguen en `docs/production-runbook.md`.
 
 Desde una terminal autenticada, los pasos 6 y el seguimiento pueden iniciarse con:
 
@@ -533,8 +537,8 @@ DATABASE_URL="postgresql://user:pass@ep-xxx.neon.tech/pdep_classroom?sslmode=req
   pnpm release:migrate
 ```
 
-No reactivar el auto-deploy hasta que la migración y el primer smoke test hayan terminado (ver
-paso 7). El build no toca la base y no reemplaza este procedimiento.
+No reactivar el auto-deploy hasta que la migración y el primer smoke test hayan terminado (pasos
+8 y 9). El build no toca la base y no reemplaza este procedimiento.
 
 #### 9.4 Actualizar URLs de callback
 

--- a/README.md
+++ b/README.md
@@ -502,13 +502,19 @@ El workflow sólo puede despacharse cuando existe en la rama por defecto (`maste
 promoción con migraciones, seguir este orden:
 
 1. Abrir el PR `development → master` y confirmar CI verde.
-2. Pausar el auto-deploy de producción de Vercel; los previews pueden seguir habilitados.
+2. Pausar el auto-deploy de producción de Vercel (`vercel git disconnect`); los previews pueden
+   seguir habilitados.
 3. Crear un restore point en Neon y anotar qué commit se va a promover.
-4. Configurar `DATABASE_URL` en GitHub → **Settings → Environments → Production**.
+4. Configurar `DATABASE_URL` en GitHub → **Settings → Environments → Production**. Verificar con
+   `gh secret list --env production` que existe: un secret con valor vacío también pasa ese
+   listado, pero hace fallar el workflow en el step "Verificar secret DATABASE_URL".
 5. Mergear el PR y anotar el SHA resultante de `master`.
 6. Ejecutar **Actions → Migrate production database → Run workflow** sobre `master` y esperar el
    resultado exitoso.
-7. Promover o redesplegar en Vercel exactamente el SHA migrado; no otro commit más nuevo.
+7. Promover o redesplegar en Vercel exactamente el SHA migrado; no otro commit más nuevo. Luego
+   reactivar el auto-deploy con `vercel git connect` y verificar con `vercel project inspect
+   pdep-classroom` y `vercel inspect https://tu-dominio.vercel.app` (debe listar el SHA esperado)
+   — ver detalle en `docs/production-runbook.md`.
 
 Desde una terminal autenticada, los pasos 6 y el seguimiento pueden iniciarse con:
 
@@ -527,8 +533,8 @@ DATABASE_URL="postgresql://user:pass@ep-xxx.neon.tech/pdep_classroom?sslmode=req
   pnpm release:migrate
 ```
 
-No reactivar el auto-deploy hasta que la migración y el primer smoke test hayan terminado. El build
-no toca la base y no reemplaza este procedimiento.
+No reactivar el auto-deploy hasta que la migración y el primer smoke test hayan terminado (ver
+paso 7). El build no toca la base y no reemplaza este procedimiento.
 
 #### 9.4 Actualizar URLs de callback
 

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -15,7 +15,8 @@ modifica la base de datos.
    instalada en la organización y suscripta a `Check suite`, `Push`, `Repository` y `Member`.
 5. Evitar que un auto-deploy de producción se adelante a la migración. Usar promoción manual o
    pausar temporalmente ese auto-deploy con `vercel git disconnect` (o desde el dashboard:
-   Settings → Git → Disconnect). Debe revertirse al final del release (ver paso 4 de "Release").
+   Settings → Git → Disconnect). La desconexión detiene todos los deploys por Git, tanto producción
+   como previews. Debe revertirse al final del release (ver paso 4 de "Release").
 
 ## Release
 

--- a/docs/production-runbook.md
+++ b/docs/production-runbook.md
@@ -14,24 +14,30 @@ modifica la base de datos.
 4. Verificar en GitHub la callback OAuth y el webhook del dominio definitivo. La App debe estar
    instalada en la organización y suscripta a `Check suite`, `Push`, `Repository` y `Member`.
 5. Evitar que un auto-deploy de producción se adelante a la migración. Usar promoción manual o
-   pausar temporalmente ese auto-deploy.
+   pausar temporalmente ese auto-deploy con `vercel git disconnect` (o desde el dashboard:
+   Settings → Git → Disconnect). Debe revertirse al final del release (ver paso 4 de "Release").
 
 ## Release
 
 1. Ejecutar **Actions → Migrate production database → Run workflow**. El environment protegido
-   `production` necesita el secret `DATABASE_URL` de Neon.
+   `production` necesita el secret `DATABASE_URL` de Neon. Si el run falla en el step "Verificar
+   secret DATABASE_URL", recargar el secret con `gh secret set DATABASE_URL --env production`
+   usando el valor de Neon (no está en Vercel: ahí la variable es sensitive y no se puede leer).
 2. Esperar el resultado exitoso y recién entonces promover el mismo commit en Vercel.
 3. Consultar `GET /api/health`; debe responder `200` y `{"ok":true,"database":"ok",...}`.
-4. Entrar como docente a `/admin/operaciones`. GitHub y Sheets deben estar en verde; cada canal de
+4. Reconectar el repo con `vercel git connect`. Verificar con `vercel project inspect
+   pdep-classroom` que figura el repo conectado, y confirmar con `vercel inspect
+   https://pdep-classroom.vercel.app` que el commit en producción es el SHA migrado.
+5. Entrar como docente a `/admin/operaciones`. GitHub y Sheets deben estar en verde; cada canal de
    comunicación configurado también — uno apagado a propósito aparece como "Revisar" y no bloquea.
    No debe haber deliveries fallidos sin explicar.
-5. Hacer el canary con un assignment descartable:
+6. Hacer el canary con un assignment descartable:
    - un docente lo crea y publica;
    - un alumno de prueba completa registro y acepta un TP individual;
    - dos alumnos forman un grupo y aceptan un TP grupal;
    - se confirma repo, colaboradores, suscripción a los canales configurados y actualización de CI
      por webhook.
-6. Si la comisión ya tenía grupos en Sheets, ejecutar una sola vez **Importar grupos desde
+7. Si la comisión ya tenía grupos en Sheets, ejecutar una sola vez **Importar grupos desde
    Sheets**. Desde ese momento Classroom es la fuente de verdad.
 
 ## Operación habitual


### PR DESCRIPTION
## Summary

- Agrega un step "Verificar secret DATABASE_URL" en `migrate-production.yml`, justo después del
  checkout, que corta el workflow con `exit 1` y un `::error::` explícito cuando el secret del
  environment `production` resuelve a string vacío. Antes, `""` no es nullish y `?? fallback` no
  la cubría, así que MikroORM fallaba 20s después con "No database specified".
- Documenta en `docs/production-runbook.md` y `README.md` que pausar el auto-deploy de Vercel se
  hace con `vercel git disconnect` (o desde el dashboard) y que debe revertirse con
  `vercel git connect` al final del release, con verificación posterior (`vercel project inspect`,
  `vercel inspect`) de que el commit en producción es el SHA migrado.
- Reordena los pasos de "Release" en el runbook: la reconexión de Vercel queda después del health
  check (`GET /api/health`), que funciona como el smoke test que habilita reactivar el auto-deploy.
- Documenta en el README cómo recuperarse si el nuevo guard falla: recargar el secret con
  `gh secret set DATABASE_URL --env production` y verificar previamente con
  `gh secret list --env production` (un secret vacío pasa ese listado pero falla el guard).

## Test plan

- [ ] Correr el workflow `Migrate production database` con el secret `DATABASE_URL` vacío en el
      environment `production` y confirmar que falla en el nuevo step, en segundos, con el mensaje
      indicando el comando de recuperación.
- [ ] Correr el mismo workflow con el secret cargado correctamente y confirmar que sigue migrando
      sin cambios de comportamiento.
- [ ] Revisar que el runbook y el README quedaron consistentes en la numeración de pasos.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentación**
  * Se actualizaron las instrucciones de migración y despliegue en producción.
  * Se documentó cómo pausar y reactivar el auto-deploy durante las migraciones.
  * Se añadieron pasos para verificar el secreto `DATABASE_URL`, confirmar el commit migrado y validar el despliegue.

* **Correcciones**
  * El flujo de migración ahora falla claramente si falta el secreto `DATABASE_URL`, mostrando instrucciones para configurarlo.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->